### PR TITLE
[Temporary Voice Filter] Updates

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -2499,7 +2499,7 @@ std::vector<ChordRest*> Score::deleteRange(Segment* s1, Segment* s2, int track1,
 void Score::cmdDeleteSelection()
       {
       std::vector<ChordRest*> crsSelectedAfterDeletion;
-
+      int tempVoiceFilter = selection().hasTemporaryFilter();
       // For note-entry changes:
       int iTrack = _is.track();
       auto iTick = _is.tick();
@@ -2629,6 +2629,9 @@ void Score::cmdDeleteSelection()
                   else
                         select(cr, SelectType::SINGLE);
                   }
+            }
+      else if (tempVoiceFilter) {
+            ;
             }
       else if (!crsSelectedAfterDeletion.empty()) {
             std::vector<Element*> elementsToSelect;

--- a/libmscore/paste.cpp
+++ b/libmscore/paste.cpp
@@ -513,8 +513,9 @@ bool Score::pasteStaff(XmlReader& e, Segment* dst, int dstStaff, Fraction scale)
 
             for (MuseScoreView* v : qAsConst(viewer))
                   v->adjustCanvasPosition(el, false);
-            if (!selection().isRange())
+            if (!selection().isRange()) {
                   _selection.setState(SelState::RANGE);
+                  }
             }
       return true;
       }

--- a/libmscore/select.cpp
+++ b/libmscore/select.cpp
@@ -727,7 +727,10 @@ void Selection::updateState()
       if (n == 0) {
             setState(SelState::NONE);
             if (hasTemporaryFilter()) {
-                  hasTemporaryFilter(false);
+                  if (!score()->noteEntryMode()) {
+                        hasTemporaryFilter(0);
+                        }
+                  // keep [range] when [note entry] + [voice switch]:
                   auto& sf = score()->selectionFilter();
                   sf.setFiltered(SelectionFilterType::ALL, true);
                   }

--- a/libmscore/select.h
+++ b/libmscore/select.h
@@ -151,7 +151,7 @@ class Selection {
       Segment* _activeSegment;
       int _activeTrack;
 
-      bool _temporaryFilter { false };
+      int _temporaryFilter = 0;
 
       Fraction _currentTick;  // tracks the most recent selection
       int _currentTrack;
@@ -196,8 +196,8 @@ class Selection {
       void remove(Element*);
       void clear();
 
-      bool hasTemporaryFilter() { return _temporaryFilter; }
-      void hasTemporaryFilter(bool v) { _temporaryFilter = v; }
+      int hasTemporaryFilter() { return _temporaryFilter; }
+      void hasTemporaryFilter(int v) { _temporaryFilter = v; }
 
       Element* element() const;
       ChordRest* cr() const;

--- a/libmscore/transpose.cpp
+++ b/libmscore/transpose.cpp
@@ -368,6 +368,8 @@ bool Score::transpose(TransposeMode mode, TransposeDirection direction, Key trKe
 
       alreadyTransposed.clear();
       QList<Staff*> sl;
+      int tempFilteredVoice = selection().hasTemporaryFilter();
+
       for (int staffIdx = _selection.staffStart(); staffIdx < _selection.staffEnd(); ++staffIdx) {
             Staff* s = staff(staffIdx);
             if (s->staffType(Fraction(0,1))->group() == StaffGroup::PERCUSSION)      // ignore percussion staff
@@ -415,6 +417,9 @@ bool Score::transpose(TransposeMode mode, TransposeDirection direction, Key trKe
 
                   if (e->isChord()) {
                         Chord* chord = toChord(e);
+                        if (tempFilteredVoice && (chord->voice() != (tempFilteredVoice - 1))) {
+                              continue;
+                              }
                         std::vector<Note*> nl = chord->notes();
                         for (Note* n : nl) {
                               if (mode == TransposeMode::DIATONICALLY) {

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -5096,6 +5096,7 @@ void MuseScore::undoRedo(bool undo)
       {
       Q_ASSERT(cv);
       Q_ASSERT(cs);
+      int tempVoiceFilter = cv->score()->selection().hasTemporaryFilter();
       if (_sstate & (STATE_EDIT | STATE_HARMONY_FIGBASS_EDIT | STATE_LYRICS_EDIT))
             cv->changeState(ViewState::NORMAL);
       cv->startUndoRedo(undo);
@@ -5103,6 +5104,9 @@ void MuseScore::undoRedo(bool undo)
       endCmd(/* undoRedo */ true);
       if (pianorollEditor)
             pianorollEditor->update();
+      if (tempVoiceFilter) {
+            cv->score()->cmdCycleVoiceFilter(tempVoiceFilter);
+            }
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
+ Simplify some of the filtering code by using a return value instead of having to check SelectionFilter attributes
+ Updated [delete], [navigation/move], [duration/pasting] behavior in conjunction with temporary voice filter
+ [Command: Voice 1-4] will keep range selection when existing
+ Make sure to reset to "ALL" when deleting voice 2-4 in range selection with filter so there's a valid selection.
+ Note Entry - Mouse: If mouse input toggle disabled, a range selection will be formed on a clicked measure and prepare note entry on the first Voice-1 ChordRest

Some quick demonstration of above mentioned:

[tempVoice1.webm](https://github.com/user-attachments/assets/4a5c96e2-add2-437f-9e88-4d4250f8967e)

Maintaining range selection with [click + note entry] (auto restarts into voice-1, but it's nice to either 1) select a particular note (which loses range selection, or 2) be less precise and create range selection in note-entry, which triggers the "voice-1" filter for chord rests only.

[tempVoice2.webm](https://github.com/user-attachments/assets/f6e8e95d-d04f-4a38-80be-f9132c096634)

 And again, a cycle invocation will (in note entry mode), will select chord rests only at first, or including the other element types:

[3.webm](https://github.com/user-attachments/assets/6de7fe3c-1110-46fc-95bd-45e285f8431a)

