### PR TITLE
[Lasso] (Adv. Preference) Don't require shift-key to begin lasso dragging

### DIFF
--- a/global/settings/types/preferencekeys.h
+++ b/global/settings/types/preferencekeys.h
@@ -124,6 +124,7 @@
 #define PREF_SCORE_NOTE_WARNPITCHRANGE                      "score/note/warnPitchRange"
 #define PREF_SCORE_NOTE_INPUT_DISABLE_MOUSE_INPUT           "ui/score/noteEntry/disableMouseEntry"
 #define PREF_UI_SCORE_DISABLE_NOTE_DRAG_VERTICAL            "ui/score/mouse/behavior/disableNoteDragVertical"
+#define PREF_UI_SCORE_LASSO_WITHOUT_SHIFT                   "ui/score/mouse/behavior/enableLassoWithoutShift"
 #define PREF_SCORE_NOTE_INPUT_OCTAVE_TENDENCY               "ui/score/noteEntry/octaveTendencyIsTopNote"
 #define PREF_SCORE_NOTE_INPUT_FIFTH_IS_UPWARD               "ui/score/noteEntry/octaveUpwardFifth"
 #define PREF_SCORE_NOTE_INPUT_RESET_PITCH_AT_SYSTEM         "ui/score/noteEntry/resetNoteEntryAtSystemOrCourtesy"

--- a/libmscore/mscore.cpp
+++ b/libmscore/mscore.cpp
@@ -102,6 +102,7 @@ bool    MScore::retainAugmentationInRhythmEntry;
 bool    MScore::fingerTextAutoForwardAlphaNumeric;
 
 bool    MScore::disableVerticalMouseDragOfNotes;
+bool    MScore::lassoWithoutShift;
 
 bool    MScore::palettesHideWhenApplied;
 

--- a/libmscore/mscore.h
+++ b/libmscore/mscore.h
@@ -348,6 +348,7 @@ class MScore {
       static bool fingerTextAutoForwardAlphaNumeric;
 
       static bool disableVerticalMouseDragOfNotes;
+      static bool lassoWithoutShift;
 
       static bool palettesHideWhenApplied;
 

--- a/mscore/events.cpp
+++ b/mscore/events.cpp
@@ -681,15 +681,19 @@ void ScoreView::mouseMoveEvent(QMouseEvent* me)
             return;
 
       // start some drag operations after a minimum of movement:
-      bool drag = (me->pos() - editData.startMovePixel).manhattanLength() > 4;
+      bool lmb = (editData.buttons == Qt::LeftButton);
+      bool drag = ((me->pos() - editData.startMovePixel).manhattanLength() > 4) && lmb;
+      bool haveShift = (me->modifiers() & Qt::ShiftModifier);
 
       switch (state) {
             case ViewState::NORMAL:
                   if (!drag)
                         return;
-                  if (!editData.element && (me->modifiers() & Qt::ShiftModifier)) {
-                        changeState(ViewState::LASSO);
-                        break;
+                  if (!editData.element) {
+                        if (MScore::lassoWithoutShift || haveShift) {
+                              changeState(ViewState::LASSO);
+                              break;
+                              }
                         }
                   if (editData.element) {
                         if (editData.element->normalModeEditBehavior() == Element::EditBehavior::Edit && editData.curGrip != Grip::NO_GRIP) {

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -431,6 +431,7 @@ void updateExternalValuesFromPreferences() {
       MScore::palettesHideWhenApplied = preferences.getBool(PREF_UI_APP_AUTOHIDE_PALETTES);
 
       MScore::disableVerticalMouseDragOfNotes = preferences.getBool(PREF_UI_SCORE_DISABLE_NOTE_DRAG_VERTICAL);
+      MScore::lassoWithoutShift = preferences.getBool(PREF_UI_SCORE_LASSO_WITHOUT_SHIFT);
       MScore::noteInputOctaveTendencyIsTopNote = preferences.getBool(PREF_SCORE_NOTE_INPUT_OCTAVE_TENDENCY);
       MScore::noteInputOctaveUpwardFifth = preferences.getBool(PREF_SCORE_NOTE_INPUT_FIFTH_IS_UPWARD);
       MScore::resetNoteEntryAtSystemOrCourtesy = preferences.getBool(PREF_SCORE_NOTE_INPUT_RESET_PITCH_AT_SYSTEM);

--- a/mscore/preferences.cpp
+++ b/mscore/preferences.cpp
@@ -231,6 +231,7 @@ void Preferences::init(bool storeInMemoryOnly)
             {PREF_SCORE_NOTE_INPUT_FORCE_VOICE2_BELOW,             new BoolPreference(true)},
             {PREF_SCORE_FINGERING_ALPHANUMERIC_AUTOFORWARD,        new BoolPreference(false)},
             {PREF_UI_SCORE_DISABLE_NOTE_DRAG_VERTICAL,             new BoolPreference(false)},
+            {PREF_UI_SCORE_LASSO_WITHOUT_SHIFT,                    new BoolPreference(true)},
             {PREF_SCORE_STYLE_DEFAULTSTYLEFILE,                    new StringPreference("", false)},
             {PREF_SCORE_STYLE_PARTSTYLEFILE,                       new StringPreference("", false)},
             {PREF_SCORE_PLAYBACK_CURSOR_ENTIRE_MEASURE,            new BoolPreference(false, true)},


### PR DESCRIPTION
Someone mentioned this (https://musescore.org/en/node/368298) 2024-09-07, and figured would make an 

Advanced Preference:
`ui/score/mouse/behavior/enableLassoWithoutShift`

Now it's on by default ([click-drag] will not drag the score around, but rather form a lasso), since I never click-drag a score for the purposes of view-scrolling, though it can be reverted to the original behavior by setting this to **false**.