### PR TITLE
Palette: Barlines will apply to end of previous measure when input position moves to a new measure

### DIFF
--- a/mscore/palette.cpp
+++ b/mscore/palette.cpp
@@ -517,6 +517,7 @@ bool Palette::applyPaletteElement(Element* element, Qt::KeyboardModifiers modifi
       if (element->isSpanner())
             TourHandler::startTour("spanner-drop-apply");
 
+      auto& is = score->inputState();
       bool isFrame  = false;
       auto iconType = element->isIcon() ? toIcon(element)->iconType() : IconType::NONE;
       switch (iconType) { // fallthroughs
@@ -660,9 +661,22 @@ bool Palette::applyPaletteElement(Element* element, Qt::KeyboardModifiers modifi
                                     }
                               }
                         }
-                  for (Element* e : sel.elements())
-                        applyDrop(score, viewer, e, element, modifiers);
 
+                  for (Element* e : sel.elements()) {
+                        auto ee = e;
+
+                        // Change from 3.6.2: Let barline placement be equiv. to range selection
+                        // in N.E. starting new measure entry (end of the measure placement for streamlining)
+                        if (element->type() == ElementType::BAR_LINE && is.noteEntryMode() ) {
+                              auto ism = is.cr() ? is.cr()->measure() : score->tick2measure(is.tick());
+                              auto em  = e->findMeasure();
+                              if (ism && em && (em->index() != ism->index())) {
+                                    ee = em;
+                                    }
+                              }
+
+                        applyDrop(score, viewer, ee, element, modifiers);
+                        }
                   }
             }
       else if (sel.isRange()) {


### PR DESCRIPTION
### Updated:

[barline.webm](https://github.com/user-attachments/assets/d143a80e-2dc1-480f-baf1-fb6dbe512d46)

Normally, in 3.6.2, in order to get a barline to apply to the end of a measure with the keyboard, the user had to create a range selection first within that measure, or apply it when at the first ChordRest (or get out of note entry and do the "go to next element" command to select the barline first. I wanted to be able to quickly insert one "in the moment" while during note entry without having to re-situation (go back to the beginning of measure) or create a range selection, hence this change. Otherwise, the same behavior would give a barline at the beginning of the last selected element like so:

### 3.6.2 Behavior
[362barline.webm](https://github.com/user-attachments/assets/7ba7b002-8921-4f1f-92f7-ef8654fc84cb)



