### PR TITLE
Layout [Compromise]: Arpeggio - Relayout normal arpeggios to be more symmetrical to chords

### DIFF
--- a/libmscore/arpeggio.cpp
+++ b/libmscore/arpeggio.cpp
@@ -138,30 +138,27 @@ qreal Arpeggio::calcTop() const
       if (!parent())
             return top;
 
+      int  upNoteLine       = chord()->upNote(false)->line();
+      int  downNoteLine     = chord()->downNote(false)->line();
+      bool differenceIsEven = (upNoteLine + downNoteLine + 1) % 2;
+      float redux           = 0.50;
+
       switch (arpeggioType()) {
             case ArpeggioType::BRACKET: {
-                  qreal lineWidth = score()->styleP(Sid::arpeggioLineWidth);
-                  return top - lineWidth / 2.0;
+                  top -= (score()->styleP(Sid::arpeggioLineWidth) * redux);
+                  redux = differenceIsEven ? 0.65 : 0.45;
+                  top += (spatium() * redux);
+                  break;
                   }
             case ArpeggioType::NORMAL:
             case ArpeggioType::UP:
-            case ArpeggioType::DOWN: {
-                  // if the top is in the staff on a space, move it up
-                  // if the bottom note is on a line, the distance is 0.25 spaces
-                  // if the bottom note is on a space, the distance is 0.5 spaces
-                  int topNoteLine = chord()->upNote()->line();
-                  int lines = staff()->lines(tick());
-                  int bottomLine = (lines - 1) * 2;
-                  if (topNoteLine <= 0 || topNoteLine % 2 == 0 || topNoteLine >= bottomLine)
-                        return top;
-                  int downNoteLine = chord()->downNote()->line();
-                  if (downNoteLine % 2 == 1 && downNoteLine < bottomLine)
-                        return top - 0.4 * spatium();
-                  return top - 0.25 * spatium();
-                  }
+            case ArpeggioType::DOWN:
+                  redux = differenceIsEven ? 0.35 : 0.15;
+                  top -= (spatium() * redux);
             default:
-                  return top - spatium() / 4;
+                  break;
             }
+      return top;
       }
 
 //---------------------------------------------------------

--- a/libmscore/chord.cpp
+++ b/libmscore/chord.cpp
@@ -64,7 +64,7 @@ struct LedgerLineData {
 //   upNote
 //---------------------------------------------------------
 
-Note* Chord::upNote() const
+Note* Chord::upNote(bool omitInvisible) const
       {
       Q_ASSERT(!_notes.empty());
 
@@ -94,6 +94,16 @@ Note* Chord::upNote() const
                         }
                   }
             }
+
+      if (omitInvisible && !result->visible()) {
+            std::vector<Note*> copy = _notes;
+            while (!copy.empty() && !copy.back()->visible()) {
+                  copy.pop_back();
+                  }
+            if (!copy.empty())
+                  result = copy.back();
+            }
+
       return result;
       }
 
@@ -101,7 +111,7 @@ Note* Chord::upNote() const
 //   downNote
 //---------------------------------------------------------
 
-Note* Chord::downNote() const
+Note* Chord::downNote(bool omitInvisible) const
       {
       Q_ASSERT(!_notes.empty());
 
@@ -131,6 +141,16 @@ Note* Chord::downNote() const
                         }
                   }
             }
+      if (omitInvisible && !result->visible()) {
+            std::vector<Note*> copy = _notes;
+            std::reverse(copy.begin(), copy.end());
+            while (!copy.empty() && !copy.back()->visible()) {
+                  copy.pop_back();
+                  }
+            if (!copy.empty())
+                  result = copy.back();
+            }
+
       return result;
       }
 
@@ -140,13 +160,24 @@ Note* Chord::downNote() const
 
 int Chord::upLine() const
       {
-      return onTabStaff() ? upString()*2 : upNote()->line();
+      return onTabStaff() ? upString()*2 : upNote(false)->line();
       }
 
 int Chord::downLine() const
       {
-      return onTabStaff() ? downString()*2 : downNote()->line();
+      return onTabStaff() ? downString()*2 : downNote(false)->line();
       }
+
+int Chord::upLine(bool omitInvisible) const
+      {
+      return onTabStaff() ? upString()*2 : upNote(omitInvisible)->line();
+      }
+
+int Chord::downLine(bool omitInvisible) const
+      {
+      return onTabStaff() ? downString()*2 : downNote(omitInvisible)->line();
+      }
+
 
 //---------------------------------------------------------
 //   upString / downString
@@ -398,12 +429,12 @@ QPointF Chord::stemPos() const
             return st->chordStemPos(this) * spatium() + p;
 
       if (_up) {
-            qreal nhw = _notes.size() == 1 ? downNote()->bboxRightPos() : noteHeadWidth();
+            qreal nhw = _notes.size() == 1 ? downNote(true)->bboxRightPos() : noteHeadWidth();
             p.rx() += nhw;
-            p.ry() += downNote()->pos().y();
+            p.ry() += downNote(false)->pos().y();
             }
       else
-            p.ry() += upNote()->pos().y();
+            p.ry() += upNote(false)->pos().y();
       return p;
       }
 
@@ -427,10 +458,10 @@ QPointF Chord::stemPosBeam() const
       if (_up) {
             qreal nhw = noteHeadWidth();
             p.rx() += nhw;
-            p.ry() += upNote()->pos().y();
+            p.ry() += upNote(false)->pos().y();
             }
       else
-            p.ry() += downNote()->pos().y();
+            p.ry() += downNote(false)->pos().y();
 
       return p;
       }
@@ -835,7 +866,22 @@ void Chord::addLedgerLines()
                         LedgerLine* h = new LedgerLine(score());
                         h->setParent(this);
                         h->setTrack(track);
-                        h->setVisible(lld.visible && staffVisible);
+                        // Override visibility attributes to include within visible note spectrum:
+                        bool vis = false;
+                        bool belowStaffLedgers = (j == 0);
+                        if (belowStaffLedgers) {
+                              auto n = downNote(true);
+                              if (n->line() >= lld.line && n->visible())
+                                    vis = true;
+                              }
+                        else {
+                              // Above staff ledgers:
+                              auto n = upNote(true);
+                              if (n->line() <= lld.line && n->visible())
+                                    vis = true;
+                              }
+
+                        h->setVisible(vis && staffVisible);
                         h->setLen(lld.maxX - lld.minX);
                         h->setPos(lld.minX, lld.line * _spatium * stepDistance);
                         h->setNext(_ledgerLines);
@@ -908,7 +954,7 @@ void Chord::computeUp()
             _up = _stemDirection == Direction::UP;
       else if (!parent())
             // hack for palette and drumset editor
-            _up = upNote()->line() > 4;
+            _up = upNote(true)->line() > 4;
       else if (_noteType != NoteType::NORMAL) {
             //
             // stem direction for grace notes
@@ -924,7 +970,7 @@ void Chord::computeUp()
             _up = !(track() % 2);
       else {
             int   dnMaxLine   = staff()->middleLine(tick());
-            int   ud          = (tabStaff ? upString() * 2 : upNote()->line() ) - dnMaxLine;
+            int   ud          = (tabStaff ? upString() * 2 : upNote(true)->line() ) - dnMaxLine;
             // standard case: if only 1 note or cross beaming
             if (_notes.size() == 1 || staffMove()) {
                   if (staffMove() > 0)
@@ -936,7 +982,7 @@ void Chord::computeUp()
                   }
             // if more than 1 note, compare extrema (topmost and bottommost notes)
             else {
-                  int dd = (tabStaff ? downString() * 2 : downNote()->line() ) - dnMaxLine;
+                  int dd = (tabStaff ? downString() * 2 : downNote(true)->line() ) - dnMaxLine;
                   // if extrema symmetrical, average directions of intermediate notes
                   if (-ud == dd) {
                         int up = 0;
@@ -1156,7 +1202,7 @@ bool Chord::readProperties(XmlReader& e)
 
 qreal Chord::upPos() const
       {
-      return upNote()->pos().y();
+      return upNote(true)->pos().y();
       }
 
 //---------------------------------------------------------
@@ -1165,7 +1211,7 @@ qreal Chord::upPos() const
 
 qreal Chord::downPos() const
       {
-      return downNote()->pos().y();
+      return downNote(true)->pos().y();
       }
 
 //---------------------------------------------------------
@@ -1181,7 +1227,7 @@ qreal Chord::centerX() const
       if (stt->isTabStaff())
             return stt->chordStemPosX(this) * spatium();
 
-      const Note* note = up() ? upNote() : downNote();
+      const Note* note = up() ? upNote(true) : downNote(true);
       qreal x = note->pos().x() + note->noteheadCenterX();
       if (note->mirror())
                   x += (note->headBodyWidth()) * (up() ? -1.0 : 1.0);
@@ -1327,13 +1373,13 @@ qreal hookAdjustment(QString font, int hooks, bool up, bool isSmall)
 
 qreal Chord::defaultStemLength() const
       {
-      Note* downnote;
+      bool arp = arpeggio() ? true : false;
+      Note* downnote = arp ? downNote(true) : downNote(false);
       qreal stemLen;
       qreal _spatium     = spatium();
       int hookIdx        = durationType().hooks();
-      downnote           = downNote();
-      int ul             = upLine();
-      int dl             = downLine();
+      int ul             = arp ? upLine(true)   : upLine(false);
+      int dl             = arp ? downLine(true) : downLine(false);
       const Staff* st    = staff();
       qreal lineDistance = st ? st->lineDistance(tick()) : 1.0;
 
@@ -1477,7 +1523,6 @@ qreal Chord::minAbsStemLength() const
             const bool hasHook = beamLvl && !beam();
             if (hasHook)
                   beamLvl += (up() ? 3 : 2); // reserve more space for stem with both hook and tremolo
-            
             const qreal addHeight1 = beamLvl ? 0 : sw * spatium();
             // buzz roll needs to have additional space so as not to collide with the beam/hook
             const qreal addHeight2 = (_tremolo->isBuzzRoll() && beamLvl) ? sw * spatium() : 0;
@@ -1888,7 +1933,7 @@ void Chord::layoutPitched()
       qreal lll    = 0.0;         // space to leave at left of chord
       qreal rrr    = 0.0;         // space to leave at right of chord
       qreal lhead  = 0.0;         // amount of notehead to left of chord origin
-      Note* upnote = upNote();
+      Note* upnote = upNote(false);
 
       delete _tabDur;   // no TAB? no duration symbol! (may happen when converting a TAB into PITCHED)
       _tabDur = 0;
@@ -1909,7 +1954,7 @@ void Chord::layoutPitched()
             layoutStem1();
             if (_stem) { //false when dragging notes from drum palette
                   qreal stemWidth5 = _stem->lineWidth() * .5;
-                  _stem->rxpos()   = up() ? (upNote()->headBodyWidth() - stemWidth5) : stemWidth5;
+                  _stem->rxpos()   = up() ? (upnote->headBodyWidth() - stemWidth5) : stemWidth5;
                   }
             addLedgerLines();
             return;
@@ -2186,7 +2231,7 @@ void Chord::layoutTablature()
 
       qreal lll         = 0.0;                  // space to leave at left of chord
       qreal rrr         = 0.0;                  // space to leave at right of chord
-      Note* upnote      = upNote();
+      Note* upnote      = upNote(true);
       qreal headWidth   = symWidth(SymId::noteheadBlack);
       const Staff* st   = staff();
       const StaffType* tab = st->staffTypeForElement(this);
@@ -2405,8 +2450,8 @@ void Chord::layoutTablature()
             qreal headHeight = upnote->headHeight();
             _arpeggio->layout();
             lll += _arpeggio->width() + _spatium * .5;
-            qreal y = upNote()->pos().y() - headHeight * .5;
-            qreal h = downNote()->pos().y() + downNote()->headHeight() - y;
+            qreal y = upNote(true)->pos().y() - headHeight * .5;
+            qreal h = downNote(true)->pos().y() + downNote(true)->headHeight() - y;
             _arpeggio->setHeight(h);
             _arpeggio->setPos(-lll, y);
 
@@ -2577,15 +2622,15 @@ void Chord::layoutArpeggio2()
       {
       if (!_arpeggio)
             return;
-      qreal y           = upNote()->pagePos().y() - upNote()->headHeight() * .5;
+      qreal y           = upNote(false)->pagePos().y() - upNote(false)->headHeight() * .5;
       int span          = _arpeggio->span();
       int btrack        = track() + (span - 1) * VOICES;
 
       Element* element = segment()->element(btrack);
       ChordRest* bchord = element ? toChordRest(element) : nullptr;
-      Note* dnote       = (bchord && bchord->type() == ElementType::CHORD) ? toChord(bchord)->downNote() : downNote();
+      Note* dnote       = (bchord && bchord->type() == ElementType::CHORD) ? toChord(bchord)->downNote(false) : downNote(false);
 
-      qreal h = dnote->pagePos().y() + dnote->headHeight() * .5 - y;
+      qreal h = dnote->pagePos().y() - y;
       _arpeggio->setHeight(h);
       _arpeggio->layout();
 
@@ -2891,7 +2936,7 @@ void Chord::reset()
 
 bool Chord::slash()
       {
-      Note* n = upNote();
+      Note* n = upNote(true);
       return n->fixed();
       }
 
@@ -3458,6 +3503,8 @@ Shape Chord::shape() const
       if (_stemSlash && _stemSlash->addToSkyline())
             shape.add(_stemSlash->shape().translated(_stemSlash->pos()));
       for (Note* note : _notes) {
+            if (!note->visible())
+                  continue;
             shape.add(note->shape().translated(note->pos()));
             if (addToSkyline()) {
                   for (Element* e : note->el()) {
@@ -3480,8 +3527,10 @@ Shape Chord::shape() const
                   }
             for (Chord* chord : _graceNotes)    // process grace notes last, needed for correct shape calculation
                   shape.add(chord->shape().translated(chord->pos()));
-            for (LedgerLine* l = _ledgerLines; l; l = l->next())
-                  shape.add(l->shape().translated(l->pos()));
+            for (LedgerLine* l = _ledgerLines; l; l = l->next()) {
+                  if (l->visible())
+                        shape.add(l->shape().translated(l->pos()));
+                  }
             if (!qFuzzyIsNull(_spaceLw) || !qFuzzyIsNull(_spaceRw))
                   shape.addHorizontalSpacing(Shape::SPACING_GENERAL, -_spaceLw, _spaceRw);
             }
@@ -3519,7 +3568,7 @@ void Chord::layoutArticulations()
                         a->setUp(up()); // if there are voices place articulation at stem
                   else if (a->symId() >= SymId::articMarcatoAbove && a->symId() <= SymId::articMarcatoTenutoBelow)
                         a->setUp(true); // Gould, p. 117: strong accents above staff
-                  else if (isGrace() && up() && !a->layoutCloseToNote() && downNote()->line() < 6)
+                  else if (isGrace() && up() && !a->layoutCloseToNote() && downNote(true)->line() < 6)
                         a->setUp(true); // keep articulation close to grace note
                   else
                         a->setUp(!up()); // place articulation at note head
@@ -3550,7 +3599,7 @@ void Chord::layoutArticulations()
                               y += (_spatium * 0.75);
                         if (a->isStaccato() && articulations().size() == 1) {
                               if (_up)
-                                    x = downNote()->bboxRightPos() - stem()->width() * .5;
+                                    x = downNote(true)->bboxRightPos() - stem()->width() * .5;
                               else
                                     x = stem()->width() * .5;
                               }
@@ -3581,7 +3630,7 @@ void Chord::layoutArticulations()
                               y -= (_spatium * 0.75);
                         if (a->isStaccato() && articulations().size() == 1) {
                               if (_up)
-                                    x = downNote()->bboxRightPos() - stem()->width() * .5;
+                                    x = downNote(true)->bboxRightPos() - stem()->width() * .5;
                               else
                                     x = stem()->width() * .5;
                               }

--- a/libmscore/chord.h
+++ b/libmscore/chord.h
@@ -124,8 +124,8 @@ class Chord final : public ChordRest {
       const std::vector<Note*>& notes() const     { return _notes; }
 
       // Chord has at least one Note
-      Note* upNote() const;
-      Note* downNote() const;
+      Note* upNote(bool omitInvisible=false) const;
+      Note* downNote(bool omitInvisible=false) const;
       int upString() const;
       int downString() const;
 
@@ -156,6 +156,9 @@ class Chord final : public ChordRest {
 
       int upLine() const override;
       int downLine() const override;
+      int upLine(bool omitInvisible) const;
+      int downLine(bool omitInvisible) const;
+
       QPointF stemPos() const override;          ///< page coordinates
       QPointF stemPosBeam() const override;      ///< page coordinates
       qreal stemPosX() const override;

--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -154,6 +154,8 @@ void Score::layoutChords1(Segment* segment, int staffIdx)
       bool crossBeamFound = false;
       std::vector<Note*> upStemNotes;
       std::vector<Note*> downStemNotes;
+      std::vector<Note*> upStemNotesVisible;
+      std::vector<Note*> downStemNotesVisible;
       int upVoices       = 0;
       int downVoices     = 0;
       qreal nominalWidth = noteHeadWidth() * staff->mag(tick);
@@ -188,6 +190,12 @@ void Score::layoutChords1(Segment* segment, int staffIdx)
                   if (chord->up()) {
                         ++upVoices;
                         upStemNotes.insert(upStemNotes.end(), chord->notes().begin(), chord->notes().end());
+
+                        std::copy_if(upStemNotes.begin(),
+                                     upStemNotes.end(),
+                                     std::back_inserter(upStemNotesVisible),
+                                     [](Note* n) { return n->visible(); });
+
                         upDots   = qMax(upDots, chord->dots());
                         maxUpMag = qMax(maxUpMag, chord->mag());
                         if (!upHooks)
@@ -198,6 +206,11 @@ void Score::layoutChords1(Segment* segment, int staffIdx)
                   else {
                         ++downVoices;
                         downStemNotes.insert(downStemNotes.end(), chord->notes().begin(), chord->notes().end());
+                        std::copy_if(downStemNotes.begin(),
+                                     downStemNotes.end(),
+                                     std::back_inserter(downStemNotesVisible),
+                                     [](Note* n) { return (n->visible()); });
+
                         downDots = qMax(downDots, chord->dots());
                         maxDownMag = qMax(maxDownMag, chord->mag());
                         if (!downHooks)
@@ -309,6 +322,9 @@ void Score::layoutChords1(Segment* segment, int staffIdx)
                   Note* bottomUpNote = upStemNotes.front();
                   Note* topDownNote  = downStemNotes.back();
                   int separation;
+
+                  bottomUpNote->setStaffConflict(false);
+                  topDownNote->setStaffConflict(false);
                   // TODO: handle conflicts for cross-staff notes and notes on cross-staff beams
                   // for now we simply treat these as though there is no conflict
                   if (bottomUpNote->chord()->staffMove() == topDownNote->chord()->staffMove() && !crossBeamFound)
@@ -329,19 +345,22 @@ void Score::layoutChords1(Segment* segment, int staffIdx)
                         }
 
                   else if (separation < 1) {
-
                         // overlap (possibly unison)
 
                         // build list of overlapping notes
                         for (size_t i = 0, n = upStemNotes.size(); i < n; ++i) {
-                              if (upStemNotes[i]->line() >= topDownNote->line() - 1)
+                              if (upStemNotes[i]->line() >= topDownNote->line() - 1) {
                                     overlapNotes.append(upStemNotes[i]);
+                                    upStemNotes[i]->setStaffConflict(true);
+                                    }
                               else
                                     break;
                               }
                         for (size_t i = downStemNotes.size(); i > 0; --i) { // loop most probably needs to be in this reverse order
-                              if (downStemNotes[i-1]->line() <= bottomUpNote->line() + 1)
+                              if (downStemNotes[i-1]->line() <= bottomUpNote->line() + 1) {
                                     overlapNotes.append(downStemNotes[i-1]);
+                                    downStemNotes[i-1]->setStaffConflict(true);
+                                    }
                               else
                                     break;
                               }

--- a/libmscore/note.h
+++ b/libmscore/note.h
@@ -256,6 +256,7 @@ class Note final : public Element {
                                           ///< except if only one note is dotted
       bool _fretConflict  { false };      ///< used by TAB staves to mark a fretting conflict:
                                           ///< two or more notes on the same string
+      bool _staffConflict { false };
       bool dragMode       { false };
       bool _mirror        { false };      ///< True if note is mirrored at stem.
       bool m_isSmall      { false };
@@ -409,6 +410,8 @@ class Note final : public Element {
       void setGhost(bool val)         { _ghost = val;   }
       bool fretConflict() const       { return _fretConflict; }
       void setFretConflict(bool val)  { _fretConflict = val; }
+      bool staffConflict() const      { return _staffConflict; }
+      void setStaffConflict(bool v)   { _staffConflict = v; }
 
       void add(Element*) override;
       void remove(Element*) override;

--- a/libmscore/stem.cpp
+++ b/libmscore/stem.cpp
@@ -105,7 +105,10 @@ void Stem::layout()
                   }
             else {                              // non-TAB
                   // move stem start to note attach point
-                  Note* n  = up() ? chord()->downNote() : chord()->upNote();
+                  bool arp = chord()->arpeggio() ? true : false;
+                  Note* un = arp ? chord()->upNote(true)   : chord()->upNote(false);
+                  Note* dn = arp ? chord()->downNote(true) : chord()->downNote(false);
+                  Note* n  = up() ? dn : un;
                   if ((up() && !n->mirror()) || (!up() && n->mirror()))
                         y1 += n->stemUpSE().y();
                   else

--- a/libmscore/style.cpp
+++ b/libmscore/style.cpp
@@ -449,8 +449,8 @@ static const StyleType styleTypes[] {
       { Sid::slurGateTime,            "slurGateTime",            QVariant(100) },
 
       { Sid::arpeggioNoteDistance,    "ArpeggioNoteDistance",    Spatium(.5) },
-      { Sid::arpeggioAccidentalDistance,    "ArpeggioAccidentalDistance",    Spatium(.5) },
-      { Sid::arpeggioAccidentalDistanceMin,    "ArpeggioAccidentalDistanceMin",    Spatium(.33) },
+      { Sid::arpeggioAccidentalDistance,    "ArpeggioAccidentalDistance",    Spatium(.30) },
+      { Sid::arpeggioAccidentalDistanceMin, "ArpeggioAccidentalDistanceMin", Spatium(.20) },
       { Sid::arpeggioLineWidth,       "ArpeggioLineWidth",       Spatium(.18) },
       { Sid::arpeggioHookLen,         "ArpeggioHookLen",         Spatium(.8) },
       { Sid::arpeggioHiddenInStdIfTab,"ArpeggioHiddenInStdIfTab",QVariant(false)},


### PR DESCRIPTION
+ Attempt to do away with the "dangling" arpeggio in most fonts
+ Show ledger-lines between visible notes when there are invisible notes beyond them. [...more]
+ Cut off stems to reach only to visible notes when an arpeggio exists
+ Allow hidden notes of chords to act as overlapping even when not exactly same pitches so that they do not add offset.

Compromise exists: to shorten a stem of chord with hidden notes do so only when there is an arpeggio present, since that is for what reason the stem was to be hidden initially. Otherwise, for example, a stem will be missing when overlapping quarter-dotted + eighth via invisible note


TODO: Demonstrate all this


Flaw #1: Leland comes up short on the bottom portion of the arpeggioss, but most if not all the built-in fonts seem better than default of 3.6.2 in my opinion

**Emmentaler-based (3.6.2):** One of the reasons for this change is to fix Emmentaler's default placements:

![image](https://github.com/user-attachments/assets/24e7ec1d-8e28-44ab-9216-a0ef1f5fdb29)

**Emmentaler-based (Updated):**

![image](https://github.com/user-attachments/assets/473df601-ad32-4ddb-a694-7b7f11d04acf)

**Leland (Updated):** A little off still... but I don't use it much

![image](https://github.com/user-attachments/assets/ae6b10fc-3bf8-4ce2-a574-df3866a32388)

No way around it though, often the user just has to make some nudge adjustments and/or re-vertically center to make it more symmetrical with the chord size: especially with 3.6.2 defaults

**Left-over stem (3.6.2) due to some hidden notes above:**

![image](https://github.com/user-attachments/assets/d92c35a5-8a2c-4f58-834c-e3d79e30760b)

Alleviated by not considering hidden elements, but only when there's an arpeggio. Sounds funny, but that's the compromise for now

![image](https://github.com/user-attachments/assets/72a7bbeb-d74a-4191-a545-598ef1f7e9c5)

**Only shows the ledger line up to the last visible note (Updated)**: (stem showing due to lack of arp)
![image](https://github.com/user-attachments/assets/557ff3fa-0f16-42d2-b29b-4ff593cb829c)

**Whereas 3.6.2 omits all ledger lines if its TOP or BOTTOM note is invisible:**

![image](https://github.com/user-attachments/assets/74e71d40-7c53-4db6-8839-e0c7fcba3ddb)


