### PR TITLE
Grip Nodes: Allow numeric 1-2-3-4 for start-drag-shoulder-end selection as alternative to tabbing cylcle

### DIFF
--- a/libmscore/element.cpp
+++ b/libmscore/element.cpp
@@ -2013,6 +2013,16 @@ bool Element::prevGrip(EditData& ed) const
       }
 
 //---------------------------------------------------------
+//   setGrip
+//---------------------------------------------------------
+
+bool Element::setGrip(EditData& ed, Grip g) const
+      {
+      ed.curGrip = Grip(g);
+      return true;
+      }
+
+//---------------------------------------------------------
 //   isUserModified
 //    Check if this element was modified by user and
 //    therefore must be saved.

--- a/libmscore/element.h
+++ b/libmscore/element.h
@@ -340,6 +340,7 @@ class Element : public ScoreElement {
       void updateGrips(EditData&) const;
       virtual bool nextGrip(EditData&) const;
       virtual bool prevGrip(EditData&) const;
+      virtual bool setGrip(EditData&, Grip) const;
       /** Returns anchor lines displayed while dragging element's grip in canvas coordinates. */
       virtual QVector<QLineF> gripAnchorLines(Grip) const     { return QVector<QLineF>(); }
 

--- a/mscore/events.cpp
+++ b/mscore/events.cpp
@@ -46,8 +46,14 @@ bool ScoreView::event(QEvent* event)
             case QEvent::KeyPress: {
                   QKeyEvent* ke = static_cast<QKeyEvent*>(event);
                   const int key = ke->key();
-                  if (key != Qt::Key_Tab && key != Qt::Key_Backtab)
+                  if (key != Qt::Key_Tab &&
+                      key != Qt::Key_Backtab &&
+                      key != Qt::Key_1 &&
+                      key != Qt::Key_2 &&
+                      key != Qt::Key_3 &&
+                      key != Qt::Key_4) {
                         break;
+                        }
 
                   if (textEditMode()) {
                         // Allow [tabbing] forward/backward in fingering-mode
@@ -56,10 +62,30 @@ bool ScoreView::event(QEvent* event)
                         }
 
                   if (hasEditGrips() || editMode()) {
-                        if (ke->key() == Qt::Key_Tab)
+                        int gCount = editData.element->gripsCount();
+                        if (ke->key() == Qt::Key_1) {
+                              editData.element->setGrip(editData, Grip::START);
+                              }
+                        else if (ke->key() == Qt::Key_2) {
+                              Grip g = (gCount == 3) ? Grip::MIDDLE : Grip::DRAG;
+                              if (gCount == 4) g = Grip::SHOULDER;
+                              editData.element->setGrip(editData, g);
+                              }
+                        else if (ke->key() == Qt::Key_3) {
+                              Grip g = (gCount == 3) ? Grip::MIDDLE : Grip::SHOULDER;
+                              if (gCount == 4) g = Grip::MIDDLE;
+                              editData.element->setGrip(editData, g);
+                              }
+                        else if (ke->key() == Qt::Key_4) {
+                              editData.element->setGrip(editData, Grip::END);
+                              }
+                        else if (ke->key() == Qt::Key_Tab) {
                               editData.element->nextGrip(editData);
-                        else
+                              }
+                        else {
                               editData.element->prevGrip(editData);
+                              }
+
                         updateGrips();
                         _score->update();
                         return true;
@@ -87,6 +113,15 @@ bool ScoreView::event(QEvent* event)
                                     return true;
                                     }
                               }
+                              break;
+                        case Qt::Key_1 :
+                        case Qt::Key_2 :
+                        case Qt::Key_3 :
+                        case Qt::Key_4 :
+                              if (!hasEditGrips())
+                                    break;
+                              ke->accept();
+                              return true;
                               break;
                         default:
                               break;


### PR DESCRIPTION
With these, the user can get in the habit of knowing on a single-press with the keyboard which node will be selected instead of having to follow a tab-based order

1: Start
4: End
3: Middle (e.g. the expanse of a slur)
2: Shoulder (e.g. to move the entire segment)
