### PR TITLE
Harmony Texts: Ctrl+Enter will vertically stack a new chord with underline properties to facilitate "polychord" look

### DIFF
--- a/libmscore/harmony.cpp
+++ b/libmscore/harmony.cpp
@@ -1501,6 +1501,7 @@ void Harmony::draw(QPainter* painter) const
       painter->setPen(color);
       for (const TextSegment* ts : textList) {
             QFont f(ts->font);
+            f.setUnderline(false);
             f.setPointSizeF(f.pointSizeF() * MScore::pixelRatio);
 #ifndef Q_OS_MACOS
             TextBase::drawTextWorkaround(painter, f, ts->pos(), ts->text);
@@ -1509,6 +1510,30 @@ void Harmony::draw(QPainter* painter) const
             painter->drawText(ts->pos(), ts->text);
 #endif
             }
+
+      // Want consistent-base underline (esp for polychord look)
+      if (underline()) {
+            auto lineWidth = fontMetrics().lineWidth();
+            lineWidth *= 3;
+            QPen pen(textColor(), lineWidth, Qt::SolidLine, Qt::SquareCap, Qt::MiterJoin);
+            painter->setPen(pen);
+
+            auto ts = textList.first();
+            auto bboxFirstCharacter = ts->tightBoundingRect();
+
+            auto bottomLeft = bboxFirstCharacter.bottomLeft();
+            auto bottomRight = bboxFirstCharacter.bottomRight();
+
+            bottomLeft.rx() = this->bbox().bottomLeft().x();
+            bottomRight.rx() = this->bbox().bottomRight().x();
+
+            // A little extra space below
+            auto multiplier = 2.5;
+            bottomLeft.ry()  += lineWidth * multiplier;
+            bottomRight.ry() += lineWidth * multiplier;
+            painter->drawLine(bottomLeft, bottomRight);
+            }
+
       }
 
 //---------------------------------------------------------

--- a/libmscore/harmony.cpp
+++ b/libmscore/harmony.cpp
@@ -1511,7 +1511,6 @@ void Harmony::draw(QPainter* painter) const
 #endif
             }
 
-      // Want consistent-base underline (esp for polychord look)
       if (underline()) {
             auto lineWidth = fontMetrics().lineWidth();
             lineWidth *= 3;

--- a/mscore/events.cpp
+++ b/mscore/events.cpp
@@ -867,7 +867,12 @@ void ScoreView::keyPressEvent(QKeyEvent* ev)
                   return;
                   }
             else if (editData.key == Qt::Key_Return) {
-                  changeState(ViewState::NORMAL);
+                  if (editData.modifiers & CONTROL_MODIFIER) {
+                        // Multi-chord (polychord) stacking
+                        changeState(ViewState::NORMAL);
+                        cmdAddChordName(HarmonyType::STANDARD, true);
+                        }
+                  else changeState(ViewState::NORMAL);
                   return;
                   }
             }

--- a/mscore/scoreview.h
+++ b/mscore/scoreview.h
@@ -293,7 +293,7 @@ class ScoreView : public QWidget, public MuseScoreView {
       void figuredBassTicksTab(const Fraction& ticks);
       void realtimeAdvance(bool allowRests);
       void cmdAddFret(int fret);
-      void cmdAddChordName(HarmonyType ht);
+      void cmdAddChordName(HarmonyType ht, bool poly=false);
       void cmdAddText(Tid tid, Tid customTid = Tid::DEFAULT, PropertyFlags pf = PropertyFlags::STYLED, Placement p = Placement::ABOVE);
       void cmdEnterRest(const TDuration&);
       void cmdEnterRest();


### PR DESCRIPTION
Provides a "pseudo" poly-chord support by way of allowing the user to enter another chord easily by pressing CTRL+ENTER while entering the first chord. 

Also allows generally speaking to have underline be a little more consistent, although had to make use of some arbitrary values. 3.6.2 would have breaks in its underlines for Harmony Text.

Note: the chord text formed here had to be defined in some sense, so went with "Centered". For this to work well, regular Harmony Texts have to have their alignment by default be centered. Of course, if desired, left-align works but that would be "afterwards" applied to all of the harmony texts that make use of this

Using [Ctrl+Enter]

[stacked.webm](https://github.com/user-attachments/assets/5161295b-366b-4b66-998a-8c05c1e3894f)
