### PR TITLE
Edit Mode: Always move entire chord instead of notehead with keyboard

### DIFF
--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -2600,9 +2600,7 @@ void Note::editDrag(EditData& editData)
             const Spatium deltaSp = Spatium(editData.delta.x() / spatium());
             seg->undoChangeProperty(Pid::LEADING_SPACE, seg->extraLeadingSpace() + deltaSp);
             }
-      else if (ch->notes().size() == 1) {
-            // if the chord contains only this note, then move the whole chord
-            // including stem, flag etc.
+      else if (ch) {
             ch->undoChangeProperty(Pid::OFFSET, ch->offset() + offset() + editData.evtDelta);
             setOffset(QPointF());
             }


### PR DESCRIPTION
The code to move an entire chord via [Edit Mode + Arrows] was limited to only when that chord contained one note back in early 2018 during 3.6Alpha stage. I vaguely remember posting about it on their forums thinking it was a bug or a bad decision, but whatever. Here I'm imposing my personal preference:

Idea: If the user wants to move a notehead bereft of the entire chord, use the inspector for such a thing. Mainly because a chord can be benefited from moving left/right in my opinion way more often than a single note separated from its stem and hook. Didn't make sense to me then, doesn't make sense to me now for a keyboard user.

