### PR TITLE
Images: Command to insert empty image + update to 8 grip nodes + frames property + background color

### DIFF
--- a/libmscore/image.h
+++ b/libmscore/image.h
@@ -90,7 +90,7 @@ class Image final : public BSymbol {
       bool isValid() const           { return rasterDoc || svgDoc; }
 
       Element::EditBehavior normalModeEditBehavior() const override { return Element::EditBehavior::Edit; }
-      int gripsCount() const override { return 2; }
+      int gripsCount() const override { return 8; }
       Grip initialEditModeGrip() const override { return Grip(1); }
       Grip defaultGrip() const override { return Grip(1); }
       std::vector<QPointF> gripsPositions(const EditData&) const override;

--- a/libmscore/image.h
+++ b/libmscore/image.h
@@ -45,6 +45,8 @@ class Image final : public BSymbol {
       bool _lockAspectRatio;
       bool _autoScale;              ///< fill parent frame
       bool _sizeIsSpatium;
+      qreal _frameWidth;
+      QColor _frameColor;
       mutable bool _dirty;
       bool _used;
 
@@ -78,6 +80,11 @@ class Image final : public BSymbol {
       void setSizeIsSpatium(bool val)    { _sizeIsSpatium = val;  }
       bool isUsed() const                { return _used;          }
       void setUsed(bool val)             { _used = val;           }
+
+      void setFrameWidth(qreal val)      { _frameWidth = val;     }
+      qreal getFrameWidth() const        { return _frameWidth;    }
+      void setFrameColor(const QColor& c){ _frameColor = c;       }
+      QColor getFrameColor() const       { return _frameColor;    }
 
       QVariant getProperty(Pid ) const override;
       bool setProperty(Pid propertyId, const QVariant&) override;

--- a/libmscore/property.cpp
+++ b/libmscore/property.cpp
@@ -122,6 +122,8 @@ static constexpr PropertyMetaData propertyList[] = {
 
       { Pid::SCALE,                   false, "scale",                 P_TYPE::SCALE,               DUMMY_QT_TRANSLATE_NOOP("propertyName", "scale")            },
       { Pid::LOCK_ASPECT_RATIO,       false, "lockAspectRatio",       P_TYPE::BOOL,                DUMMY_QT_TRANSLATE_NOOP("propertyName", "aspect ratio locked") },
+      { Pid::IMAGE_FRAME_WIDTH,       false, "imageFrameWidth",       P_TYPE::SP_REAL,             DUMMY_QT_TRANSLATE_NOOP("propertyName", "image frame size") },
+      { Pid::IMAGE_FRAME_COLOR,       false, "imageFrameColor",       P_TYPE::COLOR,               DUMMY_QT_TRANSLATE_NOOP("propertyName", "image frame color")},
       { Pid::SIZE_IS_SPATIUM,         false, "sizeIsSpatium",         P_TYPE::BOOL,                DUMMY_QT_TRANSLATE_NOOP("propertyName", "size is spatium")  },
       { Pid::TEXT,                    true,  "text",                  P_TYPE::STRING,              DUMMY_QT_TRANSLATE_NOOP("propertyName", "text")             },
       { Pid::HTML_TEXT,               false, 0,                       P_TYPE::STRING,              ""                                                    },

--- a/libmscore/property.h
+++ b/libmscore/property.h
@@ -128,6 +128,8 @@ enum class Pid {
 
       SCALE,
       LOCK_ASPECT_RATIO,
+      IMAGE_FRAME_WIDTH,
+      IMAGE_FRAME_COLOR,
       SIZE_IS_SPATIUM,
       TEXT,
       HTML_TEXT,

--- a/mscore/inspector/inspectorImage.cpp
+++ b/mscore/inspector/inspectorImage.cpp
@@ -43,7 +43,9 @@ InspectorImage::InspectorImage(QWidget* parent)
             { Pid::AUTOSCALE,         0, b.autoscale,       b.resetAutoscale       },
             { Pid::SIZE,              0, b.size,            b.resetSize            },
             { Pid::LOCK_ASPECT_RATIO, 0, b.lockAspectRatio, b.resetLockAspectRatio },
-            { Pid::SIZE_IS_SPATIUM,   0, b.sizeIsSpatium,   b.resetSizeIsSpatium   }
+            { Pid::SIZE_IS_SPATIUM,   0, b.sizeIsSpatium,   b.resetSizeIsSpatium   },
+            { Pid::IMAGE_FRAME_WIDTH, 0, b.frameWidth,      b.resetFrameWidth      },
+            { Pid::IMAGE_FRAME_COLOR, 0, b.frameColor,      b.resetFrameColor      }
             };
       const std::vector<InspectorPanel> ppList = { { b.title, b.panel } };
 

--- a/mscore/inspector/inspector_image.ui
+++ b/mscore/inspector/inspector_image.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>215</width>
-    <height>154</height>
+    <height>177</height>
    </rect>
   </property>
   <property name="accessibleName">
@@ -49,7 +49,6 @@
      </property>
      <property name="font">
       <font>
-       <weight>75</weight>
        <bold>true</bold>
       </font>
      </property>
@@ -76,6 +75,69 @@
       <property name="spacing">
        <number>3</number>
       </property>
+      <item row="2" column="1" colspan="2">
+       <widget class="Ms::SizeSelect" name="size" native="true">
+        <property name="accessibleName">
+         <string>Size</string>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="2">
+       <widget class="QDoubleSpinBox" name="frameWidth"/>
+      </item>
+      <item row="3" column="0" colspan="3">
+       <widget class="QCheckBox" name="sizeIsSpatium">
+        <property name="focusPolicy">
+         <enum>Qt::TabFocus</enum>
+        </property>
+        <property name="toolTip">
+         <string>Distance between two lines on a standard 5-line staff</string>
+        </property>
+        <property name="text">
+         <string>Size in staff space units</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="3">
+       <widget class="Ms::ResetButton" name="resetAutoscale" native="true">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="accessibleName">
+         <string>Reset 'Scale to frame size' value</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="3">
+       <widget class="Ms::ResetButton" name="resetLockAspectRatio" native="true">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="accessibleName">
+         <string>Reset 'Lock aspect ratio' value</string>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="0" colspan="2">
+       <widget class="QLabel" name="label">
+        <property name="text">
+         <string>Frame Width:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="2">
+       <widget class="Awl::ColorLabel" name="frameColor">
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+      </item>
       <item row="2" column="0">
        <widget class="QLabel" name="label_2">
         <property name="text">
@@ -106,36 +168,10 @@
         </property>
        </widget>
       </item>
-      <item row="2" column="1" colspan="2">
-       <widget class="Ms::SizeSelect" name="size" native="true">
-        <property name="accessibleName">
-         <string>Size</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="0" colspan="3">
-       <widget class="QCheckBox" name="sizeIsSpatium">
-        <property name="focusPolicy">
-         <enum>Qt::TabFocus</enum>
-        </property>
-        <property name="toolTip">
-         <string>Distance between two lines on a standard 5-line staff</string>
-        </property>
+      <item row="6" column="0">
+       <widget class="QLabel" name="label_3">
         <property name="text">
-         <string>Size in staff space units</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="3">
-       <widget class="Ms::ResetButton" name="resetAutoscale" native="true">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="accessibleName">
-         <string>Reset 'Scale to frame size' value</string>
+         <string>Frame Color:</string>
         </property>
        </widget>
       </item>
@@ -165,18 +201,11 @@
         </property>
        </widget>
       </item>
-      <item row="4" column="3">
-       <widget class="Ms::ResetButton" name="resetLockAspectRatio" native="true">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="accessibleName">
-         <string>Reset 'Lock aspect ratio' value</string>
-        </property>
-       </widget>
+      <item row="5" column="3">
+       <widget class="Ms::ResetButton" name="resetFrameWidth" native="true"/>
+      </item>
+      <item row="6" column="3">
+       <widget class="Ms::ResetButton" name="resetFrameColor" native="true"/>
       </item>
      </layout>
     </widget>
@@ -194,6 +223,12 @@
    <class>Ms::SizeSelect</class>
    <extends>QWidget</extends>
    <header>inspector/sizeSelect.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>Awl::ColorLabel</class>
+   <extends>QPushButton</extends>
+   <header>awl/colorlabel.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/mscore/scoreview.h
+++ b/mscore/scoreview.h
@@ -432,6 +432,7 @@ class ScoreView : public QWidget, public MuseScoreView {
       virtual void cmdAddHairpin(HairpinType);
       virtual void cmdAddPedal(HookType, HookType);
       void cmdAddNoteLine();
+      void cmdAddEmptyImage(bool, bool);
 
       void setEditElement(Element*);
       void updateEditElement();


### PR DESCRIPTION
Images will show as having 8-grip nodes. When "lock aspect ratio" is enabled, the corner nodes will be free-form motion, otherwise all are free-form motion. Frames with width control and color (solid-line only) are an extra option here.

More importantly, this converts useless "empty images" to be "workaround" options for creating highlights or boxes (aleatoric boxes are a little easier to form this way) with a frame that can be easily resized (unlike frame text). The "picture" shortcut will now perform applying an empty image with default transparency background and a small frame width.

* Can also lock the corner grips, regardless of aspect ratio option, to use shift or ctrl to only resize in horizontal/vertical activity.

[pictureFrame.webm](https://github.com/user-attachments/assets/6603189b-9d25-4c46-974a-47251f40327f)


![image](https://github.com/user-attachments/assets/4a474c07-07cd-48bf-9f9b-863611cb2c0b)

Warning obviously is that this is incompatible with both <= 3.6.2 and 4.x, meaning these will only manifest as broken images in those programs

