### PR TITLE
Advanced Preference: Custom nudge spacing

### DIFF
--- a/global/settings/types/preferencekeys.h
+++ b/global/settings/types/preferencekeys.h
@@ -142,6 +142,8 @@
 #define PREF_UI_CANVAS_MISC_SELECTIONPROXIMITY              "ui/canvas/misc/selectionProximity"
 #define PREF_UI_CANVAS_SCROLL_VERTICALORIENTATION           "ui/canvas/scroll/verticalOrientation"
 #define PREF_UI_CANVAS_SCROLL_LIMITSCROLLAREA               "ui/canvas/scroll/limitScrollArea"
+#define PREF_UI_APP_NUDGESTEP_10                            "ui/score/nudgeStepCtrl"
+#define PREF_UI_APP_NUDGESTEP_1                             "ui/score/nudgeStep"
 #define PREF_UI_APP_STARTUP_CHECKUPDATE                     "ui/application/startup/checkUpdate"
 #define PREF_UI_APP_STARTUP_CHECK_EXTENSIONS_UPDATE         "ui/application/startup/checkExtensionsUpdate"
 #define PREF_UI_APP_STARTUP_SHOWNAVIGATOR                   "ui/application/startup/showNavigator"

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -454,9 +454,14 @@ void updateExternalValuesFromPreferences() {
       MScore::setHRaster(preferences.getInt(PREF_UI_APP_RASTER_HORIZONTAL));
       MScore::setVRaster(preferences.getInt(PREF_UI_APP_RASTER_VERTICAL));
 
-      MScore::setNudgeStep(.1);         // cursor key (default 0.1)
-      MScore::setNudgeStep10(1.0);      // Ctrl + cursor key (default 1.0)
-      MScore::setNudgeStep50(0.01);     // Alt  + cursor key (default 0.01)
+      // [Cursor] (Default: 0.1):
+      MScore::setNudgeStep(preferences.getDouble(PREF_UI_APP_NUDGESTEP_1));
+
+      // Ctrl + [Cursor] (Default: 1.0):
+      MScore::setNudgeStep10(preferences.getDouble(PREF_UI_APP_NUDGESTEP_10));
+
+      // Alt + [Cursor] (Default: 0.01):
+      MScore::setNudgeStep50(0.01);
 
       if (!preferences.getBool(PREF_APP_STARTUP_FIRSTSTART)) {
             //Create directories if they are missing

--- a/mscore/preferences.cpp
+++ b/mscore/preferences.cpp
@@ -242,6 +242,8 @@ void Preferences::init(bool storeInMemoryOnly)
             {PREF_UI_CANVAS_MISC_SELECTIONPROXIMITY,               new IntPreference(6, false)},
             {PREF_UI_CANVAS_SCROLL_LIMITSCROLLAREA,                new BoolPreference(false, false)},
             {PREF_UI_CANVAS_SCROLL_VERTICALORIENTATION,            new BoolPreference(false, false)},
+            {PREF_UI_APP_NUDGESTEP_10,                             new DoublePreference(1.0, true)},
+            {PREF_UI_APP_NUDGESTEP_1,                              new DoublePreference(0.1, true)},
             {PREF_UI_APP_STARTUP_CHECKUPDATE,                      new BoolPreference(checkUpdateStartup, false)},
             {PREF_UI_APP_STARTUP_CHECK_EXTENSIONS_UPDATE,          new BoolPreference(checkExtensionsUpdateStartup, false)},
             {PREF_UI_APP_STARTUP_SHOWNAVIGATOR,                    new BoolPreference(false, false)},


### PR DESCRIPTION
Advanced Preference:  
**`ui/score/nudgeStep`** and  **`ui/score/nudgeStepCtrl`**

These may be defined to override the default nudge sizes [1.0 and 0.1] using the keyboard.

Two suggestions are either [1.0 and 0.5] or [0.5 and 0.1], but whatever works