### PR TITLE
[Command] Select All Similar (Same System + Same Staff), utilizing subtype

### DIFF
--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -825,7 +825,7 @@ class Score : public QObject, public ScoreElement {
       void getSelectedChordRest2(ChordRest** cr1, ChordRest** cr2) const;
 
       void select(Element* obj, SelectType = SelectType::SINGLE, int staff = 0);
-      void selectSimilar(Element* e, bool sameStaff);
+      void selectSimilar(Element* e, bool sameStaff, bool sameSystem = false);
       void selectSimilarInRange(Element* e);
       static void collectMatch(void* data, Element* e);
       static void collectNoteMatch(void* data, Element* e);

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -5762,10 +5762,10 @@ QNetworkAccessManager* MuseScore::networkManager()
 //   selectSimilar
 //---------------------------------------------------------
 
-void MuseScore::selectSimilar(Element* e, bool sameStaff)
+void MuseScore::selectSimilar(Element* e, bool sameStaff, bool sameSystem)
       {
       Score* score = e->score();
-      score->selectSimilar(e, sameStaff);
+      score->selectSimilar(e, sameStaff, sameSystem);
 
       if (score->selectionChanged()) {
             score->setSelectionChanged(false);

--- a/mscore/musescore.h
+++ b/mscore/musescore.h
@@ -731,7 +731,7 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
       void disableCommands(bool val) { inChordEditor = val; }
 
       Tuplet* tupletDialog();
-      void selectSimilar(Element*, bool);
+      void selectSimilar(Element*, bool, bool);
       void selectSimilarInRange(Element* e);
       void selectElementDialog(Element* e);
       void transpose();

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -357,9 +357,11 @@ void ScoreView::objectPopup(const QPoint& pos, Element* obj)
                   }
             }
       else if (cmd == "select-similar")
-            mscore->selectSimilar(obj, false);
+            mscore->selectSimilar(obj, false, false);
       else if (cmd == "select-similar-staff")
-            mscore->selectSimilar(obj, true);
+            mscore->selectSimilar(obj, true, false);
+      else if (cmd == "select-similar-staff-system")
+            mscore->selectSimilar(obj, true, true);
       else if (cmd == "select-similar-range")
             mscore->selectSimilarInRange(obj);
       else if (cmd == "select-dialog")
@@ -2320,13 +2322,20 @@ void ScoreView::cmd(const char* s)
             {{"select-similar"}, [](ScoreView* cv, const QByteArray&) {
                   if (cv->score()->selection().isSingle()) {
                         Element* e = cv->score()->selection().element();
-                        mscore->selectSimilar(e, false);
+                        mscore->selectSimilar(e, false, false);
                         }
                   }},
             {{"select-similar-staff"}, [](ScoreView* cv, const QByteArray&) {
                   if (cv->score()->selection().isSingle()) {
                         Element* e = cv->score()->selection().element();
-                        mscore->selectSimilar(e, true);
+                        mscore->selectSimilar(e, true, false);
+                        }
+                  }},
+            {{"select-similar-staff-system"}, [](ScoreView* cv, const QByteArray&) {
+                  if (cv->score()->selection().isSingle()) {
+                        Element* e = cv->score()->selection().element();
+                        mscore->selectSimilar(e, true, true);
+                        cv->updateAll();
                         }
                   }},
             {{"select-dialog"}, [](ScoreView* cv, const QByteArray&) {

--- a/mscore/shortcut.cpp
+++ b/mscore/shortcut.cpp
@@ -2848,6 +2848,13 @@ Shortcut Shortcut::_sc[] = {
       {
          MsWidget::SCORE_TAB,
          STATE_NORMAL | STATE_NOTE_ENTRY,
+         "select-similar-staff-system",
+         QT_TRANSLATE_NOOP("action","All Similar Elements in Same Staff & System"),
+         QT_TRANSLATE_NOOP("action","Select all similar elements in same staff & system")
+         },
+      {
+         MsWidget::SCORE_TAB,
+         STATE_NORMAL | STATE_NOTE_ENTRY,
          "select-similar-range",
          QT_TRANSLATE_NOOP("action","All Similar Elements in Range Selection"),
          QT_TRANSLATE_NOOP("action","Select all similar elements in the range selection")


### PR DESCRIPTION
Omits some subtypes, i.e.:
+  Dynamics: all p-f for example will be included, not just one particular dynamic.

Linked Issue(s): #27  
