### PR TITLE
Save As: Default to MSCZ if no suffix is provided

### DIFF
--- a/mscore/file.cpp
+++ b/mscore/file.cpp
@@ -2502,12 +2502,17 @@ bool MuseScore::saveAs(Score* cs_, bool saveCopy)
       else
             mscore->lastSaveDirectory = fi.absolutePath();
 
-      if (fi.suffix().isEmpty()) {
+      auto suffix = fi.suffix();
+      if (suffix != "mscz" && suffix != "mscx") {
+            suffix = "mscz";
+            }
+
+      if (suffix.isEmpty()) {
             if (!MScore::noGui)
                   QMessageBox::critical(mscore, tr("Save As"), tr("Cannot determine file type"));
             return false;
             }
-      return saveAs(cs_, saveCopy, fn, fi.suffix());
+      return saveAs(cs_, saveCopy, fn, suffix);
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
Point here is to provide an appropriate .MSCZ suffix during **Save As** if user clears filename and types a filename without the suffix, instead of getting the following error message as in 3.6.2:

[saveError.webm](https://github.com/user-attachments/assets/a0f073ae-7c48-4abd-8ce6-0c90abec680e)

Probably would be better to possibly default to MSCX also depending on the drop-down menu selection (two options: mscz/mscx) there, but there doesn't seem to be a clear way of retaining that selection choice after having accepted the dialog-box. This'll do for now.