### PR TITLE
Palettes: Hide palettes when [apply element] is issued (if advanced preference is set)

### DIFF
--- a/global/settings/types/preferencekeys.h
+++ b/global/settings/types/preferencekeys.h
@@ -158,6 +158,7 @@
 #define PREF_UI_APP_RASTER_VERTICAL                         "ui/application/raster/vertical"
 #define PREF_UI_APP_SHOWSTATUSBAR                           "ui/application/showStatusBar"
 #define PREF_UI_APP_USENATIVEDIALOGS                        "ui/application/useNativeDialogs"
+#define PREF_UI_APP_AUTOHIDE_PALETTES                       "ui/application/palette/applyAutoHides"
 #define PREF_UI_PIANO_HIGHLIGHTCOLOR                        "ui/piano/highlightColor"
 #define PREF_UI_PIANO_SHOWPITCHHELP                         "ui/piano/showPitchHelp"
 #define PREF_UI_SCORE_NOTE_DROPCOLOR                        "ui/score/note/dropColor"

--- a/libmscore/mscore.cpp
+++ b/libmscore/mscore.cpp
@@ -94,6 +94,8 @@ QColor  MScore::defaultColor;
 bool    MScore::noteInputOctaveTendencyIsTopNote;
 bool    MScore::disableVerticalMouseDragOfNotes;
 
+bool    MScore::palettesHideWhenApplied;
+
 QColor  MScore::layoutBreakColor;
 QColor  MScore::frameMarginColor;
 QColor  MScore::bgColor;

--- a/libmscore/mscore.h
+++ b/libmscore/mscore.h
@@ -340,6 +340,8 @@ class MScore {
       static bool noteInputOctaveTendencyIsTopNote;
       static bool disableVerticalMouseDragOfNotes;
 
+      static bool palettesHideWhenApplied;
+
       static QColor dropColor;
       static QColor layoutBreakColor;
       static QColor frameMarginColor;

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -429,6 +429,8 @@ void updateExternalValuesFromPreferences() {
       MScore::dropColor = preferences.getColor(PREF_UI_SCORE_NOTE_DROPCOLOR);
       MScore::defaultColor = preferences.getColor(PREF_UI_SCORE_DEFAULTCOLOR);
 
+      MScore::palettesHideWhenApplied = preferences.getBool(PREF_UI_APP_AUTOHIDE_PALETTES);
+
       MScore::disableVerticalMouseDragOfNotes = preferences.getBool(PREF_UI_SCORE_DISABLE_NOTE_DRAG_VERTICAL);
       MScore::noteInputOctaveTendencyIsTopNote = preferences.getBool(PREF_SCORE_NOTE_INPUT_OCTAVE_TENDENCY);
       MScore::defaultPlayDuration = preferences.getInt(PREF_SCORE_NOTE_DEFAULTPLAYDURATION);
@@ -6068,6 +6070,8 @@ void MuseScore::cmd(QAction* a)
       if (cmdn == "apply-current-palette-element") {
             if (paletteWidget)
                   paletteWidget->applyCurrentPaletteElement();
+            if (MScore::palettesHideWhenApplied)
+                  showPalette(false);
             return;
             }
       if (cmdn == "repeat-cmd") {

--- a/mscore/preferences.cpp
+++ b/mscore/preferences.cpp
@@ -257,6 +257,7 @@ void Preferences::init(bool storeInMemoryOnly)
             {PREF_UI_APP_RASTER_HORIZONTAL,                        new IntPreference(2)},
             {PREF_UI_APP_RASTER_VERTICAL,                          new IntPreference(2)},
             {PREF_UI_APP_SHOWSTATUSBAR,                            new BoolPreference(true)},
+            {PREF_UI_APP_AUTOHIDE_PALETTES,                        new BoolPreference(true)},
 #if defined(Q_OS_MAC) || defined(Q_OS_WIN) // use system native file dialog, Qt file dialog is very slow on Windows and Mac
             {PREF_UI_APP_USENATIVEDIALOGS,                         new BoolPreference(true)},
 #else // don't use system native file dialog, this is causing issues on some Linuxes


### PR DESCRIPTION
**Advanced Preference**: `ui/application/palette/applyAutoHides` (enabled/disabled)

### Demonstration: 

[PaletteAutoHide.webm](https://github.com/user-attachments/assets/e9a04c5e-b79a-4231-bef3-a74b82180b70)
