### PR TITLE
Status Bar: Updates

### DIFF
--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -15,6 +15,7 @@
 #include <QDir>
 #include <QStandardPaths>
 #include <QStyleFactory>
+#include <QTimer>
 
 #include "accessibletoolbutton.h"
 #include "config.h"
@@ -1164,25 +1165,38 @@ MuseScore::MuseScore()
       panAction       = getAction("pan");
 
       _statusBar = new QStatusBar;
-      _statusBar->addPermanentWidget(new QWidget(this), 2);
-      _statusBar->addPermanentWidget(new QWidget(this), 100);
-      _statusBar->addPermanentWidget(_modeText, 0);
+            _statusBar->addPermanentWidget(new QWidget(this), 2);
+            _statusBar->addPermanentWidget(new QWidget(this), 100);
+            _statusBar->addPermanentWidget(_modeText, 0);
+      
+            searchCombo = new SearchComboBox;
+                  searchCombo->setObjectName("searchCombo");
+                  searchCombo->setParent(_statusBar);
 
-      if (enableExperimental) {
-            layerSwitch = new QComboBox(this);
-            layerSwitch->setToolTip(tr("Switch layer"));
-            connect(layerSwitch, SIGNAL(activated(QString)), SLOT(switchLayer(QString)));
-            playMode = new QComboBox(this);
-            playMode->addItem(tr("Synthesizer"));
-            playMode->addItem(tr("Audio track"));
-            playMode->setToolTip(tr("Switch play mode"));
-            connect(playMode, SIGNAL(activated(int)), SLOT(switchPlayMode(int)));
+                  _statusBar->addPermanentWidget(new QLabel(tr(" | ")));
+                  _statusBar->addPermanentWidget(new QLabel(tr("Find / Go to:")));
+                  _statusBar->addPermanentWidget(searchCombo);
 
-            _statusBar->addPermanentWidget(playMode);
-            _statusBar->addPermanentWidget(layerSwitch);
-            }
+                  connect(searchCombo->lineEdit(), SIGNAL(returnPressed()), SLOT(endSearch()));
+                  searchCombo->clearEditText();
+                  searchCombo->setFocus();
+                  _statusBar->setFocusProxy(searchCombo);
 
-      _statusBar->addPermanentWidget(_positionLabel, 0);
+            if (enableExperimental) {
+                  layerSwitch = new QComboBox(this);
+                  layerSwitch->setToolTip(tr("Switch layer"));
+                  connect(layerSwitch, SIGNAL(activated(QString)), SLOT(switchLayer(QString)));
+                  playMode = new QComboBox(this);
+                  playMode->addItem(tr("Synthesizer"));
+                  playMode->addItem(tr("Audio track"));
+                  playMode->setToolTip(tr("Switch play mode"));
+                  connect(playMode, SIGNAL(activated(int)), SLOT(switchPlayMode(int)));
+                  
+                  _statusBar->addPermanentWidget(playMode);
+                  _statusBar->addPermanentWidget(layerSwitch);
+                  }
+
+            _statusBar->addPermanentWidget(_positionLabel, 0);
 
       setStatusBar(_statusBar);
       ScoreAccessibility::createInstance(this);
@@ -4145,34 +4159,52 @@ bool MuseScore::eventFilter(QObject *obj, QEvent *event)
                   }
             case QEvent::StatusTip:
                   return true; // prevent updates to the status bar
-            case QEvent::KeyPress:
+            case QEvent::KeyPress: // Note: [Return] is not registered here
                   {
                   QKeyEvent* e = static_cast<QKeyEvent*>(event);
-                  if(obj->isWidgetType() && e->key() == Qt::Key_Escape && e->modifiers() == Qt::NoModifier) {
-                        // Close the search dialog when Escape is pressed:
-                        if(_searchDialog != 0)
-                              endSearch();
-                        if (isActiveWindow()) {
-                              obj->event(e);
-                              focusScoreView();
-                              return true;
-                              }
+                  if(obj->isWidgetType()) {
+                        if (e->key() == Qt::Key_Escape && e->modifiers() == Qt::NoModifier) {
+                              // Close the search dialog when Escape is pressed:
+                              if(_searchDialog != 0) {
+                                    endSearch();
+                                    }
+                              if (isActiveWindow()) {
+                                    obj->event(e);
+                                    focusScoreView();
+                                    return true;
+                                    }
 
-                        QWidget* w = static_cast<QWidget*>(obj);
-                        if (inspector()->isAncestorOf(w) ||
-                           (selectionWindow && selectionWindow->isAncestorOf(w))) {
-                              activateWindow();
-                              focusScoreView();
-                              return true;
+                              QWidget* w = static_cast<QWidget*>(obj);
+                              if (inspector()->isAncestorOf(w) ||
+                                    (selectionWindow && selectionWindow->isAncestorOf(w))) {
+                                    activateWindow();
+                                    focusScoreView();
+                                    return true;
+                                    }
+                              }
+                        else if (obj->objectName()=="searchCombo") {
+                              obj->event(e);
+                              // Keep focus unless "accepting" via return/enter
+                              statusBar()->setFocus();
+                              if (e->key() != Qt::Key_Return && e->key() != Qt::Key_Enter)
+                                    return true;
                               }
                         }
                   break;
                   }
             case QEvent::ShortcutOverride:
-                  if (qobject_cast<QMenu*>(obj)) {
+                  {
+                  QKeyEvent* ke = static_cast<QKeyEvent*>(event);
+                  if (obj->objectName()=="searchCombo") {
+                        if (ke->key() == Qt::Key_Return) {
+                              endSearch();
+                              ke->accept();
+                              break;
+                              }
+                        }
+                  else if (qobject_cast<QMenu*>(obj)) {
                         // Disable one-letter shortcuts while in menu
                         // to prevent blocking menu mnemonics
-                        QKeyEvent* ke = static_cast<QKeyEvent*>(event);
                         const QString evtText = ke->text();
                         const bool letterOrNumber = !ke->modifiers() && evtText.size() == 1 && evtText.at(0).isLetterOrNumber();
 
@@ -4182,6 +4214,7 @@ bool MuseScore::eventFilter(QObject *obj, QEvent *event)
                               }
                         }
                   break;
+                  }
             default:
                   return QMainWindow::eventFilter(obj, event);
             }
@@ -7031,7 +7064,12 @@ void MuseScore::updateDrumTools(const Drumset* ds)
 
 void MuseScore::endSearch()
       {
-      _searchDialog->hide();
+      if (_searchDialog)
+            _searchDialog->hide();
+      if (searchCombo) {
+            auto txt = searchCombo->currentText();
+            searchCombo->editTextChanged(txt);
+            }
       if (cv)
             cv->setFocus();
       }
@@ -7042,6 +7080,7 @@ void MuseScore::endSearch()
 
 void MuseScore::showSearchDialog()
       {
+      #if 0 // Using status bar instead
       if (_searchDialog == 0) {
             _searchDialog = new QWidget;
             _searchDialog->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Maximum);
@@ -7068,10 +7107,14 @@ void MuseScore::showSearchDialog()
 
             connect(searchCombo->lineEdit(), SIGNAL(returnPressed()), SLOT(endSearch()));
             }
+      #endif
 
-      searchCombo->clearEditText();
-      searchCombo->setFocus();
-      _searchDialog->show();
+      int delay = 55; // msec
+      // Hack: scoreview re-focuses directly after endCmd(), ergo time delay:
+      QTimer::singleShot(delay, this, [&]() {
+            searchCombo->setFocus();
+            searchCombo->lineEdit()->selectAll();
+            });
       }
 
 

--- a/mscore/scoreaccessibility.cpp
+++ b/mscore/scoreaccessibility.cpp
@@ -239,24 +239,32 @@ void ScoreAccessibility::currentInfoChanged()
             if (!e) {
                   return;
                   }
-            Element* el = e->isSpannerSegment() ? static_cast<SpannerSegment*>(e)->spanner() : e;
+
+            Element* el = e->isSpannerSegment() ? toSpannerSegment(e)->spanner() : e;
             QString barsAndBeats = "";
             QString optimizedBarsAndBeats = "";
-            if (el->isSpanner()) {
-                  Spanner* s = static_cast<Spanner*>(el);
+            Spanner* s = el->isSpanner() ? toSpanner(el) : nullptr;
+            if (s && s->startSegment()) { 
                   std::pair<int, float> bar_beat = s->startSegment()->barbeat();
                   barsAndBeats += " " + tr("Start Measure: %1; Start Beat: %2").arg(QString::number(bar_beat.first)).arg(QString::number(bar_beat.second));
                   Segment* seg = s->endSegment();
-                  if(!seg)
+                  if (!seg)
                         seg = score->lastSegment()->prev1MM(SegmentType::ChordRest);
 
-                  if (seg->tick() != score->lastSegment()->prev1MM(SegmentType::ChordRest)->tick() &&
+                  if (seg && seg->tick() != score->lastSegment()->prev1MM(SegmentType::ChordRest)->tick() &&
                       s->type() != ElementType::SLUR                                               &&
                       s->type() != ElementType::TIE                                                )
                         seg = seg->prev1MM(SegmentType::ChordRest);
 
+                  if (!seg) { 
+                        seg = s->endSegment();
+                        if (!seg)
+                              return;
+                        }
+
                   bar_beat = seg->barbeat();
                   barsAndBeats += "; " + tr("End Measure: %1; End Beat: %2").arg(QString::number(bar_beat.first)).arg(QString::number(bar_beat.second));
+                  barsAndBeats += "; Ticks: " + s->tick().print() + " - " + s->tick2().print();
                   optimizedBarsAndBeats = barsAndBeats;
                   }
             else {
@@ -270,6 +278,7 @@ void ScoreAccessibility::currentInfoChanged()
                               barsAndBeats += "; " + tr("Beat: %1").arg(QString::number(bar_beat.second));
                               optimizedBarsAndBeats += "; " + tr("Beat: %1").arg(QString::number(bar_beat.second));
                               }
+                        barsAndBeats += "; Tick: " + el->tick().print();
                         }
                   }
 

--- a/mscore/scoreaccessibility.cpp
+++ b/mscore/scoreaccessibility.cpp
@@ -199,6 +199,9 @@ ScoreAccessibility::ScoreAccessibility(QMainWindow* mainWindow) : QObject(mainWi
       {
       this->mainWindow = mainWindow;
       statusBarLabel = new QLabel(mainWindow->statusBar());
+      int maxHeight = statusBarLabel->height();
+      statusBarLabel->setFixedHeight(maxHeight);
+      statusBarLabel->setMaximumHeight(maxHeight);
       mainWindow->statusBar()->addWidget(statusBarLabel);
       }
 
@@ -309,6 +312,8 @@ void ScoreAccessibility::currentInfoChanged()
                   }
 
             statusBarLabel->setText(rez.simplified()); // no linebreaks in statusbar
+            makeReadable(rez);
+            statusBarLabel->setText(rez);
 
             if (scoreView->mscoreState() & STATE_ALLTEXTUAL_EDIT) {
                   // Don't say element name during text editing.
@@ -431,6 +436,59 @@ void ScoreAccessibility::updateAccessibility()
 
 void ScoreAccessibility::makeReadable(QString& s)
       {
+      QString pre  = "<font face=\"bravura text\" size=\"6\">";
+      QString pre3 = "<font face=\"bravura text\" size=\"3\">";
+      QString post = " </font>";
+      static std::vector<std::pair<QString, QString>> statusBarUnicodeReplacements {
+            // These were printing out as curly braces or other non-musical symbols,
+            // sometimes making status bar vertically large
+            // TODO? Wildcard replacement for SMuFL
+            { "\U0000E260", pre3+"♭"+post },
+            { "\U0000E261", pre3+"♮"+post },
+            { "\U0000E262", pre3+"♯"+post },
+            { "\U0000E263", pre +"𝄪"+post },
+            { "\U0000E264", pre +"𝄫"+post },
+            // Copy and paste of symbols from program will also work:
+            { "", pre+""+post },
+            { "", pre+""+post },
+            { "", pre+""+post },
+            { "", pre+""+post },
+            { "", pre+""+post },
+            { "", pre+""+post },
+            { "", pre+""+post },
+            { "", pre+""+post },
+            { "", pre+""+post },
+            { "", pre+""+post },
+            { "", pre+""+post },
+            { "", pre+""+post },
+            { "", pre+""+post },
+            { "", pre+""+post },
+            { "", pre+""+post },
+            { "", pre+""+post },
+            { "", pre+""+post },
+            { "", pre+""+post },
+            { "", pre+""+post },
+            { "", pre+""+post },
+            { "", pre+""+post },
+            { "", pre+""+post },
+            { "", pre+""+post },
+            { "", pre+""+post },
+            { "", pre+""+post },
+            { "", pre+""+post },
+            { "", pre+""+post },
+            { "", pre+""+post },
+            { "", pre+""+post },
+            { "", pre+""+post },
+            { "", pre+""+post },
+            { "", pre+""+post },
+            { "", pre+""+post },
+            { "", pre+""+post },
+            { "", pre+""+post },
+            { "", pre+""+post },
+            { "", pre+""+post },
+            { "", pre+""+post },
+      };
+
       static std::vector<std::pair<QString, QString>> unicodeReplacements {
             { "♭", " " + tr("flat") },
             { "♮", " " + tr("natural") },
@@ -439,10 +497,15 @@ void ScoreAccessibility::makeReadable(QString& s)
             { "𝄪", " " + tr("double sharp") },
       };
 
+      for (auto const &r : statusBarUnicodeReplacements)
+            s.replace(r.first, r.second);
+
       if (!QAccessible::isActive())
             return;
+
       for (auto const &r : unicodeReplacements)
             s.replace(r.first, r.second);
+
       ScoreFont* sf = gscore->scoreFont();
       for (auto id : Sym::commonScoreSymbols) {
             if (id == SymId::space)

--- a/mscore/searchComboBox.cpp
+++ b/mscore/searchComboBox.cpp
@@ -63,6 +63,8 @@ void SearchComboBox::searchTextChanged(const QString& s)
             }
       //updating status bar
       ScoreAccessibility::instance()->updateAccessibilityInfo();
+      if (cv->score())
+            mscore->setPos(cv->score()->inputState().tick());
       emit currentSearchFinished();
       }
 


### PR DESCRIPTION
**+ Search Function now is permanently part of status-bar (bottom-right)**:

![image](https://github.com/user-attachments/assets/ab4aa531-477a-4b54-b923-4d4e1b1c7a97)

+ **Status Bar will include Fractional Tick of element after showing Beat** (mainly for development/testing purposes)

![image](https://github.com/user-attachments/assets/4ab4ed86-daec-4328-81f3-722ba534a6b2)


+ **Text in Status bar will show certain SMuFL characters instead of incorrect items from the Common Symbols tab of Special Character set**

**This update:**

![image](https://github.com/user-attachments/assets/9d8048a9-bf69-429f-9ed3-94cdf9f6efe3)

**Instead of old 3.6.2**:

![image](https://github.com/user-attachments/assets/4474ddde-145f-4ab7-b4ca-14b52415d3e1)

