### PR TITLE
Command: Open Measure Properties Dialogue & set default focus on measure offset number

### DIFF
--- a/mscore/measureproperties.cpp
+++ b/mscore/measureproperties.cpp
@@ -59,6 +59,8 @@ MeasureProperties::MeasureProperties(Measure* _m, QWidget* parent)
             horizontalLayout_2->insertWidget(0, nextButton);
             }
 
+      measureNumberOffset->setFocus();
+
       MuseScore::restoreGeometry(this);
       }
 

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -3033,6 +3033,16 @@ void ScoreView::cmd(const char* s)
                         cv->score()->cmdJoinMeasure(m1, m2);
                         }
                   }},
+            {{"measure-properties"}, [](ScoreView* cv, const QByteArray&) {
+                  if (auto m = cv->score()->selection().findMeasure()) {
+                        MeasureProperties im(m);
+                        im.exec();
+                        }
+                  else {
+                        QMessageBox::warning(0, "MuseScore",
+                                             tr("Measure Properties: No measure(s) selected\n"));
+                        }
+                  }},
             {{"next-lyric", "prev-lyric"}, [](ScoreView* cv, const QByteArray& cmd) {
                   cv->editCmd(cmd);
                   }},

--- a/mscore/shortcut.cpp
+++ b/mscore/shortcut.cpp
@@ -3190,6 +3190,13 @@ Shortcut Shortcut::_sc[] = {
          QT_TRANSLATE_NOOP("action","Join selected measures")
          },
       {
+         MsWidget::SCORE_TAB,
+         STATE_NORMAL | STATE_NOTE_ENTRY,
+         "measure-properties",
+         QT_TRANSLATE_NOOP("action","Open Measure Properties Dialogue"),
+         QT_TRANSLATE_NOOP("action","Open Measure Properties Dialogue")
+         },
+      {
          MsWidget::MAIN_WINDOW,
          STATE_NORMAL | STATE_NOTE_ENTRY | STATE_EDIT | STATE_PLAY | STATE_FOTO,
          "page-settings",


### PR DESCRIPTION
Since nothing is selected by default, might as well have something - so this selects the "Add to measure number" edit box to make it easier to perform a quick +/- measure index via up/down keys and pressing enter afterwards:

[measurePropertiesCmd.webm](https://github.com/user-attachments/assets/1ed0f732-858e-40a5-86ee-0c90edc621ff)
