### PR TITLE
Personal Preference: Layout breaks apply only to end of range selection, not also before

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -4160,7 +4160,7 @@ void Score::cmdPadNoteDecreaseTAB(const EditData& ed)
 //   cmdToggleLayoutBreak
 //---------------------------------------------------------
 
-void Score::cmdToggleLayoutBreak(LayoutBreak::Type type)
+void Score::cmdToggleLayoutBreak(LayoutBreak::Type type, bool before, bool all)
       {
       // find measure(s)
       QList<MeasureBase*> mbl;
@@ -4171,21 +4171,25 @@ void Score::cmdToggleLayoutBreak(LayoutBreak::Type type)
                   return;
             if (!startMeasure || !endMeasure)
                   return;
-#if 1
+
             // toggle break on the last measure of the range
             mbl.append(endMeasure);
-            // if more than one measure selected,
-            // also toggle break *before* the range (to try to fit selection on a single line)
-            if (startMeasure != endMeasure && startMeasure->prev())
-                  mbl.append(startMeasure->prev());
-#else
-            // toggle breaks throughout the selection
-            for (Measure* m = startMeasure; m; m = m->nextMeasure()) {
-                  mbl.append(m);
-                  if (m == endMeasure)
-                        break;
+            
+            // toggle break *before* a range consisting of more than one measure
+            // (to try to fit selection on a single line)
+            if (before) {
+                  if (startMeasure != endMeasure && startMeasure->prev())
+                        mbl.append(startMeasure->prev());
                   }
-#endif
+
+            // toggle breaks throughout the selection
+            if (all) {
+                  for (Measure* m = startMeasure; m; m = m->nextMeasure()) {
+                        mbl.append(m);
+                        if (m == endMeasure)
+                              break;
+                        }
+                  }
             }
       else {
             MeasureBase* mb = nullptr;

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -638,7 +638,7 @@ class Score : public QObject, public ScoreElement {
       void cmdHalfDuration()        { cmdIncDecDuration( 1, false); }
       void cmdIncDurationDotted()   { cmdIncDecDuration(-1, true); }
       void cmdDecDurationDotted()   { cmdIncDecDuration( 1, true); }
-      void cmdToggleLayoutBreak(LayoutBreak::Type);
+      void cmdToggleLayoutBreak(LayoutBreak::Type, bool before=false, bool all=false);
 
       void addRemoveBreaks(int interval, bool lock);
 


### PR DESCRIPTION
Motivation here I think was from being able to utilize ranges while in Note Entry Mode, retroactively performing something of some sort and then wanting to trigger a line/system break all the while not needing to exit Note Entry nor need to reduce the range to be merely of one measure length

**Like so**:

[breakonlyatend.webm](https://github.com/user-attachments/assets/39113c27-2c01-4f4d-bd37-0d4806557fda)
