### PR TITLE
Layout: Arpeggio no longer sinks into accidentals when spanning staves

### DIFF
--- a/libmscore/arpeggio.cpp
+++ b/libmscore/arpeggio.cpp
@@ -442,6 +442,7 @@ bool Arpeggio::edit(EditData& ed)
       Chord* c = chord();
       rxpos() = -(width() + spatium() * .5);
       c->layoutArpeggio2();
+      c->triggerLayout();
       return true;
       }
 


### PR DESCRIPTION
This would only happen temporarily until next score layout, but it's still an annoyance and only requires an extra layout of the arpeggio's chord to eliminate.

**3.6.2**:

[arpeggioSpan.webm](https://github.com/user-attachments/assets/25aca478-559b-45e8-ad40-25592ab65ad3)
