### PR TITLE
Playback Fixes: More stable seeking + fix occasional lingering marked notes 

### DIFF
--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -4289,7 +4289,7 @@ void Score::removeUnmanagedSpanner(Spanner* s)
 //   setPos
 //---------------------------------------------------------
 
-void MasterScore::setPos(POS pos, Fraction tick)
+void MasterScore::setPos(POS pos, Fraction tick, bool viaUserNavigation)
       {
       if (tick < Fraction(0,1))
             tick = Fraction(0,1);
@@ -4303,7 +4303,7 @@ void MasterScore::setPos(POS pos, Fraction tick)
       // so we should update cursor here
       // however, we must be careful not to call setPos() again while handling posChanged, or recursion results
       for (Score*& s : scoreList())
-            emit s->posChanged(pos, unsigned(tick.ticks()));
+            emit s->posChanged(pos, unsigned(tick.ticks()), viaUserNavigation);
       }
 
 //---------------------------------------------------------

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -580,7 +580,7 @@ class Score : public QObject, public ScoreElement {
       inline virtual const Movements* movements() const;
 
    signals:
-      void posChanged(POS, unsigned);
+      void posChanged(POS, unsigned, bool);
       void playlistChanged();
 
    public:
@@ -926,14 +926,15 @@ class Score : public QObject, public ScoreElement {
 
       // These position are in ticks and not uticks
       Fraction playPos() const                      { return pos(POS::CURRENT);   }
-      void setPlayPos(const Fraction& tick)         { setPos(POS::CURRENT, tick); }
+      void setPlayPos(const Fraction& tick, bool viaUserNavigation=false)
+            { setPos(POS::CURRENT, tick, viaUserNavigation); }
       Fraction loopInTick() const                   { return pos(POS::LEFT);      }
       Fraction loopOutTick() const                  { return pos(POS::RIGHT);     }
       void setLoopInTick(const Fraction& tick)      { setPos(POS::LEFT, tick);    }
       void setLoopOutTick(const Fraction& tick)     { setPos(POS::RIGHT, tick);   }
 
       inline Fraction pos(POS pos) const;
-      inline void setPos(POS pos, Fraction tick);
+      inline void setPos(POS pos, Fraction tick, bool viaUserNavigation=false);
 
       bool noteEntryMode() const                   { return inputState().noteEntryMode(); }
       void setNoteEntryMode(bool val)              { inputState().setNoteEntryMode(val); }
@@ -1435,7 +1436,7 @@ class MasterScore : public Score {
 
       using Score::pos;
       Fraction pos(POS pos) const { return _pos[int(pos)]; }
-      void setPos(POS pos, Fraction tick);
+      void setPos(POS pos, Fraction tick, bool viaUserNavigation=false);
 
       void addExcerpt(Excerpt*);
       void removeExcerpt(Excerpt*);
@@ -1503,7 +1504,8 @@ inline Movements* Score::movements()                   { return _masterScore->mo
 inline const Movements* Score::movements() const       { return _masterScore->movements();       }
 
 inline Fraction Score::pos(POS pos) const              { return _masterScore->pos(pos);          }
-inline void Score::setPos(POS pos, Fraction tick)      { _masterScore->setPos(pos, tick);        }
+inline void Score::setPos(POS pos, Fraction tick, bool viaUserNavigation)
+      { _masterScore->setPos(pos, tick, viaUserNavigation); }
 
 extern MasterScore* gscore;
 

--- a/mscore/events.cpp
+++ b/mscore/events.cpp
@@ -636,12 +636,15 @@ void ScoreView::mousePressEvent(QMouseEvent* ev)
                   break;
 
             case ViewState::PLAY: {
-                  Element* e = elementNear(editData.startMove);
-                  if (seq && e && (e->isNote() || e->isRest())) {
-                        if (e->isNote())
-                              e = e->parent();
-                        ChordRest* cr = toChordRest(e);
-                        seq->seek(seq->score()->repeatList().tick2utick(cr->tick().ticks()));
+                  if (seq) {
+                        if (auto e = elementNear(editData.startMove)) {
+                              if (e->isNote())
+                                    e = e->parent();
+                              int tick = e->tick().ticks();
+                              int uTick = seq->score()->repeatList().tick2utick(tick);
+                              seq->seek(uTick, true);
+                              update();
+                              }
                         }
                   }
                   break;

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -246,7 +246,7 @@ void ScoreView::setScore(Score* s)
             _curLoopOut->move(s->pos(POS::RIGHT));
             loopToggled(getAction("loop")->isChecked());
 
-            connect(s, SIGNAL(posChanged(POS,uint)), SLOT(posChanged(POS,uint)));
+            connect(s, SIGNAL(posChanged(POS,unsigned,bool)), SLOT(posChanged(POS,unsigned,bool)));
             connect(this, SIGNAL(viewRectChanged()), this, SLOT(updateContinuousPanel()));
             }
       }
@@ -583,8 +583,9 @@ void ScoreView::dataChanged(const QRectF& r)
 //    move cursor during playback
 //---------------------------------------------------------
 
-void ScoreView::moveCursor(const Fraction& tick)
+void ScoreView::moveCursor(const Fraction& tick, bool viaUserNavigation)
       {
+      (void) viaUserNavigation;
       Measure* measure = score()->tick2measureMM(tick);
       if (measure == 0)
             return;
@@ -668,8 +669,6 @@ void ScoreView::moveCursor(const Fraction& tick)
             return;
       double y        = system->staffYpage(0) + system->page()->pos().y();
       double _spatium = score()->spatium();
-
-      update(_matrix.mapRect(_cursor->rect()).toRect().adjusted(-1,-1,1,1));
 
       qreal mag = _spatium / SPATIUM20;
       double w  = (_spatium * 1.0) + score()->scoreFont()->width(SymId::noteheadBlack, mag);
@@ -6448,7 +6447,7 @@ Element* ScoreView::elementNear(QPointF p)
 //   posChanged
 //---------------------------------------------------------
 
-void ScoreView::posChanged(POS pos, unsigned tick)
+void ScoreView::posChanged(POS pos, unsigned tick, bool viaUserNavigation)
       {
       switch (pos) {
             case POS::CURRENT:
@@ -6456,9 +6455,9 @@ void ScoreView::posChanged(POS pos, unsigned tick)
                   if (this != mscore->currentScoreView() && !_moveWhenInactive)
                         return;
                   if (noteEntryMode())
-                        moveCursor();     // update input cursor position
+                        moveCursor(); // update input cursor position
                   else
-                        moveCursor(Fraction::fromTicks(tick)); // update play position
+                        moveCursor(Fraction::fromTicks(tick), viaUserNavigation); // update play position
                   break;
             case POS::LEFT:
                   _curLoopIn->move(_score->pos(POS::LEFT));

--- a/mscore/scoreview.h
+++ b/mscore/scoreview.h
@@ -345,7 +345,7 @@ class ScoreView : public QWidget, public MuseScoreView {
       Element* getDropTarget(EditData&);
 
    private slots:
-      void posChanged(POS pos, unsigned tick);
+      void posChanged(POS pos, unsigned tick, bool viaUserNavigation);
       void loopToggled(bool);
       void triggerCmdRealtimeAdvance();
       void cmdRealtimeAdvance();
@@ -393,7 +393,7 @@ class ScoreView : public QWidget, public MuseScoreView {
       void startEdit(Element*, Grip) override;
       void startEditMode(Element*);
 
-      void moveCursor(const Fraction& tick);
+      void moveCursor(const Fraction& tick, bool viaUserNavigation=false);
       void moveControlCursor(const Fraction& tick);
       bool isCursorDistanceReasonable();
       void moveControlCursorNearCursor();

--- a/mscore/seq.cpp
+++ b/mscore/seq.cpp
@@ -1117,11 +1117,9 @@ void Seq::updateEventsEnd()
 //   collectEvents
 //---------------------------------------------------------
 
-void Seq::collectEvents(int utick)
+void Seq::collectEvents(int utick, bool viaUserNavigation)
       {
-      //do not collect even while playing
-      if (state == Transport::PLAY && playlistChanged)
-            return;
+      (void) viaUserNavigation;
 
       mutex.lock();
 
@@ -1149,8 +1147,10 @@ void Seq::collectEvents(int utick)
             }
 
       updateEventsEnd();
-      playPos = mscore->loop() ? events.find(cs->loopInTick().ticks()) : events.cbegin();
+      auto eventAtTick = events.find(utick);
+      playPos = mscore->loop() ? events.find(cs->loopInTick().ticks()) : eventAtTick;
       playlistChanged = false;
+      unmarkNotes();
       mutex.unlock();
       }
 
@@ -1254,12 +1254,12 @@ int Seq::getPlayStartUtick()
 //   Do not use explicitly, use seek() or seekRT()
 //---------------------------------------------------------
 
-void Seq::seekCommon(int utick)
+void Seq::seekCommon(int utick, bool viaUserNavigation)
       {
       if (cs == 0)
             return;
 
-      collectEvents(utick);
+      collectEvents(utick, viaUserNavigation);
 
       if (cs->playMode() == PlayMode::AUDIO) {
             ogg_int64_t sp = cs->utick2utime(utick) * MScore::sampleRate;
@@ -1277,7 +1277,7 @@ void Seq::seekCommon(int utick)
 //   gui thread
 //---------------------------------------------------------
 
-void Seq::seek(int utick)
+void Seq::seek(int utick, bool viaUserNavigation)
       {
       if (preferences.getBool(PREF_IO_JACK_USEJACKTRANSPORT)) {
             if (utick > endUTick)
@@ -1286,13 +1286,12 @@ void Seq::seek(int utick)
             if (utick != 0)
                   return;
             }
-      seekCommon(utick);
+      seekCommon(utick, viaUserNavigation);
 
+      // Note: setPlayPos() will eventually call moveCursor() via signal emission
       int t = cs->repeatList().utick2tick(utick);
-      Segment* seg = cs->tick2segment(Fraction::fromTicks(t));
-      if (seg)
-            mscore->currentScoreView()->moveCursor(seg->tick());
-      cs->setPlayPos(Fraction::fromTicks(t));
+      cs->setPlayPos(Fraction::fromTicks(t), viaUserNavigation);
+
       cs->update();
       guiToSeq(SeqMsg(SeqMsgId::SEEK, utick));
       }
@@ -1875,12 +1874,12 @@ void Seq::setLoopOut()
       else
           if (t > cs->lastMeasure()->endTick())
               t = cs->lastMeasure()->endTick();
-      cs->setPos(POS::RIGHT, t);
+      cs->setPos(POS::RIGHT, t, false);
       if (state == Transport::PLAY)
             guiToSeq(SeqMsg(SeqMsgId::SEEK, t.ticks()));
       }
 
-void Seq::setPos(POS, unsigned t)
+void Seq::setPos(POS, unsigned t, bool)
       {
       qDebug("seq: setPos %d", t);
       }

--- a/mscore/seq.h
+++ b/mscore/seq.h
@@ -197,7 +197,7 @@ class Seq : public QObject, public Sequencer {
       void playEvent(const NPlayEvent&, unsigned framePos);
       void guiToSeq(const SeqMsg& msg);
       void metronome(unsigned n, float* l, bool force);
-      void seekCommon(int utick);
+      void seekCommon(int utick, bool viaUserNavigation=false);
       void unmarkNotes();
       void updateSynthesizerState(int tick1, int tick2);
       void addCountInClicks();
@@ -215,12 +215,12 @@ class Seq : public QObject, public Sequencer {
 
    public slots:
       void setRelTempo(double);
-      void seek(int utick);
+      void seek(int utick, bool viaUserNavigation=false);
       void seekRT(int utick);
       void stopNotes(int channel = -1, bool realTime = false);
       void start();
       void stop();
-      void setPos(POS, unsigned);
+      void setPos(POS, unsigned, bool viaUserNavigation=false);
       void setMetronomeGain(float val) { metronomeVolume = val; }
 
    signals:
@@ -244,7 +244,7 @@ class Seq : public QObject, public Sequencer {
       void prevMeasure();
       void prevChord();
 
-      void collectEvents(int utick);
+      void collectEvents(int utick, bool viaUserNavigation=false);
       void ensureBufferAsync(int utick);
       void guiStop();
       void stopWait();


### PR DESCRIPTION
Fix:
+ Occasional lingering marked-notes during playback when navigational move commands occur
+ Sporadic jumping/playback cursor for a split second showing up somewhere else when attempting to navigate during playback with mouse/keyboard

**Demonstration of problem:**
Lingering marked notes in 3.6.2/3.7:

[MS3x Not highlight updating when moving around via mouse .webm](https://github.com/user-attachments/assets/a6f33fd0-cccc-49b2-9a41-89d45058fe80)

Jumping to either beginning of score or somewhere before actual position often/sporadically which causes a jerk/jitter motion:

[jumpduringnav.webm](https://github.com/user-attachments/assets/993f49e0-85fc-4e89-8de7-033af6f5491b)

None of that should happen any longer with these changes.

P.S. The code change has a parameter: `viaUserNavigation` which is superfluous here, but it doesn't hurt to have for potential further changes if required to differentiate between user-induced navigation versus seeking through playback/automatic means

P.P.S, the main culprit to jumping seemed to be using events.cbegin() instead of the tick passed into the function 
```cpp
playPos = mscore->loop() ? events.find(cs->loopInTick().ticks()) : events.cbegin();
```
and a superfluous moveCursor since it is called again "down the line" after the following signal emission:
```cpp
mscore->currentScoreView()->moveCursor(seg->tick());
```