### PR TITLE
Command: Toggle all unprintable and invisible score elements. Allowed to work during playback

### DIFF
--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -6494,6 +6494,15 @@ void MuseScore::cmd(QAction* a, const QString& cmd)
             cs->setShowInvisible(a->isChecked());
             cs->update();
             }
+      else if (cmd == "toggle-all-unprintable") {
+            // Master toggle command to show/unshow all invisible and unprintable elements:
+            cs->setShowInvisible(a->isChecked());
+            cs->setShowUnprintable(a->isChecked());
+            cs->setShowFrames(a->isChecked());
+            cs->setShowPageborders(a->isChecked());
+            cs->setMarkIrregularMeasures(a->isChecked());
+            cs->update();
+            }
       else if (cmd == "show-unprintable") {
             cs->setShowUnprintable(a->isChecked());
             cs->update();

--- a/mscore/shortcut.cpp
+++ b/mscore/shortcut.cpp
@@ -2667,10 +2667,21 @@ Shortcut Shortcut::_sc[] = {
          },
       {
          MsWidget::MAIN_WINDOW,
-         STATE_NORMAL | STATE_NOTE_ENTRY,
+         STATE_NORMAL | STATE_NOTE_ENTRY | STATE_PLAY,
          "show-invisible",
          QT_TRANSLATE_NOOP("action","Show Invisible"),
          QT_TRANSLATE_NOOP("action","Show invisible"),
+         0,
+         Icons::Invalid_ICON,
+         Qt::WindowShortcut,
+         ShortcutFlags::A_SCORE | ShortcutFlags::A_CHECKABLE
+         },
+      {
+         MsWidget::MAIN_WINDOW,
+         STATE_NORMAL | STATE_NOTE_ENTRY | STATE_PLAY,
+         "toggle-all-unprintable",
+         QT_TRANSLATE_NOOP("action","Show All Invisible and Unprintable Elements"),
+         QT_TRANSLATE_NOOP("action","Show all invisible and unprintable elements"),
          0,
          Icons::Invalid_ICON,
          Qt::WindowShortcut,


### PR DESCRIPTION
#31 

For me personally, this supersedes the regular **3.6.2** [Show Invisible] command.
Also: allow this and regular [Show Invisible] commands to be invoked during playback. One would think there could be potential undesirable behavior during playback, but so far so good.

Linked Issue(s): 
