### PR TITLE
Commands: increase/decrease active duration (toggle for note entry) update

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -3989,6 +3989,18 @@ void Score::cmdPitchUpDownOctave(Direction dir, bool noteEntry)
 
 void Score::cmdPadNoteIncreaseTAB(const EditData& ed)
       {
+      if (!noteEntryMode() || selection().isRange()) {
+            cmdDoubleDuration();
+            // Update note-entry position:
+            if (noteEntryMode()) {
+                  selection().updateSelectedElements();
+                  if (auto end = selection().lastChordRest()) {
+                        nextInputPos(end, false);
+                        }
+                  }
+            return;
+            }
+
       switch (_is.duration().type() ) {
 // cycle back from longest to shortest?
 //          case TDuration::V_LONG:
@@ -4032,6 +4044,18 @@ void Score::cmdPadNoteIncreaseTAB(const EditData& ed)
 
 void Score::cmdPadNoteDecreaseTAB(const EditData& ed)
       {
+      if (!noteEntryMode() || selection().isRange()) {
+            cmdHalfDuration();
+            // Update note-entry position:
+            if (noteEntryMode()) {
+                  selection().updateSelectedElements();
+                  if (auto end = selection().lastChordRest()) {
+                        nextInputPos(end, false);
+                        }
+                  }
+            return;
+            }
+
       switch (_is.duration().type() ) {
             case TDuration::DurationType::V_LONG:
                   padToggle(Pad::NOTE0, ed);

--- a/libmscore/select.cpp
+++ b/libmscore/select.cpp
@@ -547,7 +547,12 @@ void Selection::updateSelectedElements()
             if (s1 && s2 && s1->tick() + s1->ticks() > s2->tick()) {
                   // can happen with MM rests as tick2measure returns only
                   // the first segment for them.
-                  return;
+                  if (s1->measure()->isMMRest() || s2->measure()->isMMRest()) {
+                        return;
+                        }
+
+                  // can also happen if single-range @ first ChordRest of measure
+                  // i.e. using double/half functions, ...will continue as usual
                   }
             if (s2 && s2 == s2->measure()->first())
                   s2 = s2->prev1();   // we want the last segment of the previous measure

--- a/mscore/shortcut.cpp
+++ b/mscore/shortcut.cpp
@@ -1731,14 +1731,14 @@ Shortcut Shortcut::_sc[] = {
          },
       {
          MsWidget::SCORE_TAB,
-         STATE_NOTE_ENTRY,
+         STATE_NORMAL | STATE_NOTE_ENTRY,
          "pad-note-increase",
          QT_TRANSLATE_NOOP("action","Increase Active Duration"),
          QT_TRANSLATE_NOOP("action","Increase active duration")
          },
       {
          MsWidget::SCORE_TAB,
-         STATE_NOTE_ENTRY,
+         STATE_NORMAL | STATE_NOTE_ENTRY,
          "pad-note-decrease",
          QT_TRANSLATE_NOOP("action","Decrease Active Duration"),
          QT_TRANSLATE_NOOP("action","Decrease active duration")


### PR DESCRIPTION
This pair of commands normally [**increases/decreases duration toggles**] in note-entry, rather than retroactively apply half/double whenever (regular/entry). They're not defined by default, and in a sense kind of "hidden" in the background in 3.6.2. Apparently MuseScore 4 applied its functionality to regular Q/W half/double commands so that they were toggle-only rather than applications while in note entry. Having said that:

They don't perform anything if not in note-entry mode. This update makes them act like the [half/double] functions when:
1) Not in note entry
2) If in note-entry since now "we" can have range selections, let the range selection also allow for its application.

Therefore, if deciding upon "toggle only" (Increase/Decrease active duration) or having the "applied" score-element effects of (Double/Half duration) for a defined pair of shortcuts (Q/W e.g.), you can kind of have both in one pair - at least a "little bit moah" so. It still won't retroactively apply when in note entry, but it's a better option imo to have it do something when in state 1) or 2)  mentioned above.


**UPDATE:** 
- The act of doubling/halving in note-entry with a range selection now updates the note-entry position
- Dealt with a weird flaw where the first chord/rest of a measure while range-selected, after issuing this command, would cause the loss of range selection (segments ticks seem not to get a proper update after doubling/halving, triggering an inappropriate if-block)