### PR TITLE
[Cmd: Paste Clone All] Include frames before and after score's music measures if a full range-selection of copied score exists

### DIFF
--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -2236,7 +2236,7 @@ bool Score::appendMeasuresFromScore(Score* score, const Fraction& startTick, con
 //       resorting to a regular paste afterwards as a workaround
 //---------------------------------------------------------
 
-MeasureBase* Score::insertMeasuresFromScore(Score* scoreSource, const Selection& selectionSource, MeasureBase& mbInsert) {
+MeasureBase* Score::insertMeasuresFromScore(Score* scoreSource, const Selection& selectionSource, MeasureBase& mbInsert, bool entireScore) {
       auto scoreDest = this;
       Measure* mFirst;
       Measure* mLast;
@@ -2312,6 +2312,12 @@ MeasureBase* Score::insertMeasuresFromScore(Score* scoreSource, const Selection&
             index++;
             }
 
+      if (entireScore) {
+            // Include initial and following frames if entire score's timeline is range-selected
+            mbStart = scoreSource->first();
+            mbEnd   = scoreSource->last();
+            }
+
       // Clone & Insert measures:
       std::vector<MeasureBase*> insertedMeasures;
       int safeGuard = 0;
@@ -2331,8 +2337,11 @@ MeasureBase* Score::insertMeasuresFromScore(Score* scoreSource, const Selection&
                   }
             if (!firstIteration) {
                   if ((mbCurrent->no() == mbStart->no()) && !mbCurrent->isBox()) {
-                        qDebug() << "error:" << "restart or invalid interaction with insertion point.";
-                        break;
+                        if (mbCurrent->index() == mbStart->index()) {
+                              qDebug() << "error:" << "restart or invalid interaction with insertion point.";
+                              break;
+                              }
+                        // ...OK when including entire score
                         }
                   else if (!mbCurrent->no()) {
                         qDebug() << "error:" << "reached a measure #0 mid-way" ;

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -649,7 +649,7 @@ class Score : public QObject, public ScoreElement {
 
       bool appendMeasuresFromScore(Score* score, const Fraction& startTick, const Fraction& endTick);
 
-      MeasureBase* insertMeasuresFromScore (Score* scoreSource, const Selection& selectionSource, MeasureBase& mbInsert);
+      MeasureBase* insertMeasuresFromScore (Score* scoreSource, const Selection& selectionSource, MeasureBase& mbInsert, bool entireScore);
 
       bool appendScore(Score*, bool addPageBreak = false, bool addSectionBreak = true);
 

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -433,6 +433,19 @@ void ScoreView::measurePopup(QContextMenuEvent* ev, Measure* obj)
       popup->addAction(getAction("copy"));
       popup->addAction(getAction("paste"));
       popup->addAction(getAction("paste-clone"));
+
+      // [Action: Paste Clone All] option contingent upon an existing entire range-selection:
+      auto lastSelection = mscore->getLastScoreSelection();
+      auto lastScore = lastSelection.score();
+      Measure* first;
+      Measure* last;
+      lastSelection.measureRange(&first, &last);
+      if (lastScore && lastScore->firstMeasure() == first) {
+            if (lastScore->lastMeasure() == last) {
+                  popup->addAction(getAction("paste-clone-all"));
+                  }
+            }
+
       popup->addAction(getAction("swap"));
       popup->addAction(getAction("delete"));
       popup->addAction(getAction("time-delete"));
@@ -2188,7 +2201,7 @@ bool ScoreView::normalPaste(Fraction scale)
             if (auto oe = srcSelection.element()) {
                   if (oe->isBox() && !oe->isFBox()) {
                         // Allow normal paste to insert clone of V/H/T boxes
-                        _score->insertMeasuresFromScore(srcScore, srcSelection, *insertionMeasureBase);
+                        _score->insertMeasuresFromScore(srcScore, srcSelection, *insertionMeasureBase, false);
                         _score->endCmd();
                         return MScore::_error == MS_NO_ERROR;
                         }
@@ -2217,11 +2230,10 @@ bool ScoreView::normalPaste(Fraction scale)
 //   clonePaste
 //---------------------------------------------------------
 
-bool ScoreView::clonePaste()
+bool ScoreView::clonePaste(bool entireScore)
       {
       MeasureBase* mbFirstInsertion = nullptr;
       auto currentStaff = _score->selection().staffStart();
-      _score->startCmd();
 
       auto srcScore = mscore->getLastScoreSelection().score();
       auto copiedSel = mscore->getLastScoreSelection();
@@ -2239,6 +2251,7 @@ bool ScoreView::clonePaste()
       MeasureBase* insertionMeasureBase = nullptr;
       bool rv;
 
+      _score->startCmd();
       if (auto e = _score->selection().element()) {
             if (auto mb = e->findMeasureBase()) {
                   insertionMeasureBase = mb;
@@ -2250,7 +2263,7 @@ bool ScoreView::clonePaste()
                   }
             }
       if (insertionMeasureBase) {
-            mbFirstInsertion = _score->insertMeasuresFromScore(srcScore, copiedSel, *insertionMeasureBase);
+            mbFirstInsertion = _score->insertMeasuresFromScore(srcScore, copiedSel, *insertionMeasureBase, entireScore);
             rv = MScore::_error == MS_NO_ERROR;
             }
       else rv = MScore::_error == NO_DEST;
@@ -2439,7 +2452,12 @@ void ScoreView::cmd(const char* s)
                         cv->editPaste();
                   }},
             {{"paste-clone"}, [](ScoreView* cv, const QByteArray&) {
-                  cv->clonePaste();
+                  bool entireScore = true;
+                  cv->clonePaste(!entireScore);
+                  }},
+            {{"paste-clone-all"}, [](ScoreView* cv, const QByteArray&) {
+                  bool entireScore = true;
+                  cv->clonePaste(entireScore);
                   }},
             {{"paste-half"}, [](ScoreView* cv, const QByteArray&) {
                   cv->normalPaste(Fraction(1, 2));

--- a/mscore/scoreview.h
+++ b/mscore/scoreview.h
@@ -367,7 +367,7 @@ class ScoreView : public QWidget, public MuseScoreView {
       void normalCopy();
       void fotoModeCopy(bool includeLink = false);
       bool normalPaste(Fraction scale = Fraction(1, 1));
-      bool clonePaste();
+      bool clonePaste(bool entireScore);
       void normalSwap();
 
       void setControlCursorVisible(bool v);

--- a/mscore/shortcut.cpp
+++ b/mscore/shortcut.cpp
@@ -230,6 +230,16 @@ Shortcut Shortcut::_sc[] = {
          },
       {
          MsWidget::SCORE_TAB,
+         STATE_NORMAL,
+         "paste-clone-all",
+         QT_TRANSLATE_NOOP("action","Paste (Clone + entire score-range)"),
+         0,
+         0,
+         Icons::paste_ICON,
+         Qt::ApplicationShortcut
+         },
+      {
+         MsWidget::SCORE_TAB,
          STATE_NORMAL | STATE_NOTE_ENTRY,
          "paste-half",
          QT_TRANSLATE_NOOP("action","Paste Half Duration"),


### PR DESCRIPTION
My adding the Clone Paste function:
https://github.com/Jojo-Schmitz/MuseScore/issues/638
initially didn't include the ability to clone the entire score in the sense of its also including vertical/horizontal/text frames *before* the first musical measure and also any of these types of frames _after_ the last musical measure. Now, however:

1) If a range selection includes the beginning and end measures of a score,
2) Then the right click menu will show an option to include these also with the command:
`"Paste (Clone + entire score-range)"`

![image](https://github.com/user-attachments/assets/4a0ece44-6d78-4955-b4af-1c5c13378c97)

Gives the user the option to include or not include those before/after frames... and makes it easy to bring an *entire score with all frames* into another score ;)

P.S. Command also shows in the shortcut list, but that's only out of necessity due to lack of hidden shortcut implementation (yet). 