### PR TITLE
Aside: Remove some qDebug() statements

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -4998,7 +4998,8 @@ void Score::cmd(const QAction* a, EditData& ed)
                   return;
                   }
             }
-      qDebug("unknown cmd <%s>", qPrintable(cmd));
+      if (cmd != "")
+            qDebug("unknown cmd <%s>", qPrintable(cmd));
       }
 
 

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -5659,7 +5659,7 @@ void ScoreView::midiNoteReceived(int pitch, bool chord, int velocity)
       score()->masterScore()->enqueueMidiEvent(ev);
 
       if (!score()->undoStack()->active())
-            cmd((const char*)0);
+            cmd(static_cast<const char*>(0));
 
       if (!chord && velocity && !realtimeTimer->isActive() && score()->usingNoteEntryMethod(NoteEntryMethod::REALTIME_AUTO)) {
             // First note pressed in automatic real-time mode.

--- a/mscore/seq.cpp
+++ b/mscore/seq.cpp
@@ -873,7 +873,7 @@ void Seq::process(unsigned framesPerPeriod, float* buffer)
                               break;
                         n = playPosFrame - *pPlayFrame;
                         if (n < 0) {
-                              qDebug("%d:  %d - %d", playPosUTick, playPosFrame, *pPlayFrame);
+                              // qDebug("%d:  %d - %d", playPosUTick, playPosFrame, *pPlayFrame);
                               n = 0;
                               }
                         if (mscore->loop()) {

--- a/mscore/shortcut.cpp
+++ b/mscore/shortcut.cpp
@@ -4453,8 +4453,11 @@ QString Shortcut::help() const
 Shortcut* Shortcut::getShortcut(const char* id)
       {
       Shortcut* s = _shortcuts.value(QByteArray(id));
-      if (s == 0) {
-            qDebug("Internal error: shortcut <%s> not found", id);
+      if (s == 0 && id) {
+            if (*id != 0) {
+                  // Omit debug message for null command occurring in ScoreView::midiNoteReceived()
+                  qDebug("Internal error: shortcut <%s> not found", id);
+                  }
             return 0;
             }
       return s;


### PR DESCRIPTION
Clear excess debug output for empty commands due to being, for my purposes, non-useful while "getting in the way" 