### PR TITLE
New Command: [Next/Previous Staff] without traversing voices.

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -2616,6 +2616,16 @@ Element* Score::move(const QString& cmd)
             if (noteEntryMode())
                   _is.moveInputPos(el);
             }
+      else if (cmd == "next-staff" && cr) {
+            el = nextTrack(cr, true);
+            if (noteEntryMode())
+                  _is.moveInputPos(el);
+            }
+      else if (cmd == "prev-staff" && cr) {
+            el = prevTrack(cr, true);
+            if (noteEntryMode())
+                  _is.moveInputPos(el);
+            }
       else if (cmd == "top-staff") {
             el = cr ? cmdTopStaff(cr) : cmdTopStaff();
             if (noteEntryMode())

--- a/libmscore/navigate.cpp
+++ b/libmscore/navigate.cpp
@@ -439,7 +439,7 @@ ChordRest* Score::downStaff(ChordRest* cr)
 //    that contains such an element
 //---------------------------------------------------------
 
-ChordRest* Score::nextTrack(ChordRest* cr)
+ChordRest* Score::nextTrack(ChordRest* cr, bool skipVoices)
       {
       if (!cr)
             return 0;
@@ -452,9 +452,16 @@ ChordRest* Score::nextTrack(ChordRest* cr)
       while (!el) {
             // find next non-empty track
             while (++track < tracks) {
-                  if (measure->hasVoice(track))
+                  if (skipVoices) {
+                        // Disregard voices and directly refer to next staff
+                        if ((track % 4) != 0)
+                              continue;
+                        break;
+                        }
+                  else if (measure->hasVoice(track))
                         break;
                   }
+
             // no more tracks, return original element
             if (track == tracks)
                   return cr;
@@ -475,7 +482,7 @@ ChordRest* Score::nextTrack(ChordRest* cr)
 //    that contains such an element
 //---------------------------------------------------------
 
-ChordRest* Score::prevTrack(ChordRest* cr)
+ChordRest* Score::prevTrack(ChordRest* cr, bool skipVoices)
       {
       if (!cr)
             return 0;
@@ -486,8 +493,14 @@ ChordRest* Score::prevTrack(ChordRest* cr)
 
       while (!el) {
             // find next non-empty track
-            while (--track >= 0){
-                  if (measure->hasVoice(track))
+            while (--track >= 0) {
+                  if (skipVoices) {
+                        // Disregard voices and directly refer to previous staff
+                        if ((track % 4) != 0)
+                              continue;
+                        break;
+                        }
+                  else if (measure->hasVoice(track))
                         break;
                   }
             // no more tracks, return original element

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -501,8 +501,8 @@ class Score : public QObject, public ScoreElement {
       Note* getSelectedNote();
       ChordRest* upStaff(ChordRest* cr);
       ChordRest* downStaff(ChordRest* cr);
-      ChordRest* nextTrack(ChordRest* cr);
-      ChordRest* prevTrack(ChordRest* cr);
+      ChordRest* nextTrack(ChordRest* cr, bool skipVoices=false);
+      ChordRest* prevTrack(ChordRest* cr, bool skipVoices=false);
 
       void padToggle(Pad p, const EditData& ed);
       void addTempo();

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -2416,6 +2416,8 @@ void ScoreView::cmd(const char* s)
               "prev-chord",
               "next-track",
               "prev-track",
+              "next-staff",
+              "prev-staff",
               "next-measure",
               "prev-measure",
               "next-system",

--- a/mscore/shortcut.cpp
+++ b/mscore/shortcut.cpp
@@ -1131,6 +1131,13 @@ Shortcut Shortcut::_sc[] = {
       {
          MsWidget::SCORE_TAB,
          STATE_NORMAL | STATE_NOTE_ENTRY,
+         "prev-staff",
+         QT_TRANSLATE_NOOP("action","Previous Staff"),
+         QT_TRANSLATE_NOOP("action","Previous staff")
+         },
+      {
+         MsWidget::SCORE_TAB,
+         STATE_NORMAL | STATE_NOTE_ENTRY,
          "next-chord",
          QT_TRANSLATE_NOOP("action","Next Chord"),
          QT_TRANSLATE_NOOP("action","Go to next chord or move text right")
@@ -1190,6 +1197,13 @@ Shortcut Shortcut::_sc[] = {
          "next-track",
          QT_TRANSLATE_NOOP("action","Next Staff or Voice"),
          QT_TRANSLATE_NOOP("action","Next staff or voice")
+         },
+      {
+         MsWidget::SCORE_TAB,
+         STATE_NORMAL | STATE_NOTE_ENTRY,
+         "next-staff",
+         QT_TRANSLATE_NOOP("action","Next Staff"),
+         QT_TRANSLATE_NOOP("action","Next staff")
          },
       {
          MsWidget::SCORE_TAB,


### PR DESCRIPTION
Another helper function. 

The original commands from previous versions are entitled: "Go to next/previous staff or voice"

Yet, if the user wants to go to the above or below staff via keyboard in a situation where there are multiple voices, it's nice to be able to do so with one execution. And instead of losing the ability to go to the next voice, by default MuseScore already provides the ability to traverse voices indirectly by using "Go to higher/lower pitched note in chord". As an example, during note-entry, it's often the case that (I'll use myself as an example) I will [go to previous system] to get back to the beginning of the system and then change voice to insert that voice's notation on that system. If I'm done with a particular staff, to merely use "Go to next staff" command to continue feels just "a little more slick", and that's what many of these changes are all about.

Aside: There is another set of commands: "Voice 1/2/3/4". These work while in note entry mode to prepare for note entry, or they "switch" the current selection when not in note-entry to that command's voice (similar to "Voice-n Exchange" commands but on a list selection instead of upon a range/per measure).  Reason I mention these is because they can and will be "upgraded" so that while in note-entry, they also select an existing chord (its top note of course) of that voice. Currently (3.6.2 and who knows for 4.x) they merely switch the track of the note-entry cursor without touching score selection. In an upgraded edition, they will function also as "go to [x] voice" while in note entry, so there is yet another way to go to a specified voice. 

Voice traversal via:
1) The original "Go to next/previous staff or voice" commands,
2) "Go to higher/lower pitched note in chord"... potentially multiple times if there's a large chord
3) And after a future update, the "Voice 1/2/3/4"  commands _while in note entry_

The above options allow this "go to staff" command to potentially replace the "go to staff or voice" commands if the user should desire.