### PR TITLE
New Command: Shortcut for Preferences Dialog

### DIFF
--- a/mscore/musescore.h
+++ b/mscore/musescore.h
@@ -523,7 +523,6 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
       void leaveFeedback(QString medium);
       void openRecentMenu();
       void selectScore(QAction*);
-      void startPreferenceDialog();
       void preferencesChanged(bool fromWorkspace = false, bool changeUI = true);
       void seqStarted();
       void seqStopped();
@@ -607,6 +606,7 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
       void changeWorkspace(Workspace* p, bool first=false);
       void mixerPreferencesChanged(bool showMidiControls);
       void checkForUpdates();
+      void startPreferenceDialog();
       void restartAudioEngine();
 
    public:

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -2166,6 +2166,9 @@ void ScoreView::cmd(const char* s)
             };
 
       static const std::vector<ScoreViewCmd> cmdList {
+            {{"start-preference-dialog"}, [](ScoreView* /*cv*/, const QByteArray&) {
+                  mscore->startPreferenceDialog();
+                  }},
             {{"escape"}, [](ScoreView* cv, const QByteArray&) {
                   cv->escapeCmd();
                   }},

--- a/mscore/shortcut.cpp
+++ b/mscore/shortcut.cpp
@@ -93,6 +93,13 @@ Shortcut Shortcut::_sc[] = {
          },
       {
          MsWidget::MAIN_WINDOW,
+         STATE_NORMAL | STATE_NOTE_ENTRY | STATE_EDIT,
+         "start-preference-dialog",
+         QT_TRANSLATE_NOOP("action","Start Preferences Dialog…"),
+         QT_TRANSLATE_NOOP("action","start preferences dialog")
+         },
+      {
+         MsWidget::MAIN_WINDOW,
          STATE_NORMAL | STATE_NOTE_ENTRY | STATE_EDIT | STATE_PLAY,
          "file-save-a-copy",
          QT_TRANSLATE_NOOP("action","Save a Copy…"),


### PR DESCRIPTION
... because why not? No default definition given.

`start preferences dialog`

![image](https://github.com/user-attachments/assets/6bc5bfee-a7ab-4028-b024-7ebbd88e7804)
