### PR TITLE
Various Changes: (mainly fixes)

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -521,9 +521,12 @@ void Score::expandVoice()
 //   cmdAddInterval
 //---------------------------------------------------------
 
-void Score::cmdAddInterval(int val, const std::vector<Note*>& nl)
+Note* Score::cmdAddInterval(int val, const std::vector<Note*>& nl)
       {
+      auto inputSeg = _is.segment();
+      Note* ret = nullptr;      
       startCmd();
+
       // Prepare note selection in case there are not selected tied notes and sort them
       std::vector<Note*> tmpnl;
       std::vector<Note*> _nl = nl;
@@ -550,11 +553,13 @@ void Score::cmdAddInterval(int val, const std::vector<Note*>& nl)
                   deselect(n);
             }
 
-
       Note* prevTied = nullptr;
+      Chord* firstChord = nullptr;
       std::vector<Element*> notesToSelect;
       for (Note* on : tmpnl) {
             Chord* chord = on->chord();
+            if (!firstChord)
+                  firstChord = chord;
             int valTmp = val < 0 ? val+1 : val-1;
 
             int npitch;
@@ -564,7 +569,7 @@ void Score::cmdAddInterval(int val, const std::vector<Note*>& nl)
             bool forceAccidental = false;
             if (abs(valTmp) != 7 || accidental) {
                   int line      = on->line() - valTmp;
-                  Fraction tick      = chord->tick();
+                  Fraction tick = chord->tick();
                   Staff* estaff = staff(on->staffIdx() + chord->staffMove());
                   ClefType clef = estaff->clef(tick);
                   Key key       = estaff->key(tick);
@@ -582,7 +587,7 @@ void Score::cmdAddInterval(int val, const std::vector<Note*>& nl)
                         bool error = false;
                         AccidentalVal acci = chord->measure()->findAccidental(chord->segment(), estaff->idx(), line, error);
                         if (error)
-                              return;
+                              return ret;
 
                         npitch = step2pitch(step) + octave * 12 + int(acci);
                         ntpc = step2tpc(step % 7, acci);
@@ -654,6 +659,8 @@ void Score::cmdAddInterval(int val, const std::vector<Note*>& nl)
 
             if (selIsList && note)
                   notesToSelect.push_back(dynamic_cast<Element*>(note));
+
+            ret = note;
             }
       if (_is.noteEntryMode())
             _is.setAccidentalType(AccidentalType::NONE);
@@ -665,9 +672,14 @@ void Score::cmdAddInterval(int val, const std::vector<Note*>& nl)
                       select(noteToSelect, SelectType::ADD, 0);
                   }
             }
-      if (_is.cr() == toChordRest(_nl[0]->chord()) && selIsSingle)
+      if (_is.noteEntryMethod() == NoteEntryMethod::REPITCH) {
+            if (inputSeg)
+                  _is.setSegment(inputSeg);
+            }
+      else if (_is.cr() == toChordRest(_nl[0]->chord()) && selIsSingle)
             _is.moveToNextInputPos();
       endCmd();
+      return ret;
       }
 
 //---------------------------------------------------------

--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -2546,7 +2546,8 @@ Element* Score::move(const QString& cmd)
       Measure* oim = ois ? ois->measure() : nullptr;
 
       if (cmd == "next-chord" && cr) {
-            // note input cursor
+            auto iCr = _is.cr();
+
             if (noteEntryMode())
                   _is.moveToNextInputPos();
 
@@ -2564,12 +2565,20 @@ Element* Score::move(const QString& cmd)
                   Measure* m = toChordRest(el)->measure();
                   Segment* nis = _is.segment();
                   Measure* nim = nis ? nis->measure() : nullptr;
-                  if (m != oim && m != nim)
-                        el = cr;
+                  if (m != oim && m != nim) {
+                        if (noteEntryMethod() == NoteEntryMethod::REPITCH)
+                              el = iCr;
+                        else
+                              el = cr;
+                        }
                   // do not use if new input segment is current cr
                   // this means input cursor just caught up to current selection
-                  else if (cr && nis == cr->segment() && !isRange)
-                        el = cr;
+                  else if (cr && nis == cr->segment() && !isRange) {
+                        if (noteEntryMethod() == NoteEntryMethod::REPITCH)
+                              el = iCr;
+                        else
+                              el = cr;
+                        }
                   }
             else if (!el)
                   el = cr;

--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -377,7 +377,7 @@ std::vector<Rest*> Score::setRests(const Fraction& _tick, int track, const Fract
 //   addNote from NoteVal
 //---------------------------------------------------------
 
-Note* Score::addNote(Chord* chord, const NoteVal& noteVal, bool forceAccidental, InputState* externalInputState)
+Note* Score::addNote(Chord* chord, const NoteVal& noteVal, bool forceAccidental, InputState* externalInputState, bool silent)
       {
       InputState& is = externalInputState ? (*externalInputState) : _is;
       auto inputSeg = is.segment();
@@ -397,8 +397,8 @@ Note* Score::addNote(Chord* chord, const NoteVal& noteVal, bool forceAccidental,
             a->setParent(note);
             undoAddElement(a);
             }
-      setPlayNote(true);
-      setPlayChord(true);
+      setPlayNote(!silent);
+      setPlayChord(!silent);
 
       if (externalInputState) {
             is.setTrack(note->track());

--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -380,6 +380,7 @@ std::vector<Rest*> Score::setRests(const Fraction& _tick, int track, const Fract
 Note* Score::addNote(Chord* chord, const NoteVal& noteVal, bool forceAccidental, InputState* externalInputState)
       {
       InputState& is = externalInputState ? (*externalInputState) : _is;
+      auto inputSeg = is.segment();
 
       Note* note = new Note(this);
       note->setParent(chord);
@@ -410,8 +411,14 @@ Note* Score::addNote(Chord* chord, const NoteVal& noteVal, bool forceAccidental,
 
       if (!chord->staff()->isTabStaff(chord->tick())) {
             NoteEntryMethod entryMethod = is.noteEntryMethod();
-            if (entryMethod != NoteEntryMethod::REALTIME_AUTO && entryMethod != NoteEntryMethod::REALTIME_MANUAL)
-                  is.moveToNextInputPos();
+            if (entryMethod != NoteEntryMethod::REALTIME_AUTO && entryMethod != NoteEntryMethod::REALTIME_MANUAL) {
+                  if (entryMethod == NoteEntryMethod::REPITCH) {
+                        if (inputSeg) {
+                              is.setSegment(inputSeg);
+                              }
+                        }
+                  else is.moveToNextInputPos();
+                  }
             }
       return note;
       }

--- a/libmscore/noteentry.cpp
+++ b/libmscore/noteentry.cpp
@@ -127,7 +127,7 @@ NoteVal Score::noteValForPosition(Position pos, AccidentalType at, bool &error)
 //   addPitch
 //---------------------------------------------------------
 
-Note* Score::addPitch(NoteVal& nval, bool addFlag, InputState* externalInputState)
+Note* Score::addPitch(NoteVal& nval, bool addFlag, InputState* externalInputState, bool silent)
       {
       InputState& is = externalInputState ? (*externalInputState) : _is;
 
@@ -138,7 +138,7 @@ Note* Score::addPitch(NoteVal& nval, bool addFlag, InputState* externalInputStat
                   qDebug("Score::addPitch: cr %s", c ? c->name() : "zero");
                   return 0;
                   }
-            Note* note = addNote(toChord(c), nval, /* forceAccidental */ false, externalInputState);
+            Note* note = addNote(toChord(c), nval, /* forceAccidental */ false, externalInputState, silent);
             if (is.lastSegment() == is.segment()) {
                   NoteEntryMethod entryMethod = is.noteEntryMethod();
                   if (entryMethod != NoteEntryMethod::REALTIME_AUTO && entryMethod != NoteEntryMethod::REALTIME_MANUAL)
@@ -228,7 +228,7 @@ Note* Score::addPitch(NoteVal& nval, bool addFlag, InputState* externalInputStat
                   }
             // add new note to chord
             undoAddElement(note);
-            setPlayNote(true);
+            setPlayNote(!silent);
             // recreate tie forward if there is a note to tie to
             // one-sided ties will not be recreated
             if (firstTiedNote) {

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -736,11 +736,11 @@ class Score : public QObject, public ScoreElement {
       void addElement(Element*);
       void removeElement(Element*);
 
-      Note* addPitch(NoteVal&, bool addFlag, InputState* externalInputState = nullptr);
+      Note* addPitch(NoteVal&, bool addFlag, InputState* externalInputState = nullptr, bool silent = false);
       void addPitch(int pitch, bool addFlag, bool insert);
       Note* addTiedMidiPitch(int pitch, bool addFlag, Chord* prevChord);
       Note* addMidiPitch(int pitch, bool addFlag);
-      Note* addNote(Chord*, const NoteVal& noteVal, bool forceAccidental = false, InputState* externalInputState = nullptr);
+      Note* addNote(Chord*, const NoteVal& noteVal, bool forceAccidental = false, InputState* externalInputState = nullptr, bool silent = false);
 
       NoteVal noteValForPosition(Position pos, AccidentalType at, bool &error);
 
@@ -1074,7 +1074,7 @@ class Score : public QObject, public ScoreElement {
       Element* move(const QString& cmd);
       void cmdEnterRest(const TDuration& d);
       void enterRest(const TDuration& d, InputState* externalInputState = nullptr);
-      void cmdAddInterval(int, const std::vector<Note*>&);
+      Note* cmdAddInterval(int, const std::vector<Note*>&);
       void cmdCreateTuplet(ChordRest*, Tuplet*);
       void removeAudio();
 

--- a/mscore/measuresdialog.ui
+++ b/mscore/measuresdialog.ui
@@ -14,18 +14,18 @@
    <string>Append Measures</string>
   </property>
   <layout class="QVBoxLayout">
-   <property name="margin">
-    <number>9</number>
-   </property>
    <property name="spacing">
     <number>6</number>
+   </property>
+   <property name="margin" stdset="0">
+    <number>9</number>
    </property>
    <item>
     <spacer>
      <property name="orientation">
       <enum>Qt::Vertical</enum>
      </property>
-     <property name="sizeHint">
+     <property name="sizeHint" stdset="0">
       <size>
        <width>20</width>
        <height>40</height>
@@ -42,11 +42,11 @@
    </item>
    <item>
     <layout class="QHBoxLayout">
-     <property name="margin">
-      <number>0</number>
-     </property>
      <property name="spacing">
       <number>6</number>
+     </property>
+     <property name="margin" stdset="0">
+      <number>0</number>
      </property>
      <item>
       <widget class="QLabel" name="label">
@@ -57,11 +57,14 @@
      </item>
      <item>
       <widget class="QSpinBox" name="measures">
+       <property name="minimum">
+        <number>1</number>
+       </property>
        <property name="maximum">
         <number>1000</number>
        </property>
-       <property name="minimum">
-        <number>1</number>
+       <property name="value">
+        <number>255</number>
        </property>
       </widget>
      </item>
@@ -72,7 +75,7 @@
      <property name="orientation">
       <enum>Qt::Vertical</enum>
      </property>
-     <property name="sizeHint">
+     <property name="sizeHint" stdset="0">
       <size>
        <width>20</width>
        <height>40</height>
@@ -82,18 +85,18 @@
    </item>
    <item>
     <layout class="QHBoxLayout">
-     <property name="margin">
-      <number>0</number>
-     </property>
      <property name="spacing">
       <number>6</number>
+     </property>
+     <property name="margin" stdset="0">
+      <number>0</number>
      </property>
      <item>
       <spacer>
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
        </property>
-       <property name="sizeHint">
+       <property name="sizeHint" stdset="0">
         <size>
          <width>131</width>
          <height>31</height>

--- a/mscore/palette.cpp
+++ b/mscore/palette.cpp
@@ -671,10 +671,9 @@ bool Palette::applyPaletteElement(Element* element, Qt::KeyboardModifiers modifi
                               }
                         }
 
-                  // If dynamic is placed while a hairpin is active within note entry,
-                  // finalize the hairpin to be just before the dynamic mark or after it
-                  // depending on whether the hairpin started at this position.
                   if (element->isDynamic()) {
+                        // Finalize any active hairpin just before dynamic mark (or after if hairpin 
+                        // started at current position 
                         auto hp = is.dynamicLine();
                         if (score->noteEntryMode() && hp) {
                               Element* start = hp->startElement();
@@ -685,24 +684,23 @@ bool Palette::applyPaletteElement(Element* element, Qt::KeyboardModifiers modifi
                                     hp->score()->undo(new ChangeSpannerElements(hp, start, end));
                                     is.dynamicLine()->setSelected(false);
                                     is.setDynamicLine(nullptr);
+                                    // Dynamic remains to be applied...
                                     }
                               }
                         }
 
-                  for (Element* e : sel.elements()) {
-                        auto ee = e;
-
-                        // Change from 3.6.2: Let barline placement be equiv. to range selection
-                        // in N.E. starting new measure entry (end of the measure placement for streamlining)
-                        if (element->type() == ElementType::BAR_LINE && is.noteEntryMode() ) {
-                              auto ism = is.cr() ? is.cr()->measure() : score->tick2measure(is.tick());
-                              auto em  = e->findMeasure();
-                              if (ism && em && (em->index() != ism->index())) {
-                                    ee = em;
+                  if (!finished) {
+                        for (Element* e : sel.elements()) {
+                              auto ee = e;
+                              if (element->type() == ElementType::BAR_LINE && is.noteEntryMode() ) {
+                                    auto ism = is.cr() ? is.cr()->measure() : score->tick2measure(is.tick());
+                                    auto em  = e->findMeasure();
+                                    if (ism && em && (em->index() != ism->index())) {
+                                          ee = em;
+                                          }
                                     }
+                              applyDrop(score, viewer, ee, element, modifiers);
                               }
-
-                        applyDrop(score, viewer, ee, element, modifiers);
                         }
                   }
             }

--- a/mscore/palette.cpp
+++ b/mscore/palette.cpp
@@ -724,6 +724,10 @@ bool Palette::applyPaletteElement(Element* element, Qt::KeyboardModifiers modifi
                   Measure* last = sel.endSegment() ? sel.endSegment()->measure() : nullptr;
                   bool onlyOneMeasure = (sel.startSegment()->measure() == last);
                   for (Measure* m = sel.startSegment()->measure(); m; m = m->nextMeasureMM()) {
+                        if ( (element->type() == ElementType::BAR_LINE)  ) {
+                              if (m != last)
+                                    continue;
+                              }
                         QRectF r = m->staffabbox(sel.staffStart());
                         QPointF pt(r.x() + r.width() * .5, r.y() + r.height() * .5);
                         pt += m->system()->page()->pos();

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -3906,6 +3906,9 @@ void ScoreView::startNoteEntry()
             // or, CR at last selected position if that is in view
             Page* p = nullptr;
             QList<QPointF> points;
+            points.append(toLogical(QPoint(width() * 0.5, height() * 0.5)));
+            points.append(toLogical(QPoint(width() * 0.5, height() * 0.22)));
+            points.append(toLogical(QPoint(width() * 0.5, height() * 0.88)));
             points.append(toLogical(QPoint(width() * 0.25, height() * 0.25)));
             points.append(toLogical(QPoint(0.0, 0.0)));
             points.append(toLogical(QPoint(0.0, height())));

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -2585,6 +2585,10 @@ void ScoreView::cmd(const char* s)
                         cv->changeState(ViewState::NOTE_ENTRY);
                   else if (cv->state == ViewState::NOTE_ENTRY)
                         cv->changeState(ViewState::NORMAL);
+                  else if (cv->state == ViewState::EDIT) {
+                        cv->endEdit();
+                        cv->changeState(ViewState::NOTE_ENTRY);
+                        }
 
                   else if (cv->state ==ViewState::PLAY) {
                         cv->changeState(ViewState::NORMAL);

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -3302,6 +3302,42 @@ void ScoreView::cmd(const char* s)
                         //      ;     // TODO: state    sm->postEvent(new CommandEvent("note-input"));
                         cv->score()->cmdAddInterval(n, nl);
                         }
+                  else  {
+                        auto score      = cv->score();
+                        auto selection  = score->selection();
+                        auto& is        = score->inputState();
+                        auto cr         = selection.currentCR();
+
+                        if (cv->noteEntryMode() && cr && cr->isRest()) {
+                              bool silent = true;
+                              cv->cmdRepeatSelection(silent); // TODO: silent makes no difference
+                              auto last = is.lastSegment();
+                              is.moveInputPos(last);
+                              cr = selection.currentCR();
+
+                              if (cr->isChord()) {
+                                    auto chord = toChord(cr);
+                                    // note list from selection is top most note, bottom will be bottom note.
+                                    std::vector<Note*> bottom;
+                                    bottom.emplace_back(chord->downNote());
+                                    nl = MScore::noteInputOctaveTendencyIsTopNote ? selection.noteList() : bottom;
+                                    Note* addedNote = score->cmdAddInterval(n, nl);
+                                    if (addedNote) {
+                                          // Erase all but the added note:
+                                          // TODO: Undo stack stores deletions. Without start/end commands, program halts
+                                          // due to assert of !empty note list
+                                          score->startCmd();
+                                          for (auto it = chord->notes().begin(); it != chord->notes().end(); ) {
+                                                if (*it != addedNote)
+                                                      score->deleteItem(*it);
+                                                else ++it;
+                                                }
+                                          is.moveToNextInputPos();
+                                          score->endCmd();
+                                          }
+                                    }
+                              }
+                        }
                   }},
             {{"tie"}, [](ScoreView* cv, const QByteArray&) {
                   if (cv->noteEntryMode()) {
@@ -6404,14 +6440,11 @@ void ScoreView::cmdRepeatSelection(bool silent)
                   auto c = usePrevChord ? toChord(prevCR) : static_cast<Note*>(el)->chord();
                   for (Note* note : c->notes()) {
                         NoteVal nval = note->noteVal();
-                        if (usePrevChord)
-                              _score->addPitch(nval, addTo, nullptr, silent);
-                        else
-                              _score->addPitch(nval, addTo);
+                        usePrevChord ? _score->addPitch(nval, addTo, nullptr, silent)
+                                     : _score->addPitch(nval, addTo);
                         addTo = true;
                         }
                   _score->endCmd();
-
                   }
 
             if (resetToRepitch) {

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -3897,6 +3897,7 @@ void ScoreView::startNoteEntry()
 
       is.setSegment(0);
       Note* note  = 0;
+      auto defaultDuration = TDuration(TDuration::DurationType::V_QUARTER);
 
       if (_score->selection().isNone()) {
             // no selection
@@ -4009,10 +4010,16 @@ void ScoreView::startNoteEntry()
             if (note == 0)
                   note = c->upNote();
             el = note;
+            defaultDuration = c->durationType();
+            }
+      else if (el->type() == ElementType::REST) {
+            Rest* r = toRest(el);
+            defaultDuration = r->durationType() == TDuration::DurationType::V_MEASURE ? defaultDuration : r->durationType();
             }
       TDuration d(is.duration());
+
       if (!d.isValid() || d.isZero() || d.type() == TDuration::DurationType::V_MEASURE)
-            is.setDuration(TDuration(TDuration::DurationType::V_QUARTER));
+            is.setDuration(defaultDuration);
       is.setAccidentalType(AccidentalType::NONE);
 
       _score->select(el, SelectType::SINGLE, 0);

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -6359,52 +6359,82 @@ MeasureBase* ScoreView::checkSelectionStateForInsertMeasure()
 //   cmdRepeatSelection
 //---------------------------------------------------------
 
-void ScoreView::cmdRepeatSelection()
+void ScoreView::cmdRepeatSelection(bool silent)
       {
       const Selection& selection = _score->selection();
-
+      bool resetToRepitch = false;
+      bool isRange = selection.isRange();
+      auto iCR = _score->inputState().cr();
       if (noteEntryMode() && selection.isSingle()) {
-            Element* el = _score->selection().element();
-            while (el && el->type() != ElementType::NOTE)
-                   el = el->prevSegmentElement();
-            if (el && el->type() == ElementType::NOTE && !_score->inputState().endOfScore()) {
+            if (_score->noteEntryMethod() == NoteEntryMethod::REPITCH) {
+                  resetToRepitch = true;
+                  _score->setNoteEntryMethod(NoteEntryMethod::STEPTIME);
+                  }
+
+            if (auto el = selection.element()) {
+                  bool isRest = el->type() == ElementType::REST;
+                  bool isNote = el->type() == ElementType::NOTE;
+
+                  if (!isRest && !isNote)
+                        return;
+
+                  auto startTick = selection.tickStart();
+                  auto inputTick = _score->inputState().tick();
+
+                  bool selectionAndInputAreSamePos = startTick == inputTick;
+                  bool usePrevChord = (isRest || (isNote && selectionAndInputAreSamePos));
+                  ChordRest* prevCR = isRest ? toChordRest(el) : toChordRest(el->parent());
+                  if (usePrevChord) {
+                        prevCR = prevChordRest(prevCR);
+                        while (el) {
+                              if (!prevCR || prevCR == prevChordRest(prevCR))
+                                    return;
+
+                              if (!prevCR->isRest()) {
+                                    el = prevCR;
+                                    break;
+                                    }
+
+                              prevCR = prevChordRest(prevCR);
+                              }
+                        }
+
                   _score->startCmd();
                   bool addTo = false;
-                  Chord* c = toNote(el)->chord();
+                  auto c = usePrevChord ? toChord(prevCR) : static_cast<Note*>(el)->chord();
                   for (Note* note : c->notes()) {
                         NoteVal nval = note->noteVal();
-                        _score->addPitch(nval, addTo);
+                        if (usePrevChord)
+                              _score->addPitch(nval, addTo, nullptr, silent);
+                        else
+                              _score->addPitch(nval, addTo);
                         addTo = true;
                         }
                   _score->endCmd();
+
                   }
-            if (el && el->type() == ElementType::REST) {
-                  auto prevCR = toChordRest(el);
-                  prevCR = prevChordRest(prevCR);
-                  while (el) {
-                        if (!prevCR || prevCR == prevChordRest(prevCR))
-                              return;
-                        if (!prevCR->isRest()) {
-                              el = prevCR;
-                              break;
+
+            if (resetToRepitch) {
+                  _score->setNoteEntryMethod(NoteEntryMethod::REPITCH);
+                  if (auto nCR = nextChordRest(iCR)) {
+                        auto oCR = nCR;
+                        bool end = false;
+                        while (nCR && !nCR->isChord()) {
+                              if ((nCR = nextChordRest(nCR))) {
+                                    _score->inputState().setSegment(nCR->segment());
+                                    }
+                              else end = true;
                               }
-                        prevCR = prevChordRest(prevCR);
-                        }
-                  if (!_score->inputState().endOfScore()) {
-                        _score->startCmd();
-                        bool addTo = false;
-                        auto c = toChord(prevCR);
-                        for (auto note : c->notes()) {
-                              auto noteVal = note->noteVal();
-                              _score->addPitch(noteVal, addTo);
-                              addTo = true;
+                        if (end) {
+                              _score->inputState().setSegment(oCR->segment());
                               }
-                        _score->endCmd();
                         }
+                  moveCursor();
                   }
+
             return;
             }
-      if (!selection.isRange()) {
+      if (!isRange) {
             ChordRest* cr = _score->getSelectedChordRest();
             if (!cr)
                   return;
@@ -6432,22 +6462,43 @@ void ScoreView::cmdRepeatSelection()
       int dStaff = selection.staffStart();
       if (auto endSegment = selection.endSegment()) {
             auto eTrack = selection.elements().front()->track();
-            auto staffTrack   = staff2track(dStaff);
+            auto staffTrack = staff2track(dStaff);
             bool filtered = score()->selection().hasTemporaryFilter();
             if (endSegment->segmentType() != SegmentType::ChordRest)
                   endSegment = endSegment->next1(SegmentType::ChordRest);
-            if (!endSegment)
-                  return;
-            auto e = (filtered && endSegment->element(eTrack)) ? endSegment->element(eTrack) : endSegment->element(staffTrack);
-            if (e) {
-                  auto cr = toChordRest(e);
-                  _score->startCmd();
-                  _score->pasteStaff(xml, cr->segment(), cr->staffIdx());
-                  _score->endCmd();
-                  }
-            else qDebug("cmdRepeatSelection: cannot paste: endSegment: %p dStaff %d", endSegment, dStaff);
+            if (endSegment) {
+                  int endTick   = selection.tickEnd().ticks();
+                  int startTick = selection.tickStart().ticks();
+                  if (endTick < startTick)
+                        std::swap(endTick, startTick);
+                  int totalTicks = endTick - startTick;
+
+                  if ( (endTick + totalTicks) > score()->endTick().ticks() ) {
+                        qDebug() << "cmdRepeatSelection: Results exceed size of score";
+                        if (_score->selection().hasTemporaryFilter()) {
+                              return;
+                              }
+                        }
+
+                  int track = filtered ? eTrack : staffTrack;
+                  auto el = endSegment->element(track) ? endSegment->element(track) : selection.lastChordRest(track);
+                  if (el) {
+                        int staffIdx = el->staffIdx();
+                        _score->startCmd();
+                        _score->pasteStaff(xml, endSegment, staffIdx);
+                        _score->endCmd();
+                        } else qDebug("cmdRepeatSelection: cannot paste: endSegment: %p dStaff %d", endSegment, dStaff);
+                  } else qDebug("cmdRepeatSelection: cannot paste: endSegment: %p dStaff %d", endSegment, dStaff);
+            } else qDebug("cmdRepeatSelection: cannot paste: endSegment: %p dStaff %d", endSegment, dStaff);
+
+      if (isRange && noteEntryMode()) {
+            auto& _is = _score->inputState();
+            auto track = _is.track();
+            auto ncr  = selection.endSegment()->nextChordRest(track);
+            _is.moveInputPos(ncr);
+            _is.setTrack(track);
             }
-      else qDebug() << "cmdRepeatSelection: no end segment";
+
       }
 
 //---------------------------------------------------------

--- a/mscore/scoreview.h
+++ b/mscore/scoreview.h
@@ -307,7 +307,6 @@ class ScoreView : public QWidget, public MuseScoreView {
       void cmdTuplet(int n, ChordRest*);
       void cmdTuplet(int);
       void cmdCreateTuplet(ChordRest* cr, Tuplet* tuplet);
-      void cmdRepeatSelection();
       void cmdChangeEnharmonic(bool);
 
       MeasureBase* insertMeasure(ElementType, MeasureBase*);
@@ -508,6 +507,8 @@ class ScoreView : public QWidget, public MuseScoreView {
 
       void cmdAppendMeasures(int, ElementType);
       void cmdInsertMeasures(int, ElementType);
+
+      void cmdRepeatSelection(bool silent = false);
 
       void cmdAddRemoveBreaks();
       void cmdCopyLyricsToClipboard();

--- a/mscore/shortcut.cpp
+++ b/mscore/shortcut.cpp
@@ -2844,7 +2844,7 @@ Shortcut Shortcut::_sc[] = {
          },
       {
          MsWidget::MAIN_WINDOW,
-         STATE_NORMAL | STATE_EDIT,
+         STATE_NORMAL | STATE_EDIT | STATE_NOTE_ENTRY,
          "reset",
          QT_TRANSLATE_NOOP("action","Reset Shapes and Positions"),
          QT_TRANSLATE_NOOP("action","Reset shapes and positions"),

--- a/mscore/shortcut.cpp
+++ b/mscore/shortcut.cpp
@@ -288,7 +288,7 @@ Shortcut Shortcut::_sc[] = {
          },
       {
          MsWidget::MAIN_WINDOW,
-         STATE_NORMAL | STATE_NOTE_ENTRY | STATE_PLAY,
+         STATE_NORMAL | STATE_NOTE_ENTRY | STATE_PLAY | STATE_EDIT,
          "note-input",
          QT_TRANSLATE_NOOP("action","Note Input"),
          QT_TRANSLATE_NOOP("action","Note input: Toggle Entry/Normal mode"),


### PR DESCRIPTION
**Measure Dialog box**: default value to be 255 instead of 1 - easier to add a lot of measures in one action 

**Repeat Selection**: updated to provide position afterward while in Note Entry

**Repeat Selection**: (Re-pitch Mode) Fix jumping to end of score if no chord was found when moving forward to next "pitched" chord, confusing to user.

**Repeat Selection**: Safety for end-of-score with secondary voicing

**Re-pitch Mode**: Keep note-entry position on "next chord to be repitched" when building chords.

+ 3.6.2's older behavior:

[362repitch.webm](https://github.com/user-attachments/assets/0f2affb4-4ebb-4ba5-897e-829a11cb6a45)

+ Updated:

[updaterepitch.webm](https://github.com/user-attachments/assets/c8750388-e4d3-49df-a28c-7324def38338)