### PR TITLE
Play Panel: Autofocus onto Master Volume when activating/showing

### DIFF
--- a/mscore/playpanel.cpp
+++ b/mscore/playpanel.cpp
@@ -169,6 +169,8 @@ void PlayPanel::showEvent(QShowEvent* e)
             activateWindow();
             setFocus();
             }
+      volSpinBox->setFocus();
+      volSpinBox->selectAll();
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
This makes for quick master volume change via up/down arrows:

[playPanelVolume.webm](https://github.com/user-attachments/assets/a65b2426-2cbd-48c6-a381-510ca25201fc)
