### PR TITLE
Personal Alteration: [Command: Voice 1] will enter into edit mode if a line/slurtie is selected (anything with grips > 1)

### DIFF
--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -2753,7 +2753,11 @@ void ScoreView::cmd(const char* s)
                         }
                   }},
             {{"voice-1"}, [](ScoreView* cv, const QByteArray&) {
-                  cv->changeVoice(0);
+                  auto e = cv->score()->selection().element();
+                  if (e && e->isEditable() && !cv->popupActive && e->gripsCount() > 1) {
+                        cv->startEditMode(e);
+                        }
+                  else cv->changeVoice(0);
                   }},
             {{"voice-2"}, [](ScoreView* cv, const QByteArray&) {
                   cv->changeVoice(1);


### PR DESCRIPTION
Personal note: this is because I'm using "Tab" for Voice 1/2 cycling, making sure that tabbing through grip nodes still works fine by accessing edit mode first.