### PR TITLE
Remove score selection before initializing playback - restore it after stopping

### DIFF
--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -2232,12 +2232,29 @@ void ScoreView::cmd(const char* s)
             {{"mag"}, /*[](ScoreView* cv, const QByteArray&)*/ {
                   // ??
                   }},
-            {{"play"}, [](ScoreView* cv, const QByteArray&) {
+            {{"play"}, [&](ScoreView* cv, const QByteArray&) {
                   if (seq && seq->canStart()) {
-                        if (cv->state == ViewState::NORMAL || cv->state == ViewState::NOTE_ENTRY)
+                        auto cvScore = cv->score();
+                        auto cvSel = cvScore->selection();
+                        if (cv->state == ViewState::NORMAL || cv->state == ViewState::NOTE_ENTRY) {
+                              if (cvSel.element() || !cvSel.elements().isEmpty()) {
+                                    originalSelection = cvScore->selection();
+                                    }
+                              if (!cvSel.isNone()) {
+                                    cvScore->deselectAll();
+                                    }
                               cv->changeState(ViewState::PLAY);
-                        else if (cv->state == ViewState::PLAY)
+                              }
+                        else if (cv->state == ViewState::PLAY) {
+                              if (!cvSel.isNone()) {
+                                    cv->deselectAll();
+                                    }
+                              bool validOriginalSelection = originalSelection.score();
+                              if (validOriginalSelection) {
+                                    cvScore->setSelection(originalSelection);
+                                    }
                               cv->changeState(ViewState::NORMAL);
+                              }
                         }
                   else
                         getAction("play")->setChecked(false);

--- a/mscore/scoreview.h
+++ b/mscore/scoreview.h
@@ -24,6 +24,7 @@
 #include "libmscore/mscoreview.h"
 #include "libmscore/pos.h"
 #include "libmscore/property.h"
+#include "libmscore/select.h"
 
 namespace Ms {
 
@@ -210,6 +211,7 @@ class ScoreView : public QWidget, public MuseScoreView {
       bool popupActive = false;
       bool modifySelection = false;
       Element* elementToSelect = nullptr;
+      Selection originalSelection;
 
       // Loop In/Out marks in the score
       PositionCursor* _curLoopIn;


### PR DESCRIPTION
First little commit in attempting to figure how to get **build actions** from https://github.com/jojo-Schmitz/MuseScore/ where is found "MuseScore Evolution" for keeping backports from master branch