### PR TITLE
Layout: Slurs extending to next system will reach to end of barline

### DIFF
--- a/libmscore/slur.cpp
+++ b/libmscore/slur.cpp
@@ -1129,23 +1129,30 @@ SpannerSegment* Slur::layoutSystem(System* system)
 
       SlurPos sPos;
       slurPos(&sPos);
+      
+      qreal extraXMargin = (score()->styleP(Sid::slurEndWidth));
+
+      // TODO: yOffset when spanning slur across systems, based on p1/p2 positions
+      qreal yOffsetSystemSpan = spatium() * 1.66;
+      yOffsetSystemSpan *= (_up ? -1.0 : +1.0);
+      yOffsetSystemSpan = 0.0; // for now, do nothing
 
       switch (sst) {
             case SpannerSegmentType::SINGLE:
                   slurSegment->layoutSegment(sPos.p1, sPos.p2);
                   break;
             case SpannerSegmentType::BEGIN:
-                  slurSegment->layoutSegment(sPos.p1, QPointF(system->lastNoteRestSegmentX(true), sPos.p1.y()));
+                  slurSegment->layoutSegment(sPos.p1, QPointF(system->lastNoteRestSegmentX(true) + extraXMargin, sPos.p1.y() + yOffsetSystemSpan));
                   break;
             case SpannerSegmentType::MIDDLE: {
                   qreal x1 = system->firstNoteRestSegmentX(true);
-                  qreal x2 = system->lastNoteRestSegmentX(true);
+                  qreal x2 = system->lastNoteRestSegmentX(true) + extraXMargin;
                   qreal y  = staffIdx() > system->staves()->size() ? system->y() : system->staff(staffIdx())->y();
                   slurSegment->layoutSegment(QPointF(x1, y), QPointF(x2, y));
                   }
                   break;
             case SpannerSegmentType::END:
-                  slurSegment->layoutSegment(QPointF(system->firstNoteRestSegmentX(true), sPos.p2.y()), sPos.p2);
+                  slurSegment->layoutSegment(QPointF(system->firstNoteRestSegmentX(true), sPos.p2.y() + yOffsetSystemSpan), sPos.p2);
                   break;
             }
 

--- a/libmscore/system.cpp
+++ b/libmscore/system.cpp
@@ -1702,7 +1702,7 @@ qreal System::firstNoteRestSegmentX(bool leading)
 
 qreal System::lastNoteRestSegmentX(bool trailing)
       {
-      qreal margin = score()->spatium() / 4;  // TODO: this can be parameterizable
+      qreal margin = 0.0;
       //for (const MeasureBase* mb : measures()) {
       for (auto measureBaseIter = measures().rbegin(); measureBaseIter != measures().rend(); measureBaseIter++) {
             if ((*measureBaseIter)->isMeasure()) {


### PR DESCRIPTION
3.6.2 does this correctly, but somewhere afterwards, changes occurred that made 

**Something like this (3.6.2)**

![3 7nogap](https://github.com/user-attachments/assets/0434bd32-d57e-48e4-991c-586c7ec0bd94)

**Become like this:**

![3 7gap](https://github.com/user-attachments/assets/209847a8-d91d-44d2-97dd-de997d36c1f7)

I don't like it, hence this PR

+ Slightly prepares for some y-offsetting based on P1/P2 positioning, but that's a different topic.
