### PR TITLE
[Tab Layout] Allow fingering string text to affect which linked tablature string is used

### DIFF
--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -2071,6 +2071,33 @@ void Note::layout()
                   if (chord()->measure() != tieBack()->startNote()->chord()->measure() || el().size() > 0)
                         paren = true;
                   }
+
+            auto scoreElement = links() ? links()->mainElement() : nullptr;
+            if (scoreElement && scoreElement->isNote()) {
+                  if (auto n = toNote(scoreElement)) {
+                        int updatedString = _string;
+                        int updatedFret = _fret;
+                        for (auto& e : n->el()) {
+                              if (e->isFingering()) {
+                                    if (auto fingering = toFingering(e)) {
+                                          if (fingering->tid() == Tid::STRING_NUMBER) {
+                                                auto stringData = staff()->part()->instrument(tick())->stringData();
+                                                int whichString = fingering->plainText().toInt();
+                                                int maxStrings = stringData->strings();
+                                                if (whichString <= maxStrings && whichString >= 0) {
+                                                      updatedString = whichString;  // E.g: 1-6
+                                                      updatedString -= 1;           // E.g: 0-5 (internal representation)
+                                                      updatedFret = stringData->fret(pitch(), updatedString, staff(), chord()->tick());
+                                                      }
+                                                }
+                                          }
+                                    }
+                              }
+                        _string = updatedString;
+                        _fret   = updatedFret;
+                        }
+                  }
+
             // not complete but we need systems to be layouted to add parenthesis
             if (fixed())
                   _fretString = "/";


### PR DESCRIPTION
I've noticed MusicXML exported from TuxGuitar doesn't provide a tablature by default, but rather was providing the Treble/Bass clef with string data text. In order to get appropriate tabs linked as a result when brought into MuseScore, you'd be absurdly required to manually change the tabs.

TuxGuitar file:
![image](https://github.com/user-attachments/assets/ddcef562-0885-4468-97b1-1a9bea1d3f8f)

Exported to MusicXML and brought into MuseScore:
![image](https://github.com/user-attachments/assets/0004cdc6-dae7-4bee-b80b-77c7a1fefa13)

The tabs are no longer how it came to be in the program, though string data is provided (the numbers in circles above the the notes)

With this PR change, the tabs will be based on that string data, and so equivalent to what TuxGuitar had:

![image](https://github.com/user-attachments/assets/b9ce5355-0168-496a-9e33-dced3f7783b8)

Of course it's possible I'm missing some sort of information regarding Tux Guitar and its export (also loading automatically without conversion gives same problem even missing the string text), but the point is mainly that this seems like good change generally speaking.

Update: Newer TuxGuitar (1.6x) *does* export the tablature, but still this seems like a decent mini-fix to apply the appropriate string to a linked staff
