### PR TITLE
Advanced Preference: Note-Entry - Untoggle augmentation when changing duration + Autofill tuplets and move forward

### DIFF
--- a/global/settings/types/preferencekeys.h
+++ b/global/settings/types/preferencekeys.h
@@ -127,6 +127,7 @@
 #define PREF_UI_SCORE_DISABLE_NOTE_DRAG_VERTICAL            "ui/score/mouse/behavior/disableNoteDragVertical"
 #define PREF_SCORE_NOTE_INPUT_OCTAVE_TENDENCY               "ui/score/noteEntry/octaveTendencyIsTopNote"
 #define PREF_SCORE_NOTE_INPUT_FIFTH_IS_UPWARD               "ui/score/noteEntry/octaveUpwardFifth"
+#define PREF_SCORE_NOTE_INPUT_RETAIN_AUG_RHYTHM_MODE        "ui/score/noteEntry/rhythmMode/retainAugmentation"
 #define PREF_SCORE_FINGERING_ALPHANUMERIC_AUTOFORWARD       "score/fingering/autoForwardWithAlphaNumerics"
 #define PREF_SCORE_STYLE_DEFAULTSTYLEFILE                   "score/style/defaultStyleFile"
 #define PREF_SCORE_STYLE_PARTSTYLEFILE                      "score/style/partStyleFile"

--- a/libmscore/mscore.cpp
+++ b/libmscore/mscore.cpp
@@ -93,6 +93,8 @@ QColor  MScore::defaultColor;
 
 bool    MScore::noteInputOctaveTendencyIsTopNote;
 bool    MScore::noteInputOctaveUpwardFifth;
+bool    MScore::retainAugmentationInRhythmEntry;
+
 bool    MScore::fingerTextAutoForwardAlphaNumeric;
 
 bool    MScore::disableVerticalMouseDragOfNotes;

--- a/libmscore/mscore.h
+++ b/libmscore/mscore.h
@@ -339,6 +339,8 @@ class MScore {
 
       static bool noteInputOctaveTendencyIsTopNote;
       static bool noteInputOctaveUpwardFifth;
+      static bool retainAugmentationInRhythmEntry;
+
       static bool fingerTextAutoForwardAlphaNumeric;
 
       static bool disableVerticalMouseDragOfNotes;

--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -2929,6 +2929,9 @@ void Score::padToggle(Pad p, const EditData& ed)
                               }
                         setNoteRest(_is.segment(), _is.track(), nval, _is.duration().fraction(), stemDirection);
                         _is.moveToNextInputPos();
+                        if (!MScore::retainAugmentationInRhythmEntry) {
+                              _is.setDots(0);
+                              }
                         }
                   else
                         _is.setRest(false);

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -434,6 +434,7 @@ void updateExternalValuesFromPreferences() {
       MScore::disableVerticalMouseDragOfNotes = preferences.getBool(PREF_UI_SCORE_DISABLE_NOTE_DRAG_VERTICAL);
       MScore::noteInputOctaveTendencyIsTopNote = preferences.getBool(PREF_SCORE_NOTE_INPUT_OCTAVE_TENDENCY);
       MScore::noteInputOctaveUpwardFifth = preferences.getBool(PREF_SCORE_NOTE_INPUT_FIFTH_IS_UPWARD);
+      MScore::retainAugmentationInRhythmEntry = preferences.getBool(PREF_SCORE_NOTE_INPUT_RETAIN_AUG_RHYTHM_MODE);
       MScore::fingerTextAutoForwardAlphaNumeric = preferences.getBool(PREF_SCORE_FINGERING_ALPHANUMERIC_AUTOFORWARD);
       MScore::defaultPlayDuration = preferences.getInt(PREF_SCORE_NOTE_DEFAULTPLAYDURATION);
       MScore::panPlayback = preferences.getBool(PREF_APP_PLAYBACK_PANPLAYBACK);

--- a/mscore/preferences.cpp
+++ b/mscore/preferences.cpp
@@ -226,6 +226,7 @@ void Preferences::init(bool storeInMemoryOnly)
             {PREF_SCORE_NOTE_INPUT_DISABLE_MOUSE_INPUT,            new BoolPreference(false, true)},
             {PREF_SCORE_NOTE_INPUT_OCTAVE_TENDENCY,                new BoolPreference(false, true)},
             {PREF_SCORE_NOTE_INPUT_FIFTH_IS_UPWARD,                new BoolPreference(false)},
+            {PREF_SCORE_NOTE_INPUT_RETAIN_AUG_RHYTHM_MODE,         new BoolPreference(false)},
             {PREF_SCORE_FINGERING_ALPHANUMERIC_AUTOFORWARD,        new BoolPreference(false)},
             {PREF_UI_SCORE_DISABLE_NOTE_DRAG_VERTICAL,             new BoolPreference(false)},
             {PREF_SCORE_STYLE_DEFAULTSTYLEFILE,                    new StringPreference("", false)},


### PR DESCRIPTION
For some reason, 3.6.2 etc was designed to retain augmentation dots when performing "rhythm entry", which potentially slows the user down rather than actually speeding them up (one of the purposes of rhythm entry is to not have to think too much and do a two-phase rhythm/pitch change pass).

**Advanced Preference**:
`ui/score/NoteEntry/rhythmMode/retainAugmentation` (will be off by default, but original behavior can be achieved by setting it to true)

will override this so that it gets untoggled when changing duration, so that this can be done in rhythm entry:

### retainAugmentation set to false:
[rhythm-entry.webm](https://github.com/user-attachments/assets/5ba5f26c-3f2a-4707-bd6a-d03c6c72afb6)

### 3.6.2 (and probably 4.x keeps the augmentation):
Otherwise the user has to untoggle over and over again manually, which is ridiculous:

[362RhythmDot.webm](https://github.com/user-attachments/assets/8f6ae57a-24c7-42ed-a2c1-884043aca483)

### Rhythm Mode: Tuplet entry update
Tuplets will auto-fill. It may not be 100% what is desired, but seems to me most often than not that it is, and it's easy to back-track:

[autoFill.webm](https://github.com/user-attachments/assets/c10766ee-0c47-447f-ab69-87c3b5ca1587)

One bigger change is that the tuplet applies to the selected note here rather than being applied to the note entry position, so this requires a change of behavior of the user.

### Check the original Rhythm mode behavior for tuplets - not desirable in my opinion:

[362-TupletRhythm.webm](https://github.com/user-attachments/assets/50f19262-422a-4d93-91fd-3149c85ca991)

