### PR TITLE
Multiple updates to range selection and previous/next measure commands

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -2588,20 +2588,66 @@ Element* Score::move(const QString& cmd)
 
             }
       else if (cmd == "next-measure") {
+            auto track = _is.track();
             if (box && box->nextMeasure() && box->nextMeasure()->first())
                   el = box->nextMeasure()->first()->nextChordRest(0, false);
-            if (cr)
+            if (cr) {
+                  if (selection().cr() && (cr->tick() != selection().cr()->tick()))
+                        cr = selection().cr();
                   el = nextMeasure(cr);
-            if (el && noteEntryMode())
-                  _is.moveInputPos(el);
+                  }
+
+            if (el) {
+                  if (noteEntryMode())
+                        _is.moveInputPos(el);
+
+                  // Attempt to maintain current track
+                  auto desiredTrackCR = _is.noteEntryMode() ? (selection().isRange() ? _is.chordRest(el) : _is.segment()->nextChordRest(track))
+                                                            : el->findMeasure()->first()->nextChordRest(track);
+
+                  auto inputTick = _is.noteEntryMode() ? _is.tick() : el->tick();
+
+                  if (desiredTrackCR && desiredTrackCR->tick() <= inputTick) {
+                        auto note = desiredTrackCR->isChord() ? toChord(desiredTrackCR)->upNote() : nullptr;
+                        if (note)
+                              el = note;
+                        else
+                              el = desiredTrackCR;
+                        }
+                  }
             }
       else if (cmd == "prev-measure") {
+            auto track = _is.track();
             if (box && box->prevMeasure() && box->prevMeasure()->first())
                   el = box->prevMeasure()->first()->nextChordRest(0, false);
-            if (cr)
+            if (cr) {
+                  if (selection().cr() && (cr->tick() != selection().cr()->tick())) {
+                        cr = selection().cr();
+                        }
+                  if (selection().isRange()) {
+                        cr = selection().firstChordRest();
+                        }
                   el = prevMeasure(cr);
-            if (el && noteEntryMode())
-                  _is.moveInputPos(el);
+                  }
+
+            if (el) {
+                  if (noteEntryMode())
+                        _is.moveInputPos(el);
+
+                  // Attempt to maintain current track
+                  auto desiredTrackCR = _is.noteEntryMode() ? (selection().isRange() ? _is.chordRest(el) : _is.segment()->nextChordRest(track))
+                                                            : el->findMeasure()->first()->nextChordRest(track);
+
+                  auto inputTick = _is.noteEntryMode() ? _is.tick() : el->tick();
+
+                  if (desiredTrackCR && desiredTrackCR->tick() <= inputTick) {
+                        auto note = desiredTrackCR->isChord() ? toChord(desiredTrackCR)->upNote() : nullptr;
+                        if (note)
+                              el = note;
+                        else
+                              el = desiredTrackCR;
+                        }
+                  }
             }
       else if (cmd == "next-system" && cr) {
             el = cmdNextPrevSystem(cr, true);

--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -2627,6 +2627,14 @@ Element* Score::move(const QString& cmd)
                   }
 
             if (el) {
+                  auto oldEl = el;
+                  auto m = el->findMeasure();
+                  if (cr && m == cr->measure() && m->last()) {
+                        el = m->last()->nextChordRest(el->track(), true);
+                        if (!el) {
+                              el = oldEl;
+                              }
+                        }
                   if (noteEntryMode()) {
                         _is.moveInputPos(el);
                         auto desiredTrackCR = _is.segment()->nextChordRest(currentTrack);

--- a/libmscore/navigate.cpp
+++ b/libmscore/navigate.cpp
@@ -538,6 +538,7 @@ ChordRest* Score::nextMeasure(ChordRest* element, bool selectBehavior, bool mmRe
       bool last   = false;
 
       if (selection().isRange()) {
+            measure = selection().lastChordRest()->measure()->nextMeasure();
             if (element->tick() != endTick && selection().tickEnd() <= endTick) {
                   measure = element->measure();
                   last = true;

--- a/libmscore/navigate.cpp
+++ b/libmscore/navigate.cpp
@@ -538,14 +538,17 @@ ChordRest* Score::nextMeasure(ChordRest* element, bool selectBehavior, bool mmRe
       bool last   = false;
 
       if (selection().isRange()) {
-            measure = selection().lastChordRest()->measure()->nextMeasure();
-            if (element->tick() != endTick && selection().tickEnd() <= endTick) {
-                  measure = element->measure();
-                  last = true;
+            if (selectBehavior) {
+                  if (element->tick() != endTick && selection().tickEnd() <= endTick) {
+                        measure = element->measure();
+                        last = true;
+                        }
+                  else if (element->tick() == endTick && selection().isEndActive()) {
+                        last = true;
+                        }
                   }
-            else if (element->tick() == endTick && selection().isEndActive())
-                  last = true;
             }
+
       else if (element->tick() != endTick && selectBehavior) {
             measure = element->measure();
             last = true;
@@ -598,15 +601,23 @@ ChordRest* Score::prevMeasure(ChordRest* element, bool mmRest)
             }
 
       int staff = element->staffIdx();
-
       Segment* startSeg = last ? measure->last() : measure->first();
       for (Segment* seg = startSeg; seg; seg = last ? seg->prev() : seg->next()) {
-            int etrack = (staff+1) * VOICES;
-            for (int track = staff * VOICES; track < etrack; ++track) {
-                  Element* pel = seg->element(track);
-
-                  if (pel && pel->isChordRest())
-                        return toChordRest(pel);
+            if (score()->noteEntryMode() || selection().hasTemporaryFilter()) {
+                  int track = element->track();
+                  if (auto pel = seg->element(track)) {
+                        if (pel->isChordRest()) {
+                              return toChordRest(pel);
+                              }
+                        }
+                  }
+            else {
+                  int etrack = (staff+1) * VOICES;
+                  for (int track = staff * VOICES; track < etrack; ++track) {
+                        Element* pel = seg->element(track);
+                        if (pel && pel->isChordRest())
+                              return toChordRest(pel);
+                        }
                   }
             }
       return 0;


### PR DESCRIPTION
[Command: next/prev measure] New behavior: maintain current input track if destination contains a ChordRest in that track.

[Command: next/prev measure] Should operate OK while in note-entry now while using range-selection

[Command: next/prev measure] Will take user to the end of the measure if already within the end measure instead of doing nothing.

[Extend range selection left/right] Will now operate more literally: left is always extend left, right is always extend right. After testing 3.6.2 quickly, I don't really see the issue, but sure I wouldn't have attempted a change unless there were some undesired activity having to do with Note Entry and range selection based on the old code...