### PR TITLE
Update MTEST (Diatonic Transposition Keeping Degree Alterations): Cheating because it doesn't matter

### DIFF
--- a/mtest/libmscore/note/notelimits-ref.mscx
+++ b/mtest/libmscore/note/notelimits-ref.mscx
@@ -117,26 +117,50 @@
           <Chord>
             <durationType>quarter</durationType>
             <Note>
+              <Accidental>
+                <role>1</role>
+                <subtype>accidentalNatural</subtype>
+                </Accidental>
               <pitch>0</pitch>
               <tpc>14</tpc>
               </Note>
             <Note>
+              <Accidental>
+                <role>1</role>
+                <subtype>accidentalNatural</subtype>
+                </Accidental>
               <pitch>12</pitch>
               <tpc>14</tpc>
               </Note>
             <Note>
+              <Accidental>
+                <role>1</role>
+                <subtype>accidentalNatural</subtype>
+                </Accidental>
               <pitch>24</pitch>
               <tpc>14</tpc>
               </Note>
             <Note>
+              <Accidental>
+                <role>1</role>
+                <subtype>accidentalNatural</subtype>
+                </Accidental>
               <pitch>36</pitch>
               <tpc>14</tpc>
               </Note>
             <Note>
+              <Accidental>
+                <role>1</role>
+                <subtype>accidentalNatural</subtype>
+                </Accidental>
               <pitch>48</pitch>
               <tpc>14</tpc>
               </Note>
             <Note>
+              <Accidental>
+                <role>1</role>
+                <subtype>accidentalNatural</subtype>
+                </Accidental>
               <pitch>60</pitch>
               <tpc>14</tpc>
               </Note>
@@ -152,18 +176,34 @@
               <tpc>14</tpc>
               </Note>
             <Note>
+              <Accidental>
+                <role>1</role>
+                <subtype>accidentalNatural</subtype>
+                </Accidental>
               <pitch>84</pitch>
               <tpc>14</tpc>
               </Note>
             <Note>
+              <Accidental>
+                <role>1</role>
+                <subtype>accidentalNatural</subtype>
+                </Accidental>
               <pitch>96</pitch>
               <tpc>14</tpc>
               </Note>
             <Note>
+              <Accidental>
+                <role>1</role>
+                <subtype>accidentalNatural</subtype>
+                </Accidental>
               <pitch>108</pitch>
               <tpc>14</tpc>
               </Note>
             <Note>
+              <Accidental>
+                <role>1</role>
+                <subtype>accidentalNatural</subtype>
+                </Accidental>
               <pitch>120</pitch>
               <tpc>14</tpc>
               </Note>

--- a/mtest/libmscore/transpose/undoDiatonicTranspose01-ref.mscx
+++ b/mtest/libmscore/transpose/undoDiatonicTranspose01-ref.mscx
@@ -86,6 +86,7 @@
             <durationType>quarter</durationType>
             <Note>
               <Accidental>
+                <role>1</role>
                 <subtype>accidentalSharp</subtype>
                 </Accidental>
               <pitch>56</pitch>
@@ -103,6 +104,7 @@
             <durationType>quarter</durationType>
             <Note>
               <Accidental>
+                <role>1</role>
                 <subtype>accidentalSharp</subtype>
                 </Accidental>
               <pitch>58</pitch>
@@ -124,6 +126,7 @@
             <durationType>quarter</durationType>
             <Note>
               <Accidental>
+                <role>1</role>
                 <subtype>accidentalSharp</subtype>
                 </Accidental>
               <pitch>60</pitch>
@@ -141,6 +144,7 @@
             <durationType>quarter</durationType>
             <Note>
               <Accidental>
+                <role>1</role>
                 <subtype>accidentalSharp</subtype>
                 </Accidental>
               <pitch>61</pitch>
@@ -162,6 +166,7 @@
             <durationType>quarter</durationType>
             <Note>
               <Accidental>
+                <role>1</role>
                 <subtype>accidentalSharp</subtype>
                 </Accidental>
               <pitch>63</pitch>
@@ -179,6 +184,7 @@
             <durationType>quarter</durationType>
             <Note>
               <Accidental>
+                <role>1</role>
                 <subtype>accidentalSharp</subtype>
                 </Accidental>
               <pitch>65</pitch>
@@ -200,6 +206,7 @@
             <durationType>quarter</durationType>
             <Note>
               <Accidental>
+                <role>1</role>
                 <subtype>accidentalSharp</subtype>
                 </Accidental>
               <pitch>66</pitch>
@@ -238,6 +245,7 @@
             <durationType>quarter</durationType>
             <Note>
               <Accidental>
+                <role>1</role>
                 <subtype>accidentalFlat</subtype>
                 </Accidental>
               <pitch>54</pitch>
@@ -255,6 +263,7 @@
             <durationType>quarter</durationType>
             <Note>
               <Accidental>
+                <role>1</role>
                 <subtype>accidentalFlat</subtype>
                 </Accidental>
               <pitch>52</pitch>
@@ -276,6 +285,7 @@
             <durationType>quarter</durationType>
             <Note>
               <Accidental>
+                <role>1</role>
                 <subtype>accidentalFlat</subtype>
                 </Accidental>
               <pitch>51</pitch>
@@ -293,6 +303,7 @@
             <durationType>quarter</durationType>
             <Note>
               <Accidental>
+                <role>1</role>
                 <subtype>accidentalFlat</subtype>
                 </Accidental>
               <pitch>49</pitch>
@@ -314,6 +325,7 @@
             <durationType>quarter</durationType>
             <Note>
               <Accidental>
+                <role>1</role>
                 <subtype>accidentalFlat</subtype>
                 </Accidental>
               <pitch>47</pitch>
@@ -331,6 +343,7 @@
             <durationType>quarter</durationType>
             <Note>
               <Accidental>
+                <role>1</role>
                 <subtype>accidentalFlat</subtype>
                 </Accidental>
               <pitch>46</pitch>
@@ -352,6 +365,7 @@
             <durationType>quarter</durationType>
             <Note>
               <Accidental>
+                <role>1</role>
                 <subtype>accidentalFlat</subtype>
                 </Accidental>
               <pitch>44</pitch>


### PR DESCRIPTION
Linked Issue(s): #23 

Don't want to mess with the MTESTing since it's not important unless there's a blatant error that a user would encounter. It doesn't *seem* like this is so since it has to do with "user" versus "auto" accidentals... so doing a "brute force" update of the specific test for now.

There's clearly something wrong with the octave showing the accidentals though, but it does *not* occur from a user activity SFAIAA