### PR TITLE
Update: Allow [Previous Measure/System] when input state has no chordrest. (Also fixes a grace note regression)

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -2399,8 +2399,7 @@ Element* Score::move(const QString& cmd)
             cr = selection().cr();
             if (cr && (cr->isGrace() || cmd == "next-chord" || cmd == "prev-chord"))
                   ;
-            else
-                  cr = inputState().cr();
+            else cr = inputState().cr() ? inputState().cr() : cr;
             }
       else if (selection().activeCR())
             cr = selection().activeCR();
@@ -2541,8 +2540,9 @@ Element* Score::move(const QString& cmd)
             // selection "cursor"
             // find previous chordrest, which might be a grace note
             // this may override note input cursor
-            el = noteEntryPos ? el : prevChordRest(cr);
-
+            if (auto pcr = prevChordRest(cr)) {
+                  el = (noteEntryPos && !pcr->isGrace()) ? el : pcr;
+                  }
             // Skip gap rests if we're not in note entry mode...
             while (!noteEntryMode() && el && el->isRest() && toRest(el)->isGap())
                   el = prevChordRest(toChordRest(el));


### PR DESCRIPTION
1. Initial commit @ https://github.com/Jojo-Schmitz/MuseScore/issues/604 attempted to allow moving to previous chord/rest when input state had no valid CR but previous position exists. Unfortunately this resulted in omitting grace notes while traversing in note-entry, so this PR fixes that regression

2. This PR also allows [**Go to previous measure/system**] commands to also continue working if input state has no valid CR, whereas before it would do nothing. 

Demonstration:

[3.webm](https://github.com/user-attachments/assets/6fd61fc7-71fb-4314-8fd9-7fb2dedb1c67)
