### PR TITLE
Note Entry: deactivate an active slur if user moves by a command other than [next/previous chord]

### DIFF
--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -2452,9 +2452,21 @@ void ScoreView::cmd(const char* s)
                         cv->score()->endCmd();
                         }
                   else {
-                        Element* ele = cv->score()->move(cmd);
+                        auto score = cv->score();
+                        Element* ele = score->move(cmd);
                         if (cmd == "empty-trailing-measure")
                               cv->changeState(ViewState::NOTE_ENTRY);
+
+                        // Active slur will de-activate if move command is larger than per-chord:
+                        if (score->noteEntryMode() && cmd != "next-chord" && cmd != "prev-chord") {
+                              if (auto slur = score->inputState().slur()) {
+                                    auto &el = slur->spannerSegments();
+                                    if (!el.empty())
+                                          el.front()->setSelected(false);
+                                    
+                                    score->inputState().setSlur(nullptr);
+                                    }
+                              }
                         if (ele)
                               cv->adjustCanvasPosition(ele, false);
                         cv->score()->setPlayChord(true);


### PR DESCRIPTION
Suppose this "potentially" could be undesirable, but here moving per measure/system or changing staves allows to be lazy and not require manually deactivating a slur, as it will be performed automatically:

[slur.webm](https://github.com/user-attachments/assets/80fc1e4c-c8a3-4ffb-8a1d-fb8d4c07ae15)
