### PR TITLE
New Commands: [Go to] & [Play] Next/Prev Rehearsal Marks

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -2534,7 +2534,7 @@ Element* Score::move(const QString& cmd)
       lastCR  = lastCR  ? lastCR : cr;
       firstCR = firstCR ? firstCR : cr;
 
-      Element* el = 0;
+      Element* el = selection().element();
       Segment* ois = noteEntryMode() ? _is.segment() : nullptr;
       Measure* oim = ois ? ois->measure() : nullptr;
 
@@ -2702,6 +2702,18 @@ Element* Score::move(const QString& cmd)
             if (!(el = box))
                   el = cr;
             el = cmdNextPrevSection(el, false);
+            }
+      else if (cmd == "next-rehearsal-mark") {
+            if (el->isRehearsalMark()) {}
+            else if (!(el = box))
+                  el = cr;
+            el = cmdNextPrevRehearsalMark(el, true);
+            }
+      else if (cmd == "prev-rehearsal-mark") {
+            if (el->isRehearsalMark()) {}
+            else if (!(el = box))
+                  el = cr;
+            el = cmdNextPrevRehearsalMark(el, false);
             }
       else if (cmd == "next-track" && cr) {
             el = nextTrack(cr);

--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -4580,6 +4580,37 @@ MeasureBase* Score::getNextPrevSectionBreak(MeasureBase* mb, bool dir) const
       return destination;
       }
 
+//---------------------------------------------------------
+//   cmdNextPrevRehearsalMark
+//    !next = previous
+//---------------------------------------------------------
+
+Element* Score::cmdNextPrevRehearsalMark(Element* el, bool next) const
+      {
+      auto st = SegmentType::ChordRest;
+      Segment* currentSeg=nullptr;
+      RehearsalMark* rm=nullptr;
+
+      // Get segment:
+      if (el->isRehearsalMark()) currentSeg = toRehearsalMark(el)->segment();
+      else if (el->isChord())    currentSeg = toChord(el)->segment();
+      else if (el->isNote())     currentSeg = toNote(el)->chord()->segment();
+      else if (el->isRest())     currentSeg = toRest(el)->segment();
+
+      // Seek rehearsal marks via ChordRest segments
+      for (auto seg = currentSeg; seg; seg = next ? seg->next1(st) : seg->prev1(st)) {
+            for (auto e : seg->annotations()) {
+                  if (e->isRehearsalMark()) {
+                        if (e->tick() != currentSeg->tick())
+                              rm = toRehearsalMark(e);
+                        break;
+                        }
+                  }
+            if (rm) break;
+            }
+
+      return rm;
+      }
 
 //---------------------------------------------------------
 //   getScoreElementOfMeasureBase

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -864,6 +864,7 @@ class Score : public QObject, public ScoreElement {
       ChordRest* cmdNextPrevSystem(ChordRest*, bool);
       Box* cmdNextPrevFrame(MeasureBase*, bool) const;
       Element* cmdNextPrevSection(Element*, bool) const;
+      Element* cmdNextPrevRehearsalMark(Element*, bool) const;
       MeasureBase* getNextPrevSectionBreak(MeasureBase*, bool) const;
       Element* getScoreElementOfMeasureBase(MeasureBase*) const;
 

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -6325,6 +6325,10 @@ void MuseScore::cmd(QAction* a, const QString& cmd)
             seq->prevMeasure();
       else if (cmd == "play-prev-chord")
             seq->prevChord();
+      else if (cmd == "play-next-rehearsal-mark")
+            seq->nextRehearsalMark();
+      else if (cmd == "play-prev-rehearsal-mark")
+            seq->nextRehearsalMark(false);
       else if (cmd == "seek-begin")
             seq->rewindStart();
       else if (cmd == "seek-end")

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -2771,6 +2771,8 @@ void ScoreView::cmd(const char* s)
               "prev-frame",
               "next-section",
               "prev-section",
+              "next-rehearsal-mark",
+              "prev-rehearsal-mark",
               "empty-trailing-measure",
               "top-staff"}, [](ScoreView* cv, const QByteArray& cmd) {
 
@@ -2780,7 +2782,8 @@ void ScoreView::cmd(const char* s)
                         }
 
                   Element* el = cv->score()->selection().element();
-                  if (el && (el->isTextBase())) {
+
+                  if (el && el->isTextBase() && !cmd.endsWith("rehearsal-mark")) {
                         cv->score()->startCmd();
                         const PropertyFlags pf = PropertyFlags::UNSTYLED;
                         if (cmd == "prev-chord")

--- a/mscore/seq.cpp
+++ b/mscore/seq.cpp
@@ -34,6 +34,7 @@
 #include "libmscore/measure.h"
 #include "libmscore/note.h"
 #include "libmscore/part.h"
+#include "libmscore/rehearsalmark.h"
 #include "libmscore/rendermidi.h"
 #include "libmscore/repeatlist.h"
 #include "libmscore/score.h"
@@ -1401,6 +1402,62 @@ void Seq::setController(int channel, int ctrl, int data)
 void Seq::sendEvent(const NPlayEvent& ev)
       {
       guiToSeq(SeqMsg(SeqMsgId::PLAY, ev));
+      }
+
+//---------------------------------------------------------
+//   nextRehearsalMark
+//   !next = previous
+//---------------------------------------------------------
+
+void Seq::nextRehearsalMark(bool next)
+      {
+      Segment* currentSeg=nullptr;
+      auto startTick = guiPos->first;
+      // Get start segment:
+      for (auto i = guiPos; i != eventsEnd; ++i) {
+            const NPlayEvent& npe = i->second;
+            if (auto n = npe.note()) {
+                  auto c = n->chord();
+                  currentSeg = c->segment();
+                  break;
+                  }
+            else if (auto r = npe.rest()) {
+                  currentSeg = r->segment();
+                  break;
+                  }
+            else continue;
+            }
+
+      // Seek for next/prev tick of Rehearsal Mark
+      if (currentSeg) {
+            RehearsalMark* foundRMark=nullptr;
+            Fraction rmTick;
+            auto st = SegmentType::ChordRest;
+            auto rmType = ElementType::REHEARSAL_MARK;
+            startTick = currentSeg->tick().ticks();
+            for (auto seg = currentSeg; seg; seg = (next ? seg->next1(st) : seg->prev1(st))) {
+                  auto sTick  = seg->tick();
+                  auto sTicks = seg->tick().ticks();
+                  for (auto e : seg->annotations()){
+                        if (e->type() == rmType) {
+                              int prevThresh = 380;
+                              if (next) { if (startTick >= sTicks) continue; }
+                              else if ( (startTick - sTicks) < prevThresh )
+                                    break;
+
+                              foundRMark = toRehearsalMark(e);
+                              rmTick = sTick;
+                              break;
+                              }
+                        }
+                  if (foundRMark) break;
+                  }
+
+            if (foundRMark) {
+                  int utick = score()->repeatList().tick2utick(rmTick.ticks());
+                  seek(utick);
+                  }
+            }
       }
 
 //---------------------------------------------------------

--- a/mscore/seq.h
+++ b/mscore/seq.h
@@ -239,6 +239,7 @@ class Seq : public QObject, public Sequencer {
       void seekEnd();
       void nextMeasure();
       void nextChord();
+      void nextRehearsalMark(bool next=true);
       void prevMeasure();
       void prevChord();
 

--- a/mscore/shortcut.cpp
+++ b/mscore/shortcut.cpp
@@ -1159,6 +1159,13 @@ Shortcut Shortcut::_sc[] = {
       {
          MsWidget::SCORE_TAB,
          STATE_NORMAL | STATE_NOTE_ENTRY,
+         "prev-rehearsal-mark",
+         QT_TRANSLATE_NOOP("action","Previous Rehearsal Mark"),
+         QT_TRANSLATE_NOOP("action","Go to previous rehearsal mark")
+         },
+      {
+         MsWidget::SCORE_TAB,
+         STATE_NORMAL | STATE_NOTE_ENTRY,
          "prev-track",
          QT_TRANSLATE_NOOP("action","Previous Staff or Voice"),
          QT_TRANSLATE_NOOP("action","Previous staff or voice")
@@ -1204,6 +1211,13 @@ Shortcut Shortcut::_sc[] = {
          "next-section",
          QT_TRANSLATE_NOOP("action","Next Section"),
          QT_TRANSLATE_NOOP("action","Go to next section")
+         },
+      {
+         MsWidget::SCORE_TAB,
+         STATE_NORMAL | STATE_NOTE_ENTRY,
+         "next-rehearsal-mark",
+         QT_TRANSLATE_NOOP("action","Next Rehearsal Mark"),
+         QT_TRANSLATE_NOOP("action","Go to next rehearsal mark")
          },
       {
          MsWidget::SCORE_TAB,
@@ -2537,6 +2551,20 @@ Shortcut Shortcut::_sc[] = {
          0,
          Icons::Invalid_ICON,
          Qt::ApplicationShortcut
+         },
+      {
+         MsWidget::SCORE_TAB,
+         STATE_PLAY,
+         "play-prev-rehearsal-mark",
+         QT_TRANSLATE_NOOP("action","Play Previous Rehearsal Mark"),
+         QT_TRANSLATE_NOOP("action","Play previous rehearsal mark")
+         },
+      {
+         MsWidget::SCORE_TAB,
+         STATE_PLAY,
+         "play-next-rehearsal-mark",
+         QT_TRANSLATE_NOOP("action","Play Next Rehearsal Mark"),
+         QT_TRANSLATE_NOOP("action","Play next rehearsal mark")
          },
       {
          MsWidget::MAIN_WINDOW,


### PR DESCRIPTION
**Go to previous/next rehearsal mark**
These will select the next/previous available rehearsal mark given a valid position in Normal state. Similar to selecting a rehearsal mark on the Timeline

**Play previous/next rehearsal mark**
These will move the playback cursor to the first ChordRest's play position associated with the play tick of the next/previous rehearsal mark while in the Playback state without highlighting the actual mark itself (it wouldn't be appropriate while in playback state)

Review: This is contingent upon the sequencer's being "aware" of rests, which it currently is not in this code base...