### PR TITLE
Fingering Text Entry Updates

### DIFF
--- a/global/settings/types/preferencekeys.h
+++ b/global/settings/types/preferencekeys.h
@@ -127,6 +127,7 @@
 #define PREF_UI_SCORE_DISABLE_NOTE_DRAG_VERTICAL            "ui/score/mouse/behavior/disableNoteDragVertical"
 #define PREF_SCORE_NOTE_INPUT_OCTAVE_TENDENCY               "ui/score/noteEntry/octaveTendencyIsTopNote"
 #define PREF_SCORE_NOTE_INPUT_FIFTH_IS_UPWARD               "ui/score/noteEntry/octaveUpwardFifth"
+#define PREF_SCORE_FINGERING_ALPHANUMERIC_AUTOFORWARD       "score/fingering/autoForwardWithAlphaNumerics"
 #define PREF_SCORE_STYLE_DEFAULTSTYLEFILE                   "score/style/defaultStyleFile"
 #define PREF_SCORE_STYLE_PARTSTYLEFILE                      "score/style/partStyleFile"
 #define PREF_SCORE_PLAYBACK_CURSOR_ENTIRE_MEASURE           "ui/score/playbackCursor/entireMeasure"

--- a/libmscore/fingering.cpp
+++ b/libmscore/fingering.cpp
@@ -101,6 +101,7 @@ void Fingering::layout()
 
       TextBase::layout();
       rypos() = 0.0;    // handle placement below
+      qreal verticalSpacing = 0.15; // Percentage of text-height for stacking vertically
 
       if (autoplace() && note()) {
             Note* n      = note();
@@ -144,7 +145,7 @@ void Fingering::layout()
                               qreal d = sk.minDistance(ss->skyline().north());
                               qreal yd = 0.0;
                               if (d > 0.0 && isStyled(Pid::MIN_DISTANCE))
-                                    yd -= d + height() * .25;
+                                    yd -= d + height() * verticalSpacing;
                               // force extra space above staff & chord (but not other fingerings)
                               qreal top;
                               if (chord->up() && chord->beam() && stem) {
@@ -180,7 +181,7 @@ void Fingering::layout()
                               qreal d = ss->skyline().south().minDistance(sk);
                               qreal yd = 0.0;
                               if (d > 0.0 && isStyled(Pid::MIN_DISTANCE))
-                                    yd += d + height() * .25;
+                                    yd += d + height() * verticalSpacing;
                               // force extra space below staff & chord (but not other fingerings)
                               qreal bottom;
                               if (!chord->up() && chord->beam() && stem) {

--- a/libmscore/mscore.cpp
+++ b/libmscore/mscore.cpp
@@ -93,6 +93,7 @@ QColor  MScore::defaultColor;
 
 bool    MScore::noteInputOctaveTendencyIsTopNote;
 bool    MScore::noteInputOctaveUpwardFifth;
+bool    MScore::fingerTextAutoForwardAlphaNumeric;
 
 bool    MScore::disableVerticalMouseDragOfNotes;
 

--- a/libmscore/mscore.h
+++ b/libmscore/mscore.h
@@ -339,6 +339,7 @@ class MScore {
 
       static bool noteInputOctaveTendencyIsTopNote;
       static bool noteInputOctaveUpwardFifth;
+      static bool fingerTextAutoForwardAlphaNumeric;
 
       static bool disableVerticalMouseDragOfNotes;
 

--- a/mscore/events.cpp
+++ b/mscore/events.cpp
@@ -51,7 +51,8 @@ bool ScoreView::event(QEvent* event)
                         break;
 
                   if (textEditMode()) {
-                        // block Tab/Backtab in text editing mode
+                        // Allow [tabbing] forward/backward in fingering-mode
+                        keyPressEvent(ke);
                         return true;
                         }
 
@@ -880,6 +881,13 @@ void ScoreView::keyPressEvent(QKeyEvent* ev)
       else if (editData.element->isSticking()) {
             if (editKeySticking())
                   return;
+            }
+      else if (editData.element->isFingering()) {
+            if (editData.key == Qt::Key_Tab || editData.key == Qt::Key_Backtab) {
+                  if (editData.element->edit(editData)) {
+                        return;
+                        }
+                  }
             }
 
       ScoreViewCmdContext cc(this, hasEditGrips());

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -434,6 +434,7 @@ void updateExternalValuesFromPreferences() {
       MScore::disableVerticalMouseDragOfNotes = preferences.getBool(PREF_UI_SCORE_DISABLE_NOTE_DRAG_VERTICAL);
       MScore::noteInputOctaveTendencyIsTopNote = preferences.getBool(PREF_SCORE_NOTE_INPUT_OCTAVE_TENDENCY);
       MScore::noteInputOctaveUpwardFifth = preferences.getBool(PREF_SCORE_NOTE_INPUT_FIFTH_IS_UPWARD);
+      MScore::fingerTextAutoForwardAlphaNumeric = preferences.getBool(PREF_SCORE_FINGERING_ALPHANUMERIC_AUTOFORWARD);
       MScore::defaultPlayDuration = preferences.getInt(PREF_SCORE_NOTE_DEFAULTPLAYDURATION);
       MScore::panPlayback = preferences.getBool(PREF_APP_PLAYBACK_PANPLAYBACK);
       MScore::harmonyPlayDisableCompatibility = preferences.getBool(PREF_SCORE_HARMONY_PLAY_DISABLE_COMPATIBILITY);

--- a/mscore/preferences.cpp
+++ b/mscore/preferences.cpp
@@ -226,6 +226,7 @@ void Preferences::init(bool storeInMemoryOnly)
             {PREF_SCORE_NOTE_INPUT_DISABLE_MOUSE_INPUT,            new BoolPreference(false, true)},
             {PREF_SCORE_NOTE_INPUT_OCTAVE_TENDENCY,                new BoolPreference(false, true)},
             {PREF_SCORE_NOTE_INPUT_FIFTH_IS_UPWARD,                new BoolPreference(false)},
+            {PREF_SCORE_FINGERING_ALPHANUMERIC_AUTOFORWARD,        new BoolPreference(false)},
             {PREF_UI_SCORE_DISABLE_NOTE_DRAG_VERTICAL,             new BoolPreference(false)},
             {PREF_SCORE_STYLE_DEFAULTSTYLEFILE,                    new StringPreference("", false)},
             {PREF_SCORE_STYLE_PARTSTYLEFILE,                       new StringPreference("", false)},


### PR DESCRIPTION
+ **(Shift)+Tab moves by measure** (forward/backward) like "3.6.2 style" Chord Entry (4.x no longer uses Tab for this)
+ **(Shift)+CTRL+Space skips a vertical segment** (for example, don't have to press space 3 times to skip a triad)
... Detriment: [CTRL+Space] won't insert an actual "space" character (need one from "Special Character list" instead) but this is of course super-rare for 1-5 fingering mode)
... Function: always starts at top of chord at voice-1 (isn't a means to skip per-voice) even when going backwards when skipping a vertical position.

+ **Ensure Top to Bottom voicings during layout** (Voice-1 through Voice-4) when switching above/below positions. This allows for voice-2 voices to "tuck" under voice-1 when "above" setting is applied instead of being on top (which is default behavior yet totally undesirable)

+  **Allow flipping [x] above/below while editing** fingering-text easily
... DETRIMENT: Can't insert "x" character (which wouldn't don't make no sense now, would it)
... Note: a manual [x] alteration during entry will 'stick' through entry until a manual forward (Space/Tab/Ctrl-Space) occurs. (Automatic forward will 'stick' the position)

+ **Automatically moves forward after numerical entry with Numpad**. Alpha-numerics will _not_ move forward automatically _unless_ [**Advanced Preference**] is set to true: 
`score/fingering/autoForwardWithAlphaNumerics`

... No more space pressing so much if needing continual/semi-continual entry
... Because of this, "Edit Flipping" needs to be performed pre-number entry if using auto-advance - requires a change in habit.

+ **Tighten line spacing (vertical stacking) slightly from 25% height of text to 15%**

+ Potential TODO: Make line spacing an advanced preference