### PR TITLE
Advanced Preferences for playback cursor positioning behavior + note entry to stop in place

### DIFF
--- a/global/settings/types/preferencekeys.h
+++ b/global/settings/types/preferencekeys.h
@@ -133,6 +133,8 @@
 #define PREF_SCORE_PLAYBACK_CURSOR_ENTIRE_MEASURE           "ui/score/playbackCursor/entireMeasure"
 #define PREF_SCORE_PLAYBACK_CURSOR_MOVE_BY_BEAT             "ui/score/playbackCursor/moveByBeats"
 #define PREF_SCORE_PLAYBACK_CURSOR_BACKGROUND               "ui/score/playbackCursor/behindStaff"
+#define PREF_SCORE_PLAYBACK_SELECT_POSITION_ON_STOP         "ui/score/playback/selectPlaybackPosition"
+#define PREF_SCORE_PLAYBACK_BRING_POSITION_TO_START         "ui/score/playback/resetToStart"
 #define PREF_UI_CANVAS_BG_USECOLOR                          "ui/canvas/background/useColor"
 #define PREF_UI_CANVAS_FG_USECOLOR                          "ui/canvas/foreground/useColor"
 #define PREF_UI_CANVAS_FG_USECOLOR_IN_PALETTES              "ui/canvas/foreground/useColorInPalettes"

--- a/libmscore/mscore.cpp
+++ b/libmscore/mscore.cpp
@@ -90,6 +90,8 @@ qreal   MScore::horizontalPageGapOdd = 50.0;
 QColor  MScore::selectColor[VOICES];
 QColor  MScore::cursorColor;
 QColor  MScore::defaultColor;
+bool    MScore::cursorResetToStart;
+bool    MScore::selectionFollowsCursor;
 
 bool    MScore::noteInputOctaveTendencyIsTopNote;
 bool    MScore::noteInputOctaveUpwardFifth;

--- a/libmscore/mscore.h
+++ b/libmscore/mscore.h
@@ -336,6 +336,8 @@ class MScore {
       static QColor selectColor[VOICES];
       static QColor cursorColor;
       static QColor defaultColor;
+      static bool   cursorResetToStart;
+      static bool   selectionFollowsCursor;
 
       static bool noteInputOctaveTendencyIsTopNote;
       static bool noteInputOctaveUpwardFifth;

--- a/mscore/events.cpp
+++ b/mscore/events.cpp
@@ -1144,7 +1144,8 @@ static const char* stateName(ViewState s)
 
 void ScoreView::seqStopped()
       {
-      changeState(ViewState::NORMAL);
+      if (state != ViewState::NORMAL && state != ViewState::NOTE_ENTRY)
+            changeState(ViewState::NORMAL);
       }
 
 //---------------------------------------------------------

--- a/mscore/preferences.cpp
+++ b/mscore/preferences.cpp
@@ -237,6 +237,8 @@ void Preferences::init(bool storeInMemoryOnly)
             {PREF_UI_CANVAS_BG_USECOLOR,                           new BoolPreference(true, false)},
             {PREF_UI_CANVAS_FG_USECOLOR,                           new BoolPreference(true, false)},
             {PREF_UI_CANVAS_FG_USECOLOR_IN_PALETTES,               new BoolPreference(false, false)},
+            {PREF_SCORE_PLAYBACK_SELECT_POSITION_ON_STOP,          new BoolPreference(false)},
+            {PREF_SCORE_PLAYBACK_BRING_POSITION_TO_START,          new BoolPreference(false)},
             {PREF_UI_CANVAS_BG_COLOR,                              new ColorPreference(QColor(0x385F94), false)},
             {PREF_UI_CANVAS_FG_COLOR,                              new ColorPreference(QColor(0xf9f9f9), false)},
             {PREF_UI_CANVAS_BG_WALLPAPER,                          new StringPreference(QFileInfo(QString("%1%2").arg(sharePath(), "wallpaper/background1.png")).absoluteFilePath(), false)},

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -947,6 +947,74 @@ void ScoreView::moveCursor()
       }
 
 //---------------------------------------------------------
+//   chordRestFromCursor
+//    useNextSegment - Get the following ChordRest after
+//                playback tick, if true, or fall back to
+//                previous if false
+//    considerAllTracks: If false, default to use track 0
+//    returns either Rest or Top Note of a chord (Element*)
+//---------------------------------------------------------
+
+Element* ScoreView::chordRestFromCursor(bool useNextSegment, bool considerAllTracks)
+      {
+      auto s = score();
+      ChordRest* cr = nullptr;
+      Element* el = nullptr;
+      int track = s->getSelectedElement() ? s->getSelectedElement()->track() : 0;
+      track = track < 0 ? 0 : track;
+      // auto seqCursorPos = seq->getCurTick(); // gives repeat tick (not necessarily in accord with visual score)
+      auto scoreCursorPos = cursorTick().ticks();
+      auto pos { Fraction::fromTicks(scoreCursorPos) };
+      auto seg = useNextSegment ? s->tick2rightSegment(pos, false) : s->tick2leftSegment(pos, false);
+      if (seg) {
+            if (seg->isChordRestType()) {
+                  if ( (cr = seg->cr(track)) )
+                        el = cr;
+                  else {
+                        for (int t = 0; t < s->ntracks(); ++t) {
+                              if ( (cr = seg->cr(t)) ) {
+                                    el = cr;
+                                    break;
+                                    }
+                              }
+                        }
+                  }
+            else {
+                  // Cycle through tracks if no CR* found
+                  if (considerAllTracks) {
+                        for (int t = 0; t < s->ntracks(); ++t) {
+                              if ( (cr = seg->cr(t)) ) {
+                                    el = cr;
+                                    break;
+                                    }
+                              }
+                        }
+                  // Nothing found:
+                  else el = seg->nextChordRest(0);
+                  }
+            }
+      if (el) {
+            if (el->isChord())
+                  el = toChord(el)->upNote();
+            }
+      return el;
+      }
+
+//---------------------------------------------------------
+//   startTickFromSelection
+//    Not just the tick of score->selection but using the
+//    original selection since it may be removed during playback
+//---------------------------------------------------------
+
+Fraction ScoreView::startTickFromSelection(void)
+      {
+      auto cr = originalSelection.firstChordRest();
+      if (!cr)
+            qDebug() << "original score-selection invalid";
+      return cr ? cr->tick() : Fraction(0,1);
+      }
+
+//---------------------------------------------------------
 //   cursorTick
 //---------------------------------------------------------
 
@@ -2254,6 +2322,9 @@ void ScoreView::cmd(const char* s)
       if (MScore::debugMode)
             qDebug("ScoreView::cmd <%s>", s);
 
+      if (score()->selection().element() || !score()->selection().elements().isEmpty())
+            originalSelection = score()->selection();
+
       //-------------------------------------
       // Lambda: removeDuplicates
       //-------------------------------------
@@ -2484,7 +2555,11 @@ void ScoreView::cmd(const char* s)
                               cv->changeState(ViewState::NORMAL);
 
                               bool validOriginalSelection = (originalSelection.score() == _score);
-                              if (validOriginalSelection) {
+                              if (MScore::selectionFollowsCursor) {
+                                    auto el = cv->chordRestFromCursor();
+                                    cv->score()->select(el);
+                                    }
+                              else if (validOriginalSelection) {
                                     if (/*TODO*/ true) {
                                           // Resetting to original selection should be contingent upon
                                           // user-preference of following cursor position at stop.
@@ -2896,6 +2971,30 @@ void ScoreView::cmd(const char* s)
                         if (el->isChord())
                               el = toChord(el)->upNote();
                         cv->cmdGotoElement(el);
+                        }
+                  }},
+            {{"play-at-selection"}, [](ScoreView* cv, const QByteArray&) {
+                  auto s = cv->score();
+                  static Fraction tick;
+                  if (auto cr = cv->getOriginalSelection().firstChordRest()) {
+                        tick = cr->tick();
+                        }
+                  s->deselectAll();
+
+                  // duplicated code from 'play' command:
+                  if (seq && seq->canStart()) {
+                        if (cv->state == ViewState::NORMAL || cv->state == ViewState::NOTE_ENTRY) {
+                              // Play:
+                              s->setPlayPos(tick);
+                              cv->changeState(ViewState::PLAY);
+                              }
+                        else if (cv->state == ViewState::PLAY) {
+                              // Rewind: restart to original position instead of functioning as "STOP"
+                              // Isn't 100% consistent - i.e., occasional pause if triggered quickly
+                              cv->changeState(ViewState::NORMAL);
+                              s->setPlayPos(tick);
+                              cv->changeState(ViewState::PLAY);
+                              }
                         }
                   }},
             {{"rest", "rest-TAB"}, [](ScoreView* cv, const QByteArray&) {

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -2406,6 +2406,16 @@ void ScoreView::cmd(const char* s)
                         cv->changeState(ViewState::NOTE_ENTRY);
                   else if (cv->state == ViewState::NOTE_ENTRY)
                         cv->changeState(ViewState::NORMAL);
+
+                  else if (cv->state ==ViewState::PLAY) {
+                        cv->changeState(ViewState::NORMAL);
+                        if (!cv->score()->selection().isNone())
+                              cv->deselectAll();
+                        if (auto el = cv->chordRestFromCursor()) {
+                              cv->score()->select(el);
+                              cv->changeState(ViewState::NOTE_ENTRY);
+                              }
+                        }
                   }},
             {{"copy"}, [](ScoreView* cv, const QByteArray&) {
                   if (cv->fotoMode())

--- a/mscore/scoreview.h
+++ b/mscore/scoreview.h
@@ -27,6 +27,7 @@
 #include "libmscore/property.h"
 #include "libmscore/select.h"
 #include "libmscore/textline.h"
+#include "libmscore/select.h"
 
 namespace Ms {
 
@@ -402,6 +403,10 @@ class ScoreView : public QWidget, public MuseScoreView {
       void setBackground(const QColor&);
       void setForeground(QPixmap*);
       void setForeground(const QColor&);
+
+      Element* chordRestFromCursor(bool useNextSegment=false, bool considerAllTracks=true);
+      Fraction startTickFromSelection(void);
+      const Selection& getOriginalSelection(void) { return originalSelection; }
 
       Page* addPage();
       virtual void setScore(Score* s) override;

--- a/mscore/seq.cpp
+++ b/mscore/seq.cpp
@@ -479,8 +479,15 @@ void Seq::guiStop()
       if (!cs)
             return;
 
-      int tck = cs->repeatList().utick2tick(cs->utime2utick(qreal(playFrame) / qreal(MScore::sampleRate)));
-      cs->setPlayPos(Fraction::fromTicks(tck));
+      if (MScore::cursorResetToStart) {
+            auto tick = viewer()->startTickFromSelection();
+            cs->setPlayPos(tick);
+            }
+      else {
+            int tck = cs->repeatList().utick2tick(cs->utime2utick(qreal(playFrame) / qreal(MScore::sampleRate)));
+            cs->setPlayPos(Fraction::fromTicks(tck));
+            }
+
       cs->update();
       emit stopped();
       }

--- a/mscore/seq.cpp
+++ b/mscore/seq.cpp
@@ -447,7 +447,7 @@ void MuseScore::seqStarted()
 
 void MuseScore::seqStopped()
       {
-      cv->setCursorOn(false);
+      cv->setCursorOn(cv->noteEntryMode());
       }
 
 //---------------------------------------------------------

--- a/mscore/shortcut.cpp
+++ b/mscore/shortcut.cpp
@@ -271,7 +271,7 @@ Shortcut Shortcut::_sc[] = {
          },
       {
          MsWidget::MAIN_WINDOW,
-         STATE_NORMAL | STATE_NOTE_ENTRY,
+         STATE_NORMAL | STATE_NOTE_ENTRY | STATE_PLAY,
          "note-input",
          QT_TRANSLATE_NOOP("action","Note Input"),
          QT_TRANSLATE_NOOP("action","Note input: Toggle Entry/Normal mode"),

--- a/mscore/shortcut.cpp
+++ b/mscore/shortcut.cpp
@@ -1204,6 +1204,13 @@ Shortcut Shortcut::_sc[] = {
          },
       {
          MsWidget::SCORE_TAB,
+         STATE_NORMAL | STATE_NOTE_ENTRY | STATE_PLAY,
+         "play-at-selection",
+         QT_TRANSLATE_NOOP("action","Playback Cursor Position Reset"),
+         QT_TRANSLATE_NOOP("action","Start playback at current single-element selection"),
+         },
+      {
+         MsWidget::SCORE_TAB,
          STATE_NORMAL | STATE_NOTE_ENTRY,
          "empty-trailing-measure",
          QT_TRANSLATE_NOOP("action","First Empty Trailing Measure"),


### PR DESCRIPTION
* `ui/score/playback/selectPlaybackPosition`
On stopping playback, the score selection will move forward to a reasonable position in accord with the playback cursor rather than being its original position before starting playback.

* `ui/score/playback/resetToStart`
If set to true, the playback cursor will reset to where playback first began rather than staying where it "leaves off" so that there's a sort of "start loop" effect.

* Command: **Playback Cursor Position Reset**
If triggered during playback, this will reset (_not stop_ but rather _continue playing_) at the beginning of when first playback began. Otherwise it begins playback at the beginning of the score selection (resets the playback cursor) so that it need not be default behavior set by `resetToStart` preference, but then you need two shortcuts defined if you want both styles.

Additionally, I've changed the "note-entry" command to perform the following:
* At stopping during playback, do what "selectPlaybackPosition" does: bring the selection to the playback cursor position, and also automatically enter into Note Entry Mode. This will allow the following:

... Set `resetToStart` to be true so that [**normal start/stop command**] (default: spacebar) will restart to original selection position, and then use [**command: note entry**] instead if you want to move forward while losing the original position. Also, if the user is playing back for test purposes and hears something wrong, pressing [note entry] command will stop at that point, enter into note entry to prepare for making changes easily, and this can be done without changing a single shortcut definition but rather enabling one advanced preference (they're both off by default)

Stopping via note-entry:

[noteEntryStop.webm](https://github.com/user-attachments/assets/12a22b74-a563-4b49-86a7-97cf30714051)

Restarting via adv. preference resetToStart set to true:

[resetToStart.webm](https://github.com/user-attachments/assets/3c6bcd72-e357-4fa7-908d-71c2663a884a)

