### PR TITLE
Timeline Navigation Update: Allow navigating to Rehearsal Mark during playback and provide option to compress their layout

### DIFF
--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -3105,7 +3105,7 @@ void MuseScore::createPlayPanel()
             playPanel = new PlayPanel(this);
             connect(playPanel, SIGNAL(metronomeGainChanged(float)), seq, SLOT(setMetronomeGain(float)));
             connect(playPanel, SIGNAL(speedChanged(double)), seq, SLOT(setRelTempo(double)));
-            connect(playPanel, SIGNAL(posChange(int)), seq, SLOT(seek(int)));
+            connect(playPanel, SIGNAL(posChange(int, bool)), seq, SLOT(seek(int, bool)));
             connect(playPanel, SIGNAL(closed(bool)), playId, SLOT(setChecked(bool)));
             connect(synti, SIGNAL(gainChanged(float)), playPanel, SLOT(setGain(float)));
             playPanel->setSpeedIncrement(preferences.getInt(PREF_APP_PLAYBACK_SPEEDINCREMENT));

--- a/mscore/musescore.h
+++ b/mscore/musescore.h
@@ -618,6 +618,7 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
       bool checkDirty(MasterScore*);
       IPlayPanel* playPanelInterface() const;
       PlayPanel* getPlayPanel() const { return playPanel; }
+      PlayPanel* getVerifiedPlayPanel() { createPlayPanel(); return playPanel; }
       Mixer* getMixer() const { return mixer; }
       QMenu* genCreateMenu(QWidget* parent = 0);
       virtual int appendScore(MasterScore*);

--- a/mscore/playpanel.cpp
+++ b/mscore/playpanel.cpp
@@ -335,8 +335,8 @@ void PlayPanel::setPos(int utick)
       {
       if (!cs)
             return;
-      if (cachedTickPosition != utick)
-            emit posChange(utick);
+
+      emit posChange(utick, true);
       updatePosLabel(utick);
       updateTimeLabel(cs->utick2utime(utick));
       }

--- a/mscore/playpanel.h
+++ b/mscore/playpanel.h
@@ -65,7 +65,7 @@ class PlayPanel : public QDockWidget, private Ui::PlayPanelBase, public IPlayPan
    signals:
       void speedChanged(double);
       void metronomeGainChanged(float);
-      void posChange(int);
+      void posChange(int, bool);
       void closed(bool);
 
    public slots:

--- a/mscore/timeline.cpp
+++ b/mscore/timeline.cpp
@@ -16,6 +16,7 @@
 #include "texttools.h"
 #include "timeline.h"
 #include "tourhandler.h"
+#include "playpanel.h"
 
 #include "libmscore/barline.h"
 #include "libmscore/chordrest.h"
@@ -29,6 +30,7 @@
 #include "libmscore/page.h"
 #include "libmscore/part.h"
 #include "libmscore/rehearsalmark.h"
+#include "libmscore/repeatlist.h"
 #include "libmscore/score.h"
 #include "libmscore/staff.h"
 #include "libmscore/system.h"
@@ -2201,7 +2203,16 @@ void Timeline::mousePressEvent(QMouseEvent* event)
                               // Select just the element for tempo_text
                               Element* element = static_cast<Element*>(currGraphicsItem->data(4).value<void*>());
                               _score->deselectAll();
-                              _score->select(element);
+
+                              bool isScorePlaying = (mscore->state() == ScoreState::STATE_PLAY);
+                              if (element->isRehearsalMark() && isScorePlaying) {
+                                    Fraction tick = element->tick();
+                                    int utick = _score->repeatList().tick2utick(tick.ticks());
+                                    if (auto playPanel = mscore->getVerifiedPlayPanel()) {
+                                          playPanel->setPos(utick);
+                                          }
+                                    }
+                              else _score->select(element);
                               }
                         }
                   }

--- a/mscore/timeline.cpp
+++ b/mscore/timeline.cpp
@@ -1569,6 +1569,15 @@ unsigned Timeline::getMetaRow(QString targetText)
 
 bool Timeline::addMetaValue(int x, int pos, QString metaText, int row, ElementType elementType, Element* element, Segment* seg, Measure* measure, QString tooltip)
       {
+      static int lastPositionEnd = 0;
+      bool isRehearsalMark = (elementType == ElementType::REHEARSAL_MARK);
+
+      if (isRehearsalMark && _contiguousRM) {
+            if (x == 0)
+                  lastPositionEnd = 0;
+            x = pos = lastPositionEnd;
+            }
+
       QGraphicsTextItem* graphicsTextItem = new QGraphicsTextItem(metaText);
       qreal textWidth = graphicsTextItem->boundingRect().width();
 
@@ -1697,6 +1706,10 @@ bool Timeline::addMetaValue(int x, int pos, QString metaText, int row, ElementTy
 
       scene()->addItem(graphicsRectItem);
       scene()->addItem(itemToAdd);
+
+      if (isRehearsalMark && _contiguousRM) {
+            lastPositionEnd += textWidth;
+            }
 
       std::pair<QGraphicsItem*, int> pairTimeRect = std::make_pair(graphicsRectItem, row);
       std::pair<QGraphicsItem*, int> pairTimeText = std::make_pair(itemToAdd, row);
@@ -3011,6 +3024,13 @@ void Timeline::contextMenuEvent(QContextMenuEvent*)
                         }
                   }
             contextMenu->addSeparator();
+
+            QAction* contiguousRehearsalMarks = new QAction(tr("Contiguous Rehearsal Marks"), this);
+            contiguousRehearsalMarks->setCheckable(true);
+            contiguousRehearsalMarks->setChecked(_contiguousRM);
+            connect(contiguousRehearsalMarks, SIGNAL(triggered()), this, SLOT(toggleMetaRow()));
+            contextMenu->addAction(contiguousRehearsalMarks);
+
             QAction* hide_all = new QAction(tr("Hide all"), this);
             connect(hide_all, SIGNAL(triggered()), this, SLOT(toggleMetaRow()));
             contextMenu->addAction(hide_all);
@@ -3043,6 +3063,11 @@ void Timeline::toggleMetaRow()
             else if (targetText == tr("Show all")) {
                   for (auto it = _metas.begin(); it != _metas.end(); ++it)
                         std::get<2>(*it) = true;
+                  updateGrid();
+                  return;
+                  }
+            else if (targetText == tr("Contiguous Rehearsal Marks")) {
+                  _contiguousRM = !_contiguousRM;
                   updateGrid();
                   return;
                   }

--- a/mscore/timeline.h
+++ b/mscore/timeline.h
@@ -172,6 +172,7 @@ class Timeline : public QGraphicsView {
       QPoint _oldLoc;
 
       bool _collapsedMeta { false };
+      bool _contiguousRM = true;
 
       std::vector<std::tuple<QString, void (Timeline::*)(Segment*, int*, int), bool>> _metas;
       void tempoMeta(Segment* seg, int* stagger, int pos);


### PR DESCRIPTION
The Timeline allows for a quick way to navigate to a particular rehearsal mark, but it doesn't work by default while playing back. This is especially useful in a "Wait" mode of playback (for future release of a "piano tutor" edition) without having to exit and re-enter playback mode. Ergo this change to jump to a ScoreEvent at the same tick as the Rehearsal Mark while in Playback state if clicking a Rehearsal Mark in the Timeline.

Additionally, it seems to me that breaking the "concept" of the "time"-line by allowing an all contiguous layout-mode for rehearsal marks makes for easy navigating, so there's an additional option to do so and here on by default.

Capture of switching from default to contiguous mode:

[Contiguity.webm](https://github.com/user-attachments/assets/e3466bf5-7e7e-4b5a-9c9f-4ba9e0363bcc)

As for having those funny symbols for tempo note marks, that's another ordeal. . . 
