### PR TITLE
Fix #9: Inspector undesirably "cleared" when initially enabling Begin/Continue/End text and clicking into its corresponding text edit box

### DIFF
--- a/mscore/inspector/inspector.cpp
+++ b/mscore/inspector/inspector.cpp
@@ -202,9 +202,8 @@ void Inspector::update(Score* s)
                         sameSubtypes = false;
                   }
             }
-      if (oe != element() ||
-          (oSameTypes != sameTypes) ||
-          (oSameSubtypes != sameSubtypes)) {
+      bool differentElement = oe != element() || (oSameTypes != sameTypes) || (oSameSubtypes != sameSubtypes);
+      if (differentElement) {
             ie  = 0;
             oe  = element();
             oSameTypes = sameTypes;
@@ -435,7 +434,7 @@ void Inspector::update(Score* s)
                         }
                   }
             }
-      if (ie)
+      if (ie && differentElement)
             ie->setElement();
       }
 

--- a/mscore/inspector/inspectorTextLineBase.cpp
+++ b/mscore/inspector/inspectorTextLineBase.cpp
@@ -223,6 +223,7 @@ void InspectorTextLineBase::hasBeginTextClicked(bool checked)
             t->undoResetProperty(Pid::BEGIN_FONT_SIZE);
             t->undoResetProperty(Pid::BEGIN_FONT_STYLE);
             t->undoResetProperty(Pid::BEGIN_TEXT_OFFSET);
+            tl.beginText->clear();
             t->triggerLayout();
             t->score()->endCmd();
             }
@@ -249,6 +250,7 @@ void InspectorTextLineBase::hasContinueTextClicked(bool checked)
             t->undoResetProperty(Pid::CONTINUE_FONT_SIZE);
             t->undoResetProperty(Pid::CONTINUE_FONT_STYLE);
             t->undoResetProperty(Pid::CONTINUE_TEXT_OFFSET);
+            tl.continueText->clear();
             t->triggerLayout();
             t->score()->endCmd();
             }
@@ -275,6 +277,7 @@ void InspectorTextLineBase::hasEndTextClicked(bool checked)
             t->undoResetProperty(Pid::END_FONT_SIZE);
             t->undoResetProperty(Pid::END_FONT_STYLE);
             t->undoResetProperty(Pid::END_TEXT_OFFSET);
+            tl.endText->clear();
             t->triggerLayout();
             t->score()->endCmd();
             }


### PR DESCRIPTION
Resolves: #9 

[screencast.webm](https://github.com/user-attachments/assets/8fd35e55-039d-4265-b031-5ddaaa63346a)
