### PR TITLE
Layout of Slurs: Personal Changes

### DIFF
--- a/global/settings/types/preferencekeys.h
+++ b/global/settings/types/preferencekeys.h
@@ -188,6 +188,8 @@
 #define PREF_UI_SCORE_VOICE3_COLOR                          "ui/score/voice3/color"
 #define PREF_UI_SCORE_VOICE4_COLOR                          "ui/score/voice4/color"
 #define PREF_UI_SCORE_BRACKET_MULTIPLIER                    "ui/score/bracket/multiplier"
+#define PREF_UI_SCORE_SLURS_MAX_SHOULDER_EXTRA              "ui/score/slurs/shoulder/extraHeight"
+#define PREF_UI_SCORE_SLURS_MIN_SHOULDER_EXTRA              "ui/score/slurs/shoulder/extraHeightSmall"
 #define PREF_UI_THEME_ICONHEIGHT                            "ui/theme/iconHeight"
 #define PREF_UI_THEME_ICONWIDTH                             "ui/theme/iconWidth"
 #define PREF_UI_THEME_FONTFAMILY                            "ui/theme/fontFamily"

--- a/libmscore/beam.cpp
+++ b/libmscore/beam.cpp
@@ -21,6 +21,7 @@
 #include "rest.h"
 #include "score.h"
 #include "segment.h"
+#include "slur.h"
 #include "sig.h"
 #include "spanner.h"
 #include "staff.h"
@@ -2047,6 +2048,8 @@ void Beam::layout2(std::vector<ChordRest*>crl, SpannerSegmentType, int frag)
                   qreal l       = y2 - (by + _pagePos.y());
                   stem->setLen(l);
 
+                  // Stem's main properties are now seemingly finalized
+
                   StemSlash* stemSlash = c->stemSlash();
                   if (stemSlash)
                         stemSlash->layout();
@@ -2054,6 +2057,22 @@ void Beam::layout2(std::vector<ChordRest*>crl, SpannerSegmentType, int frag)
                   if (tremolo)
                         tremolo->layout();
                   c->segment()->createShape(c->vStaffIdx());      // recreate shape
+
+                  // Cross-staff slurring re-layout
+                  if (c->beam() && c->beam()->cross()) {
+                        int tick  = c->tick().ticks();
+                        int track = c->track();
+                        auto overlappingSpanners = score()->spannerMap().findOverlapping(tick,tick);
+                        for (auto& i : overlappingSpanners) {
+                              auto s = i.value;
+                              if (s->isSlur() && s->track() == track) {
+                                    auto slur = toSlur(s);
+                                    if (auto m = c->measure())
+                                          if (auto s = m->system())
+                                                slur->layoutSystem(s, slur->frontSegment());
+                                    }
+                              }
+                        }
                   }
             }
       }

--- a/libmscore/mscore.cpp
+++ b/libmscore/mscore.cpp
@@ -125,6 +125,9 @@ bool    MScore::cursorDrawnBehindStaff;
 
 qreal   MScore::systemBracketMultiplier;
 
+qreal   MScore::slurShoulderExtraMax;
+qreal   MScore::slurShoulderExtraMin;
+
 bool    MScore::harmonyPlayDisableCompatibility;
 bool    MScore::harmonyPlayDisableNew;
 bool    MScore::playRepeats;

--- a/libmscore/mscore.h
+++ b/libmscore/mscore.h
@@ -371,6 +371,9 @@ class MScore {
 
       static qreal systemBracketMultiplier;
 
+      static qreal slurShoulderExtraMax;
+      static qreal slurShoulderExtraMin;
+
       static bool harmonyPlayDisableCompatibility;
       static bool harmonyPlayDisableNew;
       static bool playRepeats;

--- a/libmscore/slur.cpp
+++ b/libmscore/slur.cpp
@@ -272,20 +272,28 @@ void SlurSegment::computeBezier(QPointF p6o)
       double smallH = 0.5;
       qreal d = p2.x() / _spatium;
       if (d <= 2.0) {
-            shoulderH = d * 0.5 * smallH * _spatium;
+            shoulderH = (d * 0.5 * smallH * _spatium) * MScore::slurShoulderExtraMin;
             shoulderW = .6;
             }
       else {
-            qreal dd = log10(1.0 + (d - 2.0) * .5) * 2.0;
-            if (dd > 3.0)
-                  dd = 3.0;
+            qreal dd = log10(1.0 + (d - 2.0) * .5) * 2.0 * MScore::slurShoulderExtraMax;
             shoulderH = (dd + smallH) * _spatium + _extraHeight;
-            if (d > 18.0)
-                  shoulderW = 0.7; // 0.8;
+
+            if (d < 10)
+                  shoulderH *= 0.70;
+            else if (d < 20)
+                  shoulderH *= 0.75;
+            else if (d > 70)
+                  shoulderH *= 1.25;
+
+            if (d > 60)
+                  shoulderW = 0.8;
+            else if (d > 18.0)
+                  shoulderW = 0.7;
             else if (d > 10)
-                  shoulderW = 0.6; // 0.7;
+                  shoulderW = 0.6;
             else
-                  shoulderW = 0.5; // 0.6;
+                  shoulderW = 0.5;
             }
 
       shoulderH -= p6o.y();

--- a/libmscore/slur.cpp
+++ b/libmscore/slur.cpp
@@ -1226,6 +1226,44 @@ SpannerSegment* Slur::layoutSystem(System* system)
       }
 
 //---------------------------------------------------------
+//   layoutSystem
+//    Taking a slurSegment, this function is practically the
+//    same as above without needing to create any segments,
+//    for finalization of cross-staff slur placement
+//---------------------------------------------------------
+
+void Slur::layoutSystem(System* system, SlurSegment* slurSegment)
+      {
+      SlurPos sPos;
+      slurPos(&sPos);
+      qreal extraXMargin = (score()->styleP(Sid::slurEndWidth));
+
+      // TODO: yOffset when spanning slur across systems, based on p1/p2 positions
+      qreal yOffsetSystemSpan = spatium() * 1.66;
+      yOffsetSystemSpan *= (_up ? -1.0 : +1.0);
+      yOffsetSystemSpan = 0.0; // for now, do nothing
+
+      switch (slurSegment->spannerSegmentType()) {
+            case SpannerSegmentType::SINGLE:
+                  slurSegment->layoutSegment(sPos.p1, sPos.p2);
+                  break;
+            case SpannerSegmentType::BEGIN:
+                  slurSegment->layoutSegment(sPos.p1, QPointF(system->lastNoteRestSegmentX(true) + extraXMargin, sPos.p1.y() + yOffsetSystemSpan));
+                  break;
+            case SpannerSegmentType::MIDDLE: {
+                  qreal x1 = system->firstNoteRestSegmentX(true);
+                  qreal x2 = system->lastNoteRestSegmentX(true) + extraXMargin;
+                  qreal y  = staffIdx() > system->staves()->size() ? system->y() : system->staff(staffIdx())->y();
+                  slurSegment->layoutSegment(QPointF(x1, y), QPointF(x2, y));
+                  }
+                  break;
+            case SpannerSegmentType::END:
+                  slurSegment->layoutSegment(QPointF(system->firstNoteRestSegmentX(true), sPos.p2.y() + yOffsetSystemSpan), sPos.p2);
+                  break;
+            }
+      }
+
+//---------------------------------------------------------
 //   layout
 //---------------------------------------------------------
 

--- a/libmscore/slur.cpp
+++ b/libmscore/slur.cpp
@@ -290,7 +290,38 @@ void SlurSegment::computeBezier(QPointF p6o)
 
       shoulderH -= p6o.y();
 
-      if (!slur()->up())
+      // Mid-point clamp for beam-side
+      auto scr = spanner()->startCR();
+      auto ecr = spanner()->endCR();
+      bool slurUp = slur()->up();
+      if (scr && ecr) {
+            bool sameChordDirection = scr->up() == ecr->up();
+            bool sameAsSlurDirection = scr->up() == slurUp;
+            if (sameChordDirection && sameAsSlurDirection) {
+                  // This method is obviously odd, but for now:
+                  // qDebug() << "Beamside slur distance =" << d;
+                  if (d < 4)
+                        shoulderH -= 0.0;
+                  else if (d < 8)
+                        shoulderH -= 5.0;
+                  else if (d < 10)
+                        shoulderH -= 10.0;
+                  else if (d < 15)
+                        shoulderH -= 20.0;
+                  else if (d < 20)
+                        shoulderH -= 35.0;
+                  else if (d < 30)
+                        shoulderH -= 50.0;
+                  else if (d < 40)
+                        shoulderH -= 55.0;
+                  else if (d < 55)
+                        shoulderH -= 55.0;
+                  else
+                        shoulderH -= 70;
+                  }
+            }
+
+      if (!slurUp)
             shoulderH = -shoulderH;
 
       qreal c    = p2.x();

--- a/libmscore/slur.h
+++ b/libmscore/slur.h
@@ -67,6 +67,7 @@ class Slur final : public SlurTie {
       bool readProperties(XmlReader&) override;
       void layout() override;
       SpannerSegment* layoutSystem(System*) override;
+      void layoutSystem(System* system, SlurSegment* slurSegment);
       void setTrack(int val) override;
       void slurPos(SlurPos*) override;
 

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -482,6 +482,9 @@ void updateExternalValuesFromPreferences() {
       MScore::highlightMore   = preferences.getBool(PREF_SCORE_PLAYBACK_HIGHLIGHT_MORE);  
       MScore::highlightLyrics = preferences.getBool(PREF_SCORE_PLAYBACK_HIGHLIGHT_LYRICS);
 
+      MScore::slurShoulderExtraMax = preferences.getDouble(PREF_UI_SCORE_SLURS_MAX_SHOULDER_EXTRA);
+      MScore::slurShoulderExtraMin = preferences.getDouble(PREF_UI_SCORE_SLURS_MIN_SHOULDER_EXTRA);
+
       MScore::setHRaster(preferences.getInt(PREF_UI_APP_RASTER_HORIZONTAL));
       MScore::setVRaster(preferences.getInt(PREF_UI_APP_RASTER_VERTICAL));
 

--- a/mscore/preferences.cpp
+++ b/mscore/preferences.cpp
@@ -292,6 +292,8 @@ void Preferences::init(bool storeInMemoryOnly)
             {PREF_UI_SCORE_VOICE4_COLOR,                           new ColorPreference(QColor(0xC31989))},
             {PREF_UI_SCORE_CURSOR_COLOR,                           new ColorPreference(QColor(0x0065BF))},
             {PREF_UI_SCORE_BRACKET_MULTIPLIER,                     new DoublePreference(0.25)},
+            {PREF_UI_SCORE_SLURS_MAX_SHOULDER_EXTRA,               new DoublePreference(1.8)}, // Use 1.0 for 3.6.2 equivalent
+            {PREF_UI_SCORE_SLURS_MIN_SHOULDER_EXTRA,               new DoublePreference(1.2)},
             {PREF_UI_THEME_ICONWIDTH,                              new IntPreference(28, false)},
             {PREF_UI_THEME_ICONHEIGHT,                             new IntPreference(24, false)},
             {PREF_UI_THEME_FONTFAMILY,                             new StringPreference(QApplication::font().family(), false) },


### PR DESCRIPTION
Advanced Preferences:
```cpp
ui/score/slurs/shoulder/extraHeight            
ui/score/slurs/shoulder/extraHeightSmall  
```
Naming could've been better probably. Setting to 1.0 should give the equivalent of 3.6.2, but defaults here coincide with some older decision (1.8/1.2)

+ Clamp down slightly the beam-side slurs depending on how large they are.

Sure the numbers calculations aren't perfect, but they'll do

+ Re-layout of cross-staff slurs - something like this must've been done in 4.x later, but never made it into 3.x

**For example, 3.6.2:**

![image](https://github.com/user-attachments/assets/181a890b-4903-4773-8e60-1c965806e364)


Whereas here:

![image](https://github.com/user-attachments/assets/82c74a4d-a296-4d4f-b4c6-a43cf0314651)

Not great, but better starting position to make changes (obviously doesn't take into account the middle notes and their height)

Demonstration of clamping (no big deal I suppose):
**3.6.2 (no clamp)**:

[362noclamp.webm](https://github.com/user-attachments/assets/dbe2a276-a9ed-4a71-9ebd-cfc4dacde490)


**With PR Changes**:

[clamp37.webm](https://github.com/user-attachments/assets/b2761064-c111-45e3-ae67-478a52ef89f2)
