### PR TITLE
[Command: Backspace] Update: Delete entire current chord while in Note-Entry, or first move to a previous chord if a rest is selected

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -1761,7 +1761,7 @@ void Score::deleteItem(Element* el)
                                           }
                                     }
                               }
-                        //select(rest, SelectType::SINGLE, 0);
+                        select(rest, SelectType::SINGLE, 0);
                         }
                   else  {
                         // remove segment if empty


### PR DESCRIPTION
The point is that [Backspace] used to function as "undo", which is not useful since Ctrl+Z does the same thing, and a waste of an available keyboard shortcut. 

- Instead, let it actually [delete] a note or even an entire chord, then stay there at the rest remaining after the deletion. 
- Next invocation will go from a rest position to the next available Chord behind it (of the same track)
- Then, once selecting an actual chord, the next invocation will delete that chord entirely and replace it with a rest.

[backspace.webm](https://github.com/user-attachments/assets/f043bf6b-e2d1-48e2-8f79-6663a05a4c5b)

Why, oh why, was it not like this previously?
