### PR TITLE
Text Line: Square caps replace Dash-dot-dotted line-style

### DIFF
--- a/libmscore/textlinebase.cpp
+++ b/libmscore/textlinebase.cpp
@@ -150,7 +150,8 @@ void TextLineBaseSegment::draw(QPainter* painter) const
                 pen.setDashPattern(dashDotted);
                 break;
             case Qt::DashDotDotLine:
-                pen.setDashPattern(dashDotDotted);
+                // Square dots instead:
+                pen.setDashPattern(dotted);
                 break;
             case Qt::CustomDashLine:
                 pen.setDashPattern(customDashes);

--- a/mscore/editstyle.cpp
+++ b/mscore/editstyle.cpp
@@ -37,7 +37,7 @@ const char* lineStyles[] = {
       QT_TRANSLATE_NOOP("EditStyleBase", "Dashed"),
       QT_TRANSLATE_NOOP("EditStyleBase", "Dotted"),
       QT_TRANSLATE_NOOP("EditStyleBase", "Dash-dotted"),
-      QT_TRANSLATE_NOOP("EditStyleBase", "Dash-dot-dotted")
+      QT_TRANSLATE_NOOP("EditStyleBase", "Squared")
 };
 
 //---------------------------------------------------------

--- a/mscore/editstyle.ui
+++ b/mscore/editstyle.ui
@@ -7888,7 +7888,7 @@ By default, they will be placed such as that their right end are at the same lev
              </item>
              <item>
               <property name="text">
-               <string>Dash-dot-dotted</string>
+               <string>Squared</string>
               </property>
              </item>
             </widget>
@@ -8336,7 +8336,7 @@ By default, they will be placed such as that their right end are at the same lev
              </item>
              <item>
               <property name="text">
-               <string>Dash-dot-dotted</string>
+               <string>Squared</string>
               </property>
              </item>
             </widget>
@@ -8432,7 +8432,7 @@ By default, they will be placed such as that their right end are at the same lev
              </item>
              <item>
               <property name="text">
-               <string>Dash-dot-dotted</string>
+               <string>Squared</string>
               </property>
              </item>
             </widget>

--- a/mscore/inspector/inspector_line.ui
+++ b/mscore/inspector/inspector_line.ui
@@ -173,7 +173,7 @@
         </item>
         <item>
          <property name="text">
-          <string>Dash-dot-dotted</string>
+          <string>Squared</string>
          </property>
         </item>
         <item>


### PR DESCRIPTION
Aside Personal Preference, since I have no use for Dash-dot-dotted style. Square caps sound kind of interesting

![image](https://github.com/user-attachments/assets/02efc8f0-391f-422a-b290-05aa797cbf91)
