### PR TITLE
Palette: Applying a time signature will provide a valid ChordRest selection afterwards

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -739,6 +739,10 @@ bool Score::rewriteMeasures(Measure* fm, const Fraction& ns, int staffIdx)
 
 void Score::cmdAddTimeSig(Measure* fm, int staffIdx, TimeSig* ts, bool local)
       {
+      auto el = score()->selection().firstChordRest();
+      auto selectTrack = el ? el->track() : 0;
+      auto selectTick = el ? el->tick() : Fraction(0,1);
+
       deselectAll();
 
       if (fm->isMMRest())
@@ -911,6 +915,17 @@ void Score::cmdAddTimeSig(Measure* fm, int staffIdx, TimeSig* ts, bool local)
                   }
             }
       delete ts;
+
+      // Attempt valid selection afterward:
+      if (el) {
+      if (auto msr = score()->tick2measure(selectTick)) {
+      if (auto first = msr->first()) {
+      if (auto cr = first->nextChordRest(selectTrack)) {
+            if (cr->isChord())
+                  score()->select(toChord(cr)->upNote());
+            else
+                  score()->select(cr);
+            }}}}
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
### 3.6.2 Behavior: 
Nothing is selected after apply a Time Signature. Main thing that was perturbing was attempting to 
1) Apply time signature
2) Immediately attempt to apply a key signature, and you can't because nothing is selected
Whatever, the user can get in the habit of doing it the other way around. Just didn't want miniature "freezings" like this if possible

### With updated behavior:

[placing.webm](https://github.com/user-attachments/assets/e60e5f7e-c222-4869-adfe-a945b8001284)

Arg... all kinds of MTEST changes are needed, apparently....