### PR TITLE
[Cmd: Add Pitch] Applies to range/multi-list selections

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -4248,6 +4248,10 @@ void Score::cmdAddPitch(const EditData& ed, int note, bool addFlag, bool insert,
       InputState& is = inputState();
       if (is.track() == -1)          // invalid state
             return;
+      if (is.duration() == TDuration::DurationType::V_INVALID) {
+            qDebug("cmdAddPitch: invalid input state duration");
+            return;
+            }
       if (is.segment() == 0) {
             qDebug("cannot enter notes here (no chord rest at current position)");
             return;
@@ -4296,6 +4300,7 @@ void Score::cmdAddPitch(const EditData& ed, int note, bool addFlag, bool insert,
                   el = selection().elements().front();
 
             if (addFlag) {
+                  // TODO: result in a multi-list selection/keep active range selection
                   std::vector<Chord*> chords;
                   for (auto el : selection().elements()) {
                         if (el->isNote()) {
@@ -4500,6 +4505,7 @@ void Score::cmdAddPitch(Note* selectedNote, int step)
       pos.line      = relStep(step, clef);
       bool error;
       NoteVal nval = noteValForPosition(pos, _is.accidentalType(), error);
+      
       if (error) return;
       
       bool forceAccidental = false;

--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -4292,23 +4292,41 @@ void Score::cmdAddPitch(const EditData& ed, int note, bool addFlag, bool insert,
             static const int tab[] = { 0, 2, 4, 5, 7, 9, 11 };
 
             Element* el = selection().element();
-            if (addFlag && el && el->isNote()) {
-                  Chord* chord = toNote(el)->chord();
+            if (!el && !selection().elements().isEmpty())
+                  el = selection().elements().front();
 
-                  // if adding notes, add above the upNote of the current chord
-                  // alternatively, if adding tpc downward, base position will be current selected note
-                  (void) useUpNote;
-                  Note* n = below ? toNote(el) : chord->upNote();
+            if (addFlag) {
+                  std::vector<Chord*> chords;
+                  for (auto el : selection().elements()) {
+                        if (el->isNote()) {
+                              Chord* chord = toNote(el)->chord();
+                              auto it =
+                                 std::find_if(chords.begin(),
+                                              chords.end(),
+                                              [&chord](Chord* c) { return c == chord; } );
 
-                  int tpc = n->tpc();
-                  octave = (n->epitch() - int(tpc2alter(tpc))) / PITCH_DELTA_OCTAVE;
-                  if (note <= tpc2step(tpc) && !below)
-                        octave++;
-                  else if (note >= tpc2step(tpc) && below)
-                        octave--;
+                              if (it != std::end(chords)) continue; // chord already found
+                              chords.emplace_back(chord);
+
+                              // TPC above: use upNote as basis
+                              // TPC below: basis is current note selection
+
+                              Note* n = below ? toNote(el) : chord->upNote();
+                              int tpc = n->tpc();
+                              octave = (n->epitch() - int(tpc2alter(tpc))) / PITCH_DELTA_OCTAVE;
+                              if (note <= tpc2step(tpc) && !below)
+                                    octave++;
+                              else if (note >= tpc2step(tpc) && below)
+                                    octave--;
+
+                              int step = octave * TPC_DELTA_SEMITONE + note;
+                              cmdAddPitch(n, step);
+                              }
+                        }
+                        return;
                   }
-                  // Observation: this is partial in that it will only work for one element and not on a range
             else {
+                  // Observation: this is partial in that it will only work for one element and not on a range
                   int curPitch = 60;
                   el = !el ? selection().firstChordRest() : el;
                   if (!el)
@@ -4449,8 +4467,8 @@ void Score::cmdAddPitch(int step, bool addFlag, bool insert)
                         }
                   addNote(chord, nval, forceAccidental);
                   _is.setAccidentalType(AccidentalType::NONE);
-                  return;
                   }
+                  return;
             }
 
       pos.segment   = inputState().segment();
@@ -4466,6 +4484,30 @@ void Score::cmdAddPitch(int step, bool addFlag, bool insert)
             else
                   putNote(pos, !addFlag);
             }
+      _is.setAccidentalType(AccidentalType::NONE);
+      }
+
+void Score::cmdAddPitch(Note* selectedNote, int step)
+      {
+      if (!selectedNote) return;
+            
+      Position pos;
+      Chord* chord  = selectedNote->chord();
+      Segment* seg  = chord->segment();
+      pos.segment   = seg;
+      pos.staffIdx  = chord->vStaffIdx();
+      ClefType clef = staff(pos.staffIdx)->clef(seg->tick());
+      pos.line      = relStep(step, clef);
+      bool error;
+      NoteVal nval = noteValForPosition(pos, _is.accidentalType(), error);
+      if (error) return;
+      
+      bool forceAccidental = false;
+      if (_is.accidentalType() != AccidentalType::NONE) {
+            NoteVal nval2 = noteValForPosition(pos, AccidentalType::NONE, error);
+            forceAccidental = (nval.pitch == nval2.pitch);
+            }
+      addNote(chord, nval, forceAccidental);
       _is.setAccidentalType(AccidentalType::NONE);
       }
 

--- a/libmscore/noteentry.cpp
+++ b/libmscore/noteentry.cpp
@@ -430,7 +430,16 @@ void Score::putNote(const Position& p, bool replace)
 
             if (_is.rest())
                   nval.pitch = -1;
-            setNoteRest(_is.segment(), _is.track(), nval, _is.duration().fraction(), stemDirection, forceAccidental);
+
+            bool durationNeedsUpdate =
+                  _is.duration().isMeasure() ||
+                  _is.duration().isZero()    ||
+                  !_is.duration().isValid();
+
+            Fraction defaultDuration = TDuration(TDuration::DurationType::V_QUARTER).fraction();
+            Fraction duration = (!durationNeedsUpdate ? _is.duration().fraction() : defaultDuration);
+            // duration = _is.duration().fraction();
+            setNoteRest(_is.segment(), _is.track(), nval, duration, stemDirection, forceAccidental);
             _is.setAccidentalType(AccidentalType::NONE);
             }
       if (!st->isTabStaff(cr->tick()))

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -1255,6 +1255,8 @@ class Score : public QObject, public ScoreElement {
       void setFooterText(Text* t, int index)          { _footersText.at(index) = t;     }
 
       void cmdAddPitch(int note, bool addFlag, bool insert);
+      void cmdAddPitch(Note* selectedNote, int step);
+
       void forAllLyrics(std::function<void(Lyrics*)> f);
 
       System* getNextSystem(LayoutContext&);


### PR DESCRIPTION
Potential todo: update selection to be the resultant pitches rather than going into Note Entry. Will probably leave as is.

Given a range selection or list-selection, normally the user can not add a specific pitch above/below current selection except by [_add interval_] functions. This changes that to allow A-G commands

[cmdAddPitchAppliesToRangeList.webm](https://github.com/user-attachments/assets/a060f4cb-3464-49bd-be43-13835a9f9574)
