### PR TITLE
Note Entry: (Adv. Pref) Force Voice-2 under Voice-1 + Command : Reset octave position to default + Fix

### DIFF
--- a/global/settings/types/preferencekeys.h
+++ b/global/settings/types/preferencekeys.h
@@ -127,6 +127,7 @@
 #define PREF_UI_SCORE_DISABLE_NOTE_DRAG_VERTICAL            "ui/score/mouse/behavior/disableNoteDragVertical"
 #define PREF_SCORE_NOTE_INPUT_OCTAVE_TENDENCY               "ui/score/noteEntry/octaveTendencyIsTopNote"
 #define PREF_SCORE_NOTE_INPUT_FIFTH_IS_UPWARD               "ui/score/noteEntry/octaveUpwardFifth"
+#define PREF_SCORE_NOTE_INPUT_RESET_PITCH_AT_SYSTEM         "ui/score/noteEntry/resetNoteEntryAtSystemOrCourtesy"
 #define PREF_SCORE_NOTE_INPUT_RETAIN_AUG_RHYTHM_MODE        "ui/score/noteEntry/rhythmMode/retainAugmentation"
 #define PREF_SCORE_FINGERING_ALPHANUMERIC_AUTOFORWARD       "score/fingering/autoForwardWithAlphaNumerics"
 #define PREF_SCORE_STYLE_DEFAULTSTYLEFILE                   "score/style/defaultStyleFile"

--- a/global/settings/types/preferencekeys.h
+++ b/global/settings/types/preferencekeys.h
@@ -128,6 +128,7 @@
 #define PREF_SCORE_NOTE_INPUT_OCTAVE_TENDENCY               "ui/score/noteEntry/octaveTendencyIsTopNote"
 #define PREF_SCORE_NOTE_INPUT_FIFTH_IS_UPWARD               "ui/score/noteEntry/octaveUpwardFifth"
 #define PREF_SCORE_NOTE_INPUT_RESET_PITCH_AT_SYSTEM         "ui/score/noteEntry/resetNoteEntryAtSystemOrCourtesy"
+#define PREF_SCORE_NOTE_INPUT_FORCE_VOICE2_BELOW            "ui/score/noteEntry/voice2/forceBeneathVoice1"
 #define PREF_SCORE_NOTE_INPUT_RETAIN_AUG_RHYTHM_MODE        "ui/score/noteEntry/rhythmMode/retainAugmentation"
 #define PREF_SCORE_FINGERING_ALPHANUMERIC_AUTOFORWARD       "score/fingering/autoForwardWithAlphaNumerics"
 #define PREF_SCORE_STYLE_DEFAULTSTYLEFILE                   "score/style/defaultStyleFile"

--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -4317,7 +4317,7 @@ void Score::cmdAddPitch(const EditData& ed, int note, bool addFlag, bool insert,
                                           bool isCourtesy  = (previousClef == clef->clefType());
                                           bool isBeginning = clef->tick().isZero();
                                           // check if it's an actual change or just a courtesy
-                                          if (!isCourtesy || isBeginning) {
+                                          if (!isCourtesy || isBeginning || MScore::resetNoteEntryAtSystemOrCourtesy) {
                                                 curPitch = line2pitch(4, clef->clefType(), Key::C); // C 72 for treble clef
                                                 break;
                                                 }

--- a/libmscore/mscore.cpp
+++ b/libmscore/mscore.cpp
@@ -94,6 +94,7 @@ QColor  MScore::defaultColor;
 bool    MScore::noteInputOctaveTendencyIsTopNote;
 bool    MScore::noteInputOctaveUpwardFifth;
 bool    MScore::resetNoteEntryAtSystemOrCourtesy;
+bool    MScore::noteInputForceVoice2BeneathVoice1;
 bool    MScore::retainAugmentationInRhythmEntry;
 
 bool    MScore::fingerTextAutoForwardAlphaNumeric;

--- a/libmscore/mscore.cpp
+++ b/libmscore/mscore.cpp
@@ -93,6 +93,7 @@ QColor  MScore::defaultColor;
 
 bool    MScore::noteInputOctaveTendencyIsTopNote;
 bool    MScore::noteInputOctaveUpwardFifth;
+bool    MScore::resetNoteEntryAtSystemOrCourtesy;
 bool    MScore::retainAugmentationInRhythmEntry;
 
 bool    MScore::fingerTextAutoForwardAlphaNumeric;

--- a/libmscore/mscore.h
+++ b/libmscore/mscore.h
@@ -339,6 +339,7 @@ class MScore {
 
       static bool noteInputOctaveTendencyIsTopNote;
       static bool noteInputOctaveUpwardFifth;
+      static bool resetNoteEntryAtSystemOrCourtesy;
       static bool retainAugmentationInRhythmEntry;
 
       static bool fingerTextAutoForwardAlphaNumeric;

--- a/libmscore/mscore.h
+++ b/libmscore/mscore.h
@@ -340,6 +340,7 @@ class MScore {
       static bool noteInputOctaveTendencyIsTopNote;
       static bool noteInputOctaveUpwardFifth;
       static bool resetNoteEntryAtSystemOrCourtesy;
+      static bool noteInputForceVoice2BeneathVoice1;
       static bool retainAugmentationInRhythmEntry;
 
       static bool fingerTextAutoForwardAlphaNumeric;

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -486,6 +486,8 @@ class Score : public QObject, public ScoreElement {
       Audio* _audio { 0 };
       PlayMode _playMode { PlayMode::SYNTHESIZER };
 
+      bool _resetOctave = false;
+
       qreal _noteHeadWidth { 0.0 };       // cached value
       QString accInfo;                    ///< information about selected element(s) for use by screen-readers
       QString accMessage;                 ///< temporary status message for use by screen-readers
@@ -620,6 +622,9 @@ class Score : public QObject, public ScoreElement {
       void getNextMeasure(LayoutContext&);      // get next measure for layout
 
       void resetAllPositions();
+
+      void resetOctave(bool v) { _resetOctave = v;    }
+      bool resetOctave(void)   { return _resetOctave; }
 
       void cmdRemovePart(Part*);
       void cmdAddTie(bool addToChord = false);
@@ -774,7 +779,7 @@ class Score : public QObject, public ScoreElement {
       void cmdRelayout();
       void cmdToggleAutoplace(bool all);
       void cmdApplyInputState();
-      void cmdCycleVoiceFilter(int voice=0);
+      void cmdCycleVoiceFilter(int voice=0, bool octaveReset=false);
 
       bool playNote() const                 { return _updateState._playNote; }
       void setPlayNote(bool v)              { _updateState._playNote = v;    }

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -435,6 +435,7 @@ void updateExternalValuesFromPreferences() {
       MScore::noteInputOctaveTendencyIsTopNote = preferences.getBool(PREF_SCORE_NOTE_INPUT_OCTAVE_TENDENCY);
       MScore::noteInputOctaveUpwardFifth = preferences.getBool(PREF_SCORE_NOTE_INPUT_FIFTH_IS_UPWARD);
       MScore::resetNoteEntryAtSystemOrCourtesy = preferences.getBool(PREF_SCORE_NOTE_INPUT_RESET_PITCH_AT_SYSTEM);
+      MScore::noteInputForceVoice2BeneathVoice1 = preferences.getBool(PREF_SCORE_NOTE_INPUT_FORCE_VOICE2_BELOW);
       MScore::retainAugmentationInRhythmEntry = preferences.getBool(PREF_SCORE_NOTE_INPUT_RETAIN_AUG_RHYTHM_MODE);
       MScore::fingerTextAutoForwardAlphaNumeric = preferences.getBool(PREF_SCORE_FINGERING_ALPHANUMERIC_AUTOFORWARD);
       MScore::defaultPlayDuration = preferences.getInt(PREF_SCORE_NOTE_DEFAULTPLAYDURATION);

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -434,6 +434,7 @@ void updateExternalValuesFromPreferences() {
       MScore::disableVerticalMouseDragOfNotes = preferences.getBool(PREF_UI_SCORE_DISABLE_NOTE_DRAG_VERTICAL);
       MScore::noteInputOctaveTendencyIsTopNote = preferences.getBool(PREF_SCORE_NOTE_INPUT_OCTAVE_TENDENCY);
       MScore::noteInputOctaveUpwardFifth = preferences.getBool(PREF_SCORE_NOTE_INPUT_FIFTH_IS_UPWARD);
+      MScore::resetNoteEntryAtSystemOrCourtesy = preferences.getBool(PREF_SCORE_NOTE_INPUT_RESET_PITCH_AT_SYSTEM);
       MScore::retainAugmentationInRhythmEntry = preferences.getBool(PREF_SCORE_NOTE_INPUT_RETAIN_AUG_RHYTHM_MODE);
       MScore::fingerTextAutoForwardAlphaNumeric = preferences.getBool(PREF_SCORE_FINGERING_ALPHANUMERIC_AUTOFORWARD);
       MScore::defaultPlayDuration = preferences.getInt(PREF_SCORE_NOTE_DEFAULTPLAYDURATION);

--- a/mscore/preferences.cpp
+++ b/mscore/preferences.cpp
@@ -228,6 +228,7 @@ void Preferences::init(bool storeInMemoryOnly)
             {PREF_SCORE_NOTE_INPUT_FIFTH_IS_UPWARD,                new BoolPreference(false)},
             {PREF_SCORE_NOTE_INPUT_RETAIN_AUG_RHYTHM_MODE,         new BoolPreference(false)},
             {PREF_SCORE_NOTE_INPUT_RESET_PITCH_AT_SYSTEM,          new BoolPreference(false)},
+            {PREF_SCORE_NOTE_INPUT_FORCE_VOICE2_BELOW,             new BoolPreference(true)},
             {PREF_SCORE_FINGERING_ALPHANUMERIC_AUTOFORWARD,        new BoolPreference(false)},
             {PREF_UI_SCORE_DISABLE_NOTE_DRAG_VERTICAL,             new BoolPreference(false)},
             {PREF_SCORE_STYLE_DEFAULTSTYLEFILE,                    new StringPreference("", false)},

--- a/mscore/preferences.cpp
+++ b/mscore/preferences.cpp
@@ -227,6 +227,7 @@ void Preferences::init(bool storeInMemoryOnly)
             {PREF_SCORE_NOTE_INPUT_OCTAVE_TENDENCY,                new BoolPreference(false, true)},
             {PREF_SCORE_NOTE_INPUT_FIFTH_IS_UPWARD,                new BoolPreference(false)},
             {PREF_SCORE_NOTE_INPUT_RETAIN_AUG_RHYTHM_MODE,         new BoolPreference(false)},
+            {PREF_SCORE_NOTE_INPUT_RESET_PITCH_AT_SYSTEM,          new BoolPreference(false)},
             {PREF_SCORE_FINGERING_ALPHANUMERIC_AUTOFORWARD,        new BoolPreference(false)},
             {PREF_UI_SCORE_DISABLE_NOTE_DRAG_VERTICAL,             new BoolPreference(false)},
             {PREF_SCORE_STYLE_DEFAULTSTYLEFILE,                    new StringPreference("", false)},

--- a/mscore/shortcut.cpp
+++ b/mscore/shortcut.cpp
@@ -100,6 +100,13 @@ Shortcut Shortcut::_sc[] = {
          },
       {
          MsWidget::MAIN_WINDOW,
+         STATE_NORMAL | STATE_NOTE_ENTRY | STATE_EDIT,
+         "reset-input-octave",
+         QT_TRANSLATE_NOOP("action","Reset input octave to default"),
+         QT_TRANSLATE_NOOP("action","Reset input octave to default")
+         },
+      {
+         MsWidget::MAIN_WINDOW,
          STATE_NORMAL | STATE_NOTE_ENTRY | STATE_EDIT | STATE_PLAY,
          "file-save-a-copy",
          QT_TRANSLATE_NOOP("action","Save a Copy…"),


### PR DESCRIPTION
Alpha-numeric Entry:

+ **Advanced Preference: Force Voice-2 beneath Voice-1**
`ui/score/noteEntry/voice2/forceBeneathVoice1` (by default will be on, so a difference in default behavior)
Forces to consider the octave *below* [Voice-1] when entering notes in [Voice-2], and make sure that voice-2 is below it if _the about to be entered pitch_ would have been above voice-1. This might not always be desirable (hence the advanced preference), but I've found for myself that more often than not it *is* desirable. I hesitate to decide whether or not to include the unison pitch between voices 1 & 2, but for now it is *not* included (which means equivalent pitch will go an octave below voice-1)

A demonstration: (only one octave-shift (upward) was required for entering voice-2 on lower staff)

[voice2-automatic below voice1.webm](https://github.com/user-attachments/assets/c684b67b-9654-4743-b88b-1156f67880cf)



* **Command: Reset input octave to default** - Helper function useful mainly for when current entry position is in ledger domain and the user knows the next entry will be within default staff space. Don't have to think about how many octave shifts will be needed to correct the next input.
... This will also be triggered when invoking [**Cycle through voices in range-selection**] when no range is selected while in note-entry mode, so it need not be defined separately for invocation.

* Fixed an occasional problem - A system header clef registers as existing when there isn't one, making [note entry position] seem arbitrarily crazy based on the faux pas clef.

**Advanced Preference: Reset pitch at system or courtesy** 
`ui/score/noteEntry/resetNoteEntryAtSystemOrCourtesy` (default: off - no change of behavior)
Least of all, depending on how the user works, it might be useful to have a new system automatically reset to default clef position of entry, so this is available (_not on by default_) if desired. 