### PR TITLE
Advanced Preference: ability to disable vertical note dragging with mouse

### DIFF
--- a/global/settings/types/preferencekeys.h
+++ b/global/settings/types/preferencekeys.h
@@ -124,6 +124,7 @@
 #define PREF_SCORE_NOTE_DEFAULTPLAYDURATION                 "score/note/defaultPlayDuration"
 #define PREF_SCORE_NOTE_WARNPITCHRANGE                      "score/note/warnPitchRange"
 #define PREF_SCORE_NOTE_INPUT_DISABLE_MOUSE_INPUT           "ui/score/noteEntry/disableMouseEntry"
+#define PREF_UI_SCORE_DISABLE_NOTE_DRAG_VERTICAL            "ui/score/mouse/behavior/disableNoteDragVertical"
 #define PREF_SCORE_NOTE_INPUT_OCTAVE_TENDENCY               "ui/score/noteEntry/octaveTendencyIsTopNote"
 #define PREF_SCORE_STYLE_DEFAULTSTYLEFILE                   "score/style/defaultStyleFile"
 #define PREF_SCORE_STYLE_PARTSTYLEFILE                      "score/style/partStyleFile"

--- a/libmscore/mscore.cpp
+++ b/libmscore/mscore.cpp
@@ -92,6 +92,7 @@ QColor  MScore::cursorColor;
 QColor  MScore::defaultColor;
 
 bool    MScore::noteInputOctaveTendencyIsTopNote;
+bool    MScore::disableVerticalMouseDragOfNotes;
 
 QColor  MScore::layoutBreakColor;
 QColor  MScore::frameMarginColor;

--- a/libmscore/mscore.h
+++ b/libmscore/mscore.h
@@ -338,6 +338,7 @@ class MScore {
       static QColor defaultColor;
 
       static bool noteInputOctaveTendencyIsTopNote;
+      static bool disableVerticalMouseDragOfNotes;
 
       static QColor dropColor;
       static QColor layoutBreakColor;

--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -2561,8 +2561,10 @@ QRectF Note::drag(EditData& ed)
 
       if (noteEditData->mode == NoteEditData::EditMode_AddSpacing)
             horizontalDrag(ed);
-      else if (noteEditData->mode == NoteEditData::EditMode_ChangePitch)
-            verticalDrag(ed);
+      else if (noteEditData->mode == NoteEditData::EditMode_ChangePitch) {
+            if (!MScore::disableVerticalMouseDragOfNotes)
+                  verticalDrag(ed);
+            }
 
       return QRectF();
       }

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -429,6 +429,7 @@ void updateExternalValuesFromPreferences() {
       MScore::dropColor = preferences.getColor(PREF_UI_SCORE_NOTE_DROPCOLOR);
       MScore::defaultColor = preferences.getColor(PREF_UI_SCORE_DEFAULTCOLOR);
 
+      MScore::disableVerticalMouseDragOfNotes = preferences.getBool(PREF_UI_SCORE_DISABLE_NOTE_DRAG_VERTICAL);
       MScore::noteInputOctaveTendencyIsTopNote = preferences.getBool(PREF_SCORE_NOTE_INPUT_OCTAVE_TENDENCY);
       MScore::defaultPlayDuration = preferences.getInt(PREF_SCORE_NOTE_DEFAULTPLAYDURATION);
       MScore::panPlayback = preferences.getBool(PREF_APP_PLAYBACK_PANPLAYBACK);

--- a/mscore/preferences.cpp
+++ b/mscore/preferences.cpp
@@ -225,6 +225,7 @@ void Preferences::init(bool storeInMemoryOnly)
             {PREF_SCORE_NOTE_WARNPITCHRANGE,                       new BoolPreference(true, false)},
             {PREF_SCORE_NOTE_INPUT_DISABLE_MOUSE_INPUT,            new BoolPreference(false, true)},
             {PREF_SCORE_NOTE_INPUT_OCTAVE_TENDENCY,                new BoolPreference(false, true)},
+            {PREF_UI_SCORE_DISABLE_NOTE_DRAG_VERTICAL,             new BoolPreference(false)},
             {PREF_SCORE_STYLE_DEFAULTSTYLEFILE,                    new StringPreference("", false)},
             {PREF_SCORE_STYLE_PARTSTYLEFILE,                       new StringPreference("", false)},
             {PREF_UI_CANVAS_BG_USECOLOR,                           new BoolPreference(true, false)},


### PR DESCRIPTION
If the user does not intend to be changing the pitches of notes with their mouse device,
this option allows disabling said behavior accidentally for whatever reason.

`ui/score/mouse/behavior/disableNoteDragVertical`

![image](https://github.com/user-attachments/assets/3b7b9df7-f799-4ec2-9f33-4378c4bc602c)


[NoDrag.webm](https://github.com/user-attachments/assets/cf2411a0-c9a6-4b7a-93c8-2e538a903cde)
