### PR TITLE
Layout: Staccatos closer on beam-side

### DIFF
--- a/libmscore/chord.cpp
+++ b/libmscore/chord.cpp
@@ -3541,12 +3541,13 @@ void Chord::layoutArticulations()
                   if (!headSide && stem()) {
                         y = upPos() + stem()->stemLen();
                         if (beam())
-                              y += score()->styleS(Sid::beamWidth).val() * _spatium * .5;
+                              y += score()->styleS(Sid::beamWidth).val();
+
                         int line = (int)lrint((y + 0.5 * _spStaff) / _spStaff);
                         if (line < staffType->lines())  // align between staff lines
                               y = line * _spStaff + _spatium * .5;
                         else
-                              y += _spatium;
+                              y += (_spatium * 0.75);
                         if (a->isStaccato() && articulations().size() == 1) {
                               if (_up)
                                     x = downNote()->bboxRightPos() - stem()->width() * .5;
@@ -3571,12 +3572,13 @@ void Chord::layoutArticulations()
                   if (!headSide && stem()) {
                         y = downPos() + stem()->stemLen();
                         if (beam())
-                              y -= score()->styleS(Sid::beamWidth).val() * _spatium * .5;
+                              y -= score()->styleS(Sid::beamWidth).val();
+
                         int line = (int)lrint((y-0.5*_spStaff) / _spStaff);
                         if (line >= 0)  // align between staff lines
                               y = line * _spStaff - _spatium * .5;
                         else
-                              y -= _spatium;
+                              y -= (_spatium * 0.75);
                         if (a->isStaccato() && articulations().size() == 1) {
                               if (_up)
                                     x = downNote()->bboxRightPos() - stem()->width() * .5;


### PR DESCRIPTION
**Previously in 3.6.2**:

![image](https://github.com/user-attachments/assets/382f4a9b-b755-48ca-809c-e75e68721b77)



**With these changes*:

![image](https://github.com/user-attachments/assets/c2574780-0869-4d57-bfe8-20756b1fff20)

