### PR TITLE
Advanced Preference: Note Input - Allow for fifth upward/sixth downward, instead of fourth upward/fifth downward as option

### DIFF
--- a/global/settings/types/preferencekeys.h
+++ b/global/settings/types/preferencekeys.h
@@ -126,6 +126,7 @@
 #define PREF_SCORE_NOTE_INPUT_DISABLE_MOUSE_INPUT           "ui/score/noteEntry/disableMouseEntry"
 #define PREF_UI_SCORE_DISABLE_NOTE_DRAG_VERTICAL            "ui/score/mouse/behavior/disableNoteDragVertical"
 #define PREF_SCORE_NOTE_INPUT_OCTAVE_TENDENCY               "ui/score/noteEntry/octaveTendencyIsTopNote"
+#define PREF_SCORE_NOTE_INPUT_FIFTH_IS_UPWARD               "ui/score/noteEntry/octaveUpwardFifth"
 #define PREF_SCORE_STYLE_DEFAULTSTYLEFILE                   "score/style/defaultStyleFile"
 #define PREF_SCORE_STYLE_PARTSTYLEFILE                      "score/style/partStyleFile"
 #define PREF_UI_CANVAS_BG_USECOLOR                          "ui/canvas/background/useColor"

--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -4160,9 +4160,17 @@ void Score::cmdAddPitch(const EditData& ed, int note, bool addFlag, bool insert,
                         }
 
                   int delta = octave * 12 + tab[note] - curPitch;
-                  if (delta > 6)
+                  // Default: upward limit is interval of a fourth
+                  auto upTendency   = +6;
+                  auto downTendency = -6;
+                  if (MScore::noteInputOctaveUpwardFifth) {
+                        // Alternatively, upward limit is interval of a fifth, sixth/third is downward
+                        ++upTendency;
+                        downTendency += 2;
+                        }
+                  if  (delta > upTendency)
                         --octave;
-                  else if (delta < -6)
+                  else if (delta < downTendency)
                         ++octave;
                   }
             }

--- a/libmscore/mscore.cpp
+++ b/libmscore/mscore.cpp
@@ -92,6 +92,8 @@ QColor  MScore::cursorColor;
 QColor  MScore::defaultColor;
 
 bool    MScore::noteInputOctaveTendencyIsTopNote;
+bool    MScore::noteInputOctaveUpwardFifth;
+
 bool    MScore::disableVerticalMouseDragOfNotes;
 
 QColor  MScore::layoutBreakColor;

--- a/libmscore/mscore.h
+++ b/libmscore/mscore.h
@@ -338,6 +338,8 @@ class MScore {
       static QColor defaultColor;
 
       static bool noteInputOctaveTendencyIsTopNote;
+      static bool noteInputOctaveUpwardFifth;
+
       static bool disableVerticalMouseDragOfNotes;
 
       static QColor dropColor;

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -431,6 +431,7 @@ void updateExternalValuesFromPreferences() {
 
       MScore::disableVerticalMouseDragOfNotes = preferences.getBool(PREF_UI_SCORE_DISABLE_NOTE_DRAG_VERTICAL);
       MScore::noteInputOctaveTendencyIsTopNote = preferences.getBool(PREF_SCORE_NOTE_INPUT_OCTAVE_TENDENCY);
+      MScore::noteInputOctaveUpwardFifth = preferences.getBool(PREF_SCORE_NOTE_INPUT_FIFTH_IS_UPWARD);
       MScore::defaultPlayDuration = preferences.getInt(PREF_SCORE_NOTE_DEFAULTPLAYDURATION);
       MScore::panPlayback = preferences.getBool(PREF_APP_PLAYBACK_PANPLAYBACK);
       MScore::harmonyPlayDisableCompatibility = preferences.getBool(PREF_SCORE_HARMONY_PLAY_DISABLE_COMPATIBILITY);

--- a/mscore/preferences.cpp
+++ b/mscore/preferences.cpp
@@ -225,6 +225,7 @@ void Preferences::init(bool storeInMemoryOnly)
             {PREF_SCORE_NOTE_WARNPITCHRANGE,                       new BoolPreference(true, false)},
             {PREF_SCORE_NOTE_INPUT_DISABLE_MOUSE_INPUT,            new BoolPreference(false, true)},
             {PREF_SCORE_NOTE_INPUT_OCTAVE_TENDENCY,                new BoolPreference(false, true)},
+            {PREF_SCORE_NOTE_INPUT_FIFTH_IS_UPWARD,                new BoolPreference(false)},
             {PREF_UI_SCORE_DISABLE_NOTE_DRAG_VERTICAL,             new BoolPreference(false)},
             {PREF_SCORE_STYLE_DEFAULTSTYLEFILE,                    new StringPreference("", false)},
             {PREF_SCORE_STYLE_PARTSTYLEFILE,                       new StringPreference("", false)},


### PR DESCRIPTION
Advanced Preference:
`ui/score/noteEntry/octaveUpwardFifth`

![image](https://github.com/user-attachments/assets/102908bc-7082-4091-87bd-39877d6696f9)

Normally, note-entry with an alphanumeric keyboard using the [**Insert Note A-G**] commands will place the next pitch on _a lower staff place_ if it is of a fifth-interval difference - the fourth interval being the upper limit for being placed above. Enabling this will allow for the fifth interval to become _the upper limit_ so that only the sixth/seventh in relation to the previous pitch will be inserted below. This may be easier to remember in the moment, reassuring where the next inserted pitch will be placed. Just another option to make use of or not.

As an example, let the most recent note be a C. If the user presses D-G with this option, that pitch will be placed on a higher staff position than the C's position. A or B will be inserted on a lower staff place.

### 3.6.2 or with the option off:
[regularNoteEntry.webm](https://github.com/user-attachments/assets/b35e1cba-2683-430d-a0c5-483d45aadff5)

### With option enabled:


[tendencyFifth.webm](https://github.com/user-attachments/assets/0426228e-2d3a-4224-b639-dfacc4c30434)
