### PR TITLE
[Tempo Text] Include [copy/paste] ability for list-selections

### DIFF
--- a/libmscore/paste.cpp
+++ b/libmscore/paste.cpp
@@ -868,7 +868,7 @@ void Score::pasteSymbols(XmlReader& e, ChordRest* dst)
                                     else
                                           undoAddElement(el);
                                     }
-                              else if (tag == "StaffText" || tag == "Sticking") {
+                              else if (tag == "StaffText" || tag == "Sticking" || tag == "Tempo") {
                                     Element* el = Element::name2Element(tag, this);
                                     el->read(e);
                                     el->setTrack(destTrack);

--- a/libmscore/select.cpp
+++ b/libmscore/select.cpp
@@ -57,6 +57,7 @@
 #include "accidental.h"
 #include "articulation.h"
 #include "stafftext.h"
+#include "tempotext.h"
 #include "sticking.h"
 
 namespace Ms {
@@ -1041,6 +1042,9 @@ Enabling copying of more element types requires enabling pasting in Score::paste
                         // fall through
                   case ElementType::HAIRPIN:
                         seg = toHairpin(e)->startSegment();
+                        break;
+                  case ElementType::TEMPO_TEXT:
+                        seg = toTempoText(e)->segment();
                         break;
                   default:
                         continue;


### PR DESCRIPTION
Why not? Not sure why they didn't allow it in <3.6.2. List selection + copy will allow to paste in same timing
 
[pasteOfTempo.webm](https://github.com/user-attachments/assets/41445a32-bc09-42a3-af26-1210dcbf80bc)

Notice that range selection also doesn't copy/paste/repeat etc. But at least here a list selection will copy/paste with this.
