### PR TITLE
Update branch 0019

### DIFF
--- a/libmscore/navigate.cpp
+++ b/libmscore/navigate.cpp
@@ -516,8 +516,15 @@ ChordRest* Score::prevTrack(ChordRest* cr, bool skipVoices)
             while (--track >= 0) {
                   if (skipVoices) {
                         // Disregard voices and directly refer to previous staff
-                        if ((track % 4) != 0)
+                        int currStaff = cr->staffIdx();
+                        int prevStaff = track2staff(track);
+                        bool trackIsFirstVoice = ((track % 4) == 0);
+                        if (!trackIsFirstVoice) {
                               continue;
+                              }
+                        else if (currStaff == prevStaff) {
+                              continue;
+                              }
                         break;
                         }
                   else if (measure->hasVoice(track))


### PR DESCRIPTION
**Branch**: 3.x-www-0019-CommandNextPrevStaff
**Squashed Commit**: New Command: [Next/Previous Staff] without traversing voices

Earlier problem: took for granted that "zero" voice would be another staff, but needed to verify the result was indeed a different staff, otherwise starting on "voice-3" for example and moving "previous" would only take the user to voice-1 of the same staff.