### PR TITLE
Minor Change: A note's accidental undergoes visibility toggling coincidentally with its notehead visibility change

### DIFF
--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -2995,6 +2995,8 @@ bool Note::setProperty(Pid propertyId, const QVariant& v)
                   break;
             case Pid::VISIBLE: {
                   setVisible(v.toBool());
+                  if (auto acc = this->accidental())
+                      acc->setVisible(v.toBool());
                   if (m)
                         m->checkMultiVoices(chord()->staffIdx());
                   break;


### PR DESCRIPTION
**E.g.**: 

[visToggle.webm](https://github.com/user-attachments/assets/c746a4c9-3fa3-411c-b212-ba17a318b06f)
