### PR TITLE
Text Line: Let Element Color apply to texts to distinguish between line color

### DIFF
--- a/libmscore/line.cpp
+++ b/libmscore/line.cpp
@@ -707,7 +707,8 @@ void LineSegment::localSpatiumChanged(qreal ov, qreal nv)
 Element* LineSegment::propertyDelegate(Pid pid)
       {
       if (pid == Pid::DIAGONAL
-         || pid == Pid::COLOR
+         || pid ==   Pid::LINE_COLOR
+         || pid ==   Pid::COLOR
          || pid ==   Pid::LINE_WIDTH
          || pid ==   Pid::LINE_STYLE
          || pid ==   Pid::DASH_LINE_LEN
@@ -755,6 +756,7 @@ SLine::SLine(const SLine& s)
       _diagonal    = s._diagonal;
       _lineWidth   = s._lineWidth;
       _lineColor   = s._lineColor;
+      _color       = s._color;
       _lineStyle   = s._lineStyle;
       _dashLineLen = s._dashLineLen;
       _dashGapLen  = s._dashGapLen;
@@ -1226,6 +1228,7 @@ void SLine::writeProperties(XmlWriter& xml) const
             xml.tag("diagonal", _diagonal);
       writeProperty(xml, Pid::LINE_WIDTH);
       writeProperty(xml, Pid::LINE_STYLE);
+      writeProperty(xml, Pid::LINE_COLOR);
       writeProperty(xml, Pid::ANCHOR);
       writeProperty(xml, Pid::DASH_LINE_LEN);
       writeProperty(xml, Pid::DASH_GAP_LEN);
@@ -1324,8 +1327,6 @@ bool SLine::readProperties(XmlReader& e)
             _dashGapLen = e.readDouble();
       else if (tag == "lineColor")
             _lineColor = e.readColor();
-      else if (tag == "color")
-            _lineColor = e.readColor();
       else if (!Spanner::readProperties(e))
             return false;
       return true;
@@ -1396,8 +1397,10 @@ QVariant SLine::getProperty(Pid id) const
       switch (id) {
             case Pid::DIAGONAL:
                   return _diagonal;
-            case Pid::COLOR:
+            case Pid::LINE_COLOR:
                   return _lineColor;
+            case Pid::COLOR:
+                  return _color;
             case Pid::LINE_WIDTH:
                   return _lineWidth;
             case Pid::LINE_STYLE:
@@ -1421,8 +1424,11 @@ bool SLine::setProperty(Pid id, const QVariant& v)
             case Pid::DIAGONAL:
                   _diagonal = v.toBool();
                   break;
-            case Pid::COLOR:
+            case Pid::LINE_COLOR:
                   _lineColor = v.value<QColor>();
+                  break;
+            case Pid::COLOR:
+                  _color = v.value<QColor>();
                   break;
             case Pid::LINE_WIDTH:
                   _lineWidth = v.toReal();
@@ -1452,7 +1458,7 @@ QVariant SLine::propertyDefault(Pid pid) const
       switch (pid) {
             case Pid::DIAGONAL:
                   return false;
-            case Pid::COLOR:
+            case Pid::LINE_COLOR:
                   return MScore::defaultColor;
             case Pid::LINE_WIDTH:
                   if (propertyFlags(pid) != PropertyFlags::NOSTYLE)

--- a/libmscore/property.cpp
+++ b/libmscore/property.cpp
@@ -194,6 +194,7 @@ static constexpr PropertyMetaData propertyList[] = {
       { Pid::LINE_STYLE,              true,  "lineStyle",             P_TYPE::INT,                 DUMMY_QT_TRANSLATE_NOOP("propertyName", "line style")       },
       { Pid::LINE_WIDTH,              false, "lineWidth",             P_TYPE::SP_REAL,             DUMMY_QT_TRANSLATE_NOOP("propertyName", "line width")       },
       { Pid::LINE_WIDTH_SPATIUM,      false, "lineWidth",             P_TYPE::SPATIUM,             DUMMY_QT_TRANSLATE_NOOP("propertyName", "line width (spatium)") },
+      { Pid::LINE_COLOR,              false, "lineColor",             P_TYPE::COLOR,               DUMMY_QT_TRANSLATE_NOOP("propertyName", "line color")       },
       { Pid::LASSO_POS,               false, 0,                       P_TYPE::POINT_MM,            DUMMY_QT_TRANSLATE_NOOP("propertyName", "lasso position")   },
       { Pid::LASSO_SIZE,              false, 0,                       P_TYPE::SIZE_MM,             DUMMY_QT_TRANSLATE_NOOP("propertyName", "lasso size")       },
       { Pid::TIME_STRETCH,            true,  "timeStretch",           P_TYPE::REAL,                DUMMY_QT_TRANSLATE_NOOP("propertyName", "time stretch")     },

--- a/libmscore/property.h
+++ b/libmscore/property.h
@@ -200,6 +200,7 @@ enum class Pid {
       LINE_STYLE,
       LINE_WIDTH,
       LINE_WIDTH_SPATIUM,
+      LINE_COLOR,
       LASSO_POS,
       LASSO_SIZE,
       TIME_STRETCH,

--- a/libmscore/spanner.cpp
+++ b/libmscore/spanner.cpp
@@ -127,7 +127,7 @@ QByteArray SpannerSegment::mimeData(const QPointF& dragOffset) const
 
 Element* SpannerSegment::propertyDelegate(Pid pid)
       {
-      if (pid == Pid::COLOR || pid == Pid::VISIBLE || pid == Pid::PLACEMENT)
+      if (pid == Pid::LINE_COLOR || pid == Pid::VISIBLE || pid == Pid::PLACEMENT)
             return spanner();
       return 0;
       }

--- a/libmscore/textlinebase.cpp
+++ b/libmscore/textlinebase.cpp
@@ -73,6 +73,7 @@ void TextLineBaseSegment::setSelected(bool f)
 void TextLineBaseSegment::draw(QPainter* painter) const
       {
       TextLineBase* tl = textLineBase();
+      QColor lineColor = curColor(tl->visible() && tl->lineVisible(), tl->lineColor());      
       QColor textColor = tl->color();
 
       // Playback marked color:
@@ -93,20 +94,21 @@ void TextLineBaseSegment::draw(QPainter* painter) const
                   }
             }
 
-      _text->setColor(textColor);
-      _endText->setColor(textColor);
-
       if (!_text->empty()) {
-            painter->translate(_text->pos());
             _text->setVisible(tl->visible());
-            _text->draw(painter);
+            _text->setColor(textColor);
+
+            painter->translate(_text->pos());
+               _text->draw(painter);
             painter->translate(-_text->pos());
             }
 
       if (!_endText->empty()) {
-            painter->translate(_endText->pos());
             _endText->setVisible(tl->visible());
-            _endText->draw(painter);
+            _endText->setColor(textColor);
+
+            painter->translate(_endText->pos());
+               _endText->draw(painter);
             painter->translate(-_endText->pos());
             }
 
@@ -121,13 +123,12 @@ void TextLineBaseSegment::draw(QPainter* painter) const
       else
             color = tl->lineColor();
 #endif
-      QColor color = curColor(tl->visible() && tl->lineVisible(), tl->lineColor());
 
       qreal textlineLineWidth = tl->lineWidth();
       if (staff())
             textlineLineWidth *= mag();
-      QPen pen(color, textlineLineWidth, tl->lineStyle());
-      QPen solidPen(color, textlineLineWidth, Qt::SolidLine);
+      QPen pen(lineColor, textlineLineWidth, tl->lineStyle());
+      QPen solidPen(lineColor, textlineLineWidth, Qt::SolidLine);
 
       //Replace generic Qt dash patterns with improved equivalents to show true dots
       QVector<qreal> dotted        = { 0.01, 1.99 }; // 0.01 for cap dots. tighter than default Qt Dotline (would be { 0.01, 2.99 }). 
@@ -268,6 +269,7 @@ void TextLineBaseSegment::layout()
       {
       npoints      = 0;
       TextLineBase* tl = textLineBase();
+      QColor textColor = tl->color();
       qreal _spatium = tl->spatium();
       bool isSingleOrBegin = isSingleBeginType();
 
@@ -305,7 +307,7 @@ void TextLineBaseSegment::layout()
             }
       _text->setPlacement(Placement::ABOVE);
       _text->setTrack(track());
-      _text->setColor(textLineBase()->lineColor());
+      _text->setColor(textColor);
       _text->layout();
 
       if ((isSingleType() || isEndType())) {
@@ -320,7 +322,7 @@ void TextLineBaseSegment::layout()
             _endText->setStrike(tl->endFontStyle() & FontStyle::Strike);
             _endText->setPlacement(Placement::ABOVE);
             _endText->setTrack(track());
-            _endText->setColor(textLineBase()->lineColor());
+            _endText->setColor(textColor);
             _endText->layout();
             }
       else {

--- a/mscore/inspector/inspectorTextLineBase.cpp
+++ b/mscore/inspector/inspectorTextLineBase.cpp
@@ -57,7 +57,7 @@ InspectorTextLineBase::InspectorTextLineBase(QWidget* parent)
       const std::vector<InspectorItem> iiList = {
             { Pid::DIAGONAL,                0, l.diagonal,                l.resetDiagonal              },
             { Pid::LINE_VISIBLE,            0, l.lineVisible,             l.resetLineVisible           },
-            { Pid::COLOR,                   0, l.lineColor,               l.resetLineColor             },
+            { Pid::LINE_COLOR,              0, l.lineColor,               l.resetLineColor             },
             { Pid::LINE_WIDTH,              0, l.lineWidth,               l.resetLineWidth             },
             { Pid::LINE_STYLE,              0, l.lineStyle,               l.resetLineStyle             },
             { Pid::DASH_LINE_LEN,           0, l.dashLineLength,          l.resetDashLineLength        },
@@ -198,7 +198,7 @@ void InspectorTextLineBase::valueChanged(int idx)
             updateBeginHookType();
       else if (iList[idx].t == Pid::END_HOOK_TYPE)
             updateEndHookType();
-      else if (iList[idx].t == Pid::COLOR)
+      else if (iList[idx].t == Pid::LINE_COLOR)
             inspector->update();
       }
 


### PR DESCRIPTION
This will apply to start/continue/end text:

![image](https://github.com/user-attachments/assets/6e26904c-e7df-4dbb-be67-e5f015641d4f)

And of course this will apply to the line itself + hooks
![image](https://github.com/user-attachments/assets/0c936594-35e7-4af2-a97f-efa7824d325a)


