### PR TITLE
Fix two potential crashes

### DIFF
--- a/libmscore/slurtie.cpp
+++ b/libmscore/slurtie.cpp
@@ -370,6 +370,9 @@ void SlurTieSegment::read(XmlReader& e)
 
 void SlurTieSegment::drawEditMode(QPainter* p, EditData& ed)
       {
+      if (ed.grip.isEmpty())
+            return;
+
       QPolygonF polygon(7);
       polygon[0] = QPointF(ed.grip[int(Grip::START)].center());
       polygon[1] = QPointF(ed.grip[int(Grip::BEZIER1)].center());

--- a/libmscore/textlinebase.h
+++ b/libmscore/textlinebase.h
@@ -33,10 +33,10 @@ class TextLineBaseSegment : public LineSegment {
       Text* _text;
       Text* _endText;
       QPointF points[6];
-      QPolygonF joinedHairpin;
       int npoints;
       qreal lineLength;
       bool twoLines { false };
+      QPolygonF joinedHairpin;
 
    public:
       TextLineBaseSegment(Spanner*, Score* s, ElementFlags f = ElementFlag::NOTHING);


### PR DESCRIPTION
+ Slur spanning multiple systems, insert into edit mode with it but then drag on another spanner on another system can cause a crash

+ Some weird Qt destructor race condition can occur for the QPolygonF joinedHairpin when closing a tab that is fixed by moving its position in construction toward the end. Don't ask me.