### PR TITLE
[Piano Roll Editor] Make "Change Playback Length" default view (like in 3.6.2)

### DIFF
--- a/mscore/pianoroll/pianoroll.cpp
+++ b/mscore/pianoroll/pianoroll.cpp
@@ -119,12 +119,12 @@ PianorollEditor::PianorollEditor(QWidget* parent)
             bool _selected;
             };
       ToolIconData _iconDataTool[] = {
-            { QStringLiteral(":/data/icons/preEdit-select.svg"), PianoRollEditTool::SELECT, tr("Select Notes"), true },
+            { QStringLiteral(":/data/icons/preEdit-select.svg"), PianoRollEditTool::SELECT, tr("Select Notes"), false },
             { QStringLiteral(":/data/icons/preEdit-insertNote.svg"), PianoRollEditTool::ADD, tr("Add Note"), false },
             //{ QStringLiteral(":/data/icons/preEdit-appendChord.svg"), PianoRollEditTool::APPEND_NOTE, tr("Append Note to Chord"), false },
             { QStringLiteral(":/data/icons/preEdit-cutNote.svg"), PianoRollEditTool::CUT, tr("Cut Chord"), false },
             { QStringLiteral(":/data/icons/preEdit-eraseNote.svg"), PianoRollEditTool::ERASE, tr("Erase Note"), false },
-            { QStringLiteral(":/data/icons/preEdit-changeLength.svg"), PianoRollEditTool::EVENT_ADJUST, tr("Change Playback Length"), false },
+            { QStringLiteral(":/data/icons/preEdit-changeLength.svg"), PianoRollEditTool::EVENT_ADJUST, tr("Change Playback Length"), true },
             { QStringLiteral(":/data/icons/preEdit-tie.svg"), PianoRollEditTool::TIE, tr("Toggle Tie"), false },
             { "", PianoRollEditTool::LAST, "", false },
             };

--- a/mscore/pianoroll/pianoview.h
+++ b/mscore/pianoroll/pianoview.h
@@ -128,7 +128,7 @@ private:
       Fraction _editNoteLength = Fraction(1, 4);
       int _editNoteDots = 0;
       int _editNoteVoice = 0;
-      PianoRollEditTool _editNoteTool = PianoRollEditTool::SELECT;
+      PianoRollEditTool _editNoteTool = PianoRollEditTool::EVENT_ADJUST;
 
       QList<PianoItem*> _noteList;
       quint8 _pitchHighlight[128];


### PR DESCRIPTION
3.7-Evolution has had a few updates to the Piano Roll Editor (P.R.E), but there's a default change from how it used to work. Originally, the piano roll always showed the actual note play events, whereas lately it shows the main "front-end" instead (theoretically making it easier to select notes and move them around). My change here doesn't lose any functionality, but makes the default "view" be like 3.6.2.

3.7-Evolution without my change:
![image](https://github.com/user-attachments/assets/f5ebc796-a094-4e16-a8c1-7dd13f5ce63d)

After clicking **Change Playback Length**,  *then* it shows the offsets that exist:
![image](https://github.com/user-attachments/assets/93bb075c-04ab-495c-93cb-90b75edcf2b8)

This update will make it so the offsets automatically show immediately upon opening the PRE by making the **Change Playback Length** setting be default

