### PR TITLE
Fix: Note-entry tying while in secondary voice from full-measure note skipping measures 

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -1376,8 +1376,6 @@ void Score::cmdAddTie(bool addToChord)
                         }
                   }
             }
-      if (lastAddedChord)
-            nextInputPos(lastAddedChord, false);
       endCmd();
       }
 


### PR DESCRIPTION
### Demonstration of problem:

[noteEntrySkip.webm](https://github.com/user-attachments/assets/8784ec9a-16b7-4460-82a5-ca92c3afe1f8)

Could be more problematic when making edits mid-score