### PR TITLE
Various Changes (Fingering)

### DIFF
--- a/global/settings/types/preferencekeys.h
+++ b/global/settings/types/preferencekeys.h
@@ -192,6 +192,8 @@
 #define PREF_UI_SCORE_SLURS_MIN_SHOULDER_EXTRA              "ui/score/slurs/shoulder/extraHeightSmall"
 #define PREF_UI_SCORE_TIES_ADJUST_FOR_LEDGER_LINES          "ui/score/ties/adjustForLedgerLines"
 #define PREF_UI_SCORE_TIES_UNIFORM_ADJUSTMENTS              "ui/score/ties/uniformTieAdjustments"
+#define PREF_UI_SCORE_FINGERING_OMIT_VOICING                "ui/score/fingering/omitVoicing"
+#define PREF_UI_SCORE_FINGERING_OMIT_TIGHTENING             "ui/score/fingering/omitTightening"
 #define PREF_UI_THEME_ICONHEIGHT                            "ui/theme/iconHeight"
 #define PREF_UI_THEME_ICONWIDTH                             "ui/theme/iconWidth"
 #define PREF_UI_THEME_FONTFAMILY                            "ui/theme/fontFamily"

--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -1508,8 +1508,32 @@ void Score::cmdSetBeamMode(Beam::Mode mode)
                         fingering->setTid(value);
                         fingering->styleChanged();
                         }
+                  else if (el->isBeam()) {
+                        // Beams: toggle Force Horizontal
+                        auto beam = toBeam(el);
+                        bool value = !beam->noSlope();
+                        beam->undoChangeProperty(Pid::USER_MODIFIED, false);
+                        beam->undoChangeProperty(Pid::BEAM_NO_SLOPE, value);
+                        beam->setPropertyFlags(Pid::BEAM_NO_SLOPE, PropertyFlags::UNSTYLED);
+                        }
+                  else if (el->isTuplet()) {
+                        // Tuples: Toggle Show/Auto bracket + NumberType
+                        auto tuplet = toTuplet(el);
+                        TupletNumberType  numberType = tuplet->numberType();
+                        TupletBracketType bracketType = tuplet->bracketType();
+                        if (mode == Beam::Mode::MID) {
+                              bracketType = tuplet->hasBracket() ? TupletBracketType::SHOW_NO_BRACKET : TupletBracketType::SHOW_BRACKET;
+                              tuplet->undoChangeProperty(Pid::BRACKET_TYPE, static_cast<int>(bracketType));
+                              tuplet->setPropertyFlags(Pid::BRACKET_TYPE, PropertyFlags::UNSTYLED);
+                              }
+                        else if (mode == Beam::Mode::BEGIN) {
+                              numberType = (tuplet->numberType() == TupletNumberType::SHOW_NUMBER) ? TupletNumberType::SHOW_RELATION                                                                                                   : TupletNumberType::SHOW_NUMBER;
+                              tuplet->undoChangeProperty(Pid::NUMBER_TYPE, static_cast<int>(numberType));
+                              tuplet->setPropertyFlags(Pid::NUMBER_TYPE, PropertyFlags::UNSTYLED);
+                              }
+                        }
                   }
-            }      
+            }
 
       for (ChordRest* cr : getSelectedChordRests()) {
             if (cr)

--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -20,6 +20,7 @@
 #include "clef.h"
 #include "excerpt.h"
 #include "fermata.h"
+#include "fingering.h"
 #include "glissando.h"
 #include "hairpin.h"
 #include "harmony.h"
@@ -1497,6 +1498,19 @@ void Score::cmdAddOttava(OttavaType type)
 
 void Score::cmdSetBeamMode(Beam::Mode mode)
       {
+      // Alternative features:
+      if (selection().isList()) {
+            for (auto el : selection().elements()) {
+                  if (el->isFingering()) {
+                        // TODO: Enable/disable **while** in fingering entry mode
+                        auto fingering = toFingering(el);
+                        Tid value = (fingering->tid() == Tid::LH_GUITAR_FINGERING) ? Tid::FINGERING : Tid::LH_GUITAR_FINGERING;
+                        fingering->setTid(value);
+                        fingering->styleChanged();
+                        }
+                  }
+            }      
+
       for (ChordRest* cr : getSelectedChordRests()) {
             if (cr)
                   cr->undoChangeProperty(Pid::BEAM_MODE, int(mode));

--- a/libmscore/fingering.cpp
+++ b/libmscore/fingering.cpp
@@ -106,8 +106,8 @@ void Fingering::layout()
       if (autoplace() && note()) {
             Note* n      = note();
             Chord* chord = n->chord();
-            bool voices  = chord->measure()->hasVoices(chord->staffIdx(), chord->tick(), chord->actualTicks());
-            bool tight   = voices && chord->notes().size() == 1 && !chord->beam() && tid() != Tid::STRING_NUMBER;
+            bool voices  = MScore::fingeringTextOmitVoicing ? false : chord->measure()->hasVoices(chord->staffIdx(), chord->tick(), chord->actualTicks());
+            bool tight   = MScore::fingeringTextOmitTightening ? false : voices && chord->notes().size() == 1 && !chord->beam() && tid() != Tid::STRING_NUMBER;
 
             qreal headWidth = n->bboxRightPos();
 

--- a/libmscore/fingering.cpp
+++ b/libmscore/fingering.cpp
@@ -103,13 +103,14 @@ void Fingering::layout()
       rypos() = 0.0;    // handle placement below
       qreal verticalSpacing = 0.15; // Percentage of text-height for stacking vertically
 
-      if (autoplace() && note()) {
+      if (note()) {
             Note* n      = note();
             Chord* chord = n->chord();
+            Note* downNote = chord->downNote();
+            qreal headWidth = n->bboxRightPos();
             bool voices  = MScore::fingeringTextOmitVoicing ? false : chord->measure()->hasVoices(chord->staffIdx(), chord->tick(), chord->actualTicks());
             bool tight   = MScore::fingeringTextOmitTightening ? false : voices && chord->notes().size() == 1 && !chord->beam() && tid() != Tid::STRING_NUMBER;
-
-            qreal headWidth = n->bboxRightPos();
+            bool ap = autoplace();
 
             // update offset after drag
             qreal rebase = 0.0;
@@ -129,10 +130,16 @@ void Fingering::layout()
                   SysStaff* ss = m->system()->staff(chord->vStaffIdx());
                   Staff* vStaff = chord->staff();     // TODO: use current height at tick
 
-                  if (n->mirror())
-                        rxpos() -= n->ipos().x();
-                  rxpos() += headWidth * .5;
-                  if (above) {
+                  if (n->mirror()) {
+                        qreal xOff = n->ipos().x();
+                        xOff -= (n != downNote) ? downNote->ipos().x() : 0.0;
+                        rxpos() -= xOff;
+                        }
+                  rxpos() += headWidth * 0.5;
+                  if (!ap) {
+                        rypos() += (above ? -sp : +sp) * 1.5;
+                        }
+                  else if (above) {
                         if (tight) {
                               if (chord->stem())
                                     rxpos() -= 0.8 * sp;
@@ -216,7 +223,8 @@ void Fingering::layout()
             // for other fingering styles, do not autoplace
 
             // restore autoplace
-            setAutoplace(true);
+            if (ap)
+                  setAutoplace(true);
             }
       else if (offsetChanged() != OffsetChange::NONE) {
             // rebase horizontally too, as autoplace may have adjusted it

--- a/libmscore/image.cpp
+++ b/libmscore/image.cpp
@@ -116,6 +116,22 @@ QSizeF Image::imageSize() const
       }
 
 //---------------------------------------------------------
+//   isEmpty()
+//---------------------------------------------------------
+
+bool Image::isEmpty() const
+      {
+      bool v = false;
+      switch (imageType) {
+            case ImageType::NONE:                     v = true;   break;
+            case ImageType::RASTER: if (!rasterDoc)   v = true;   break;
+            case ImageType::SVG:    if (!svgDoc)      v = true;   break;
+            default: break;
+            }
+      return v;
+      }
+
+//---------------------------------------------------------
 //   draw
 //---------------------------------------------------------
 

--- a/libmscore/image.h
+++ b/libmscore/image.h
@@ -95,6 +95,7 @@ class Image final : public BSymbol {
       void setImageType(ImageType);
       ImageType getImageType() const { return imageType; }
       bool isValid() const           { return rasterDoc || svgDoc; }
+      bool isEmpty() const;
 
       Element::EditBehavior normalModeEditBehavior() const override { return Element::EditBehavior::Edit; }
       int gripsCount() const override { return 8; }

--- a/libmscore/mscore.cpp
+++ b/libmscore/mscore.cpp
@@ -124,6 +124,8 @@ bool    MScore::cursorMoveByMeasure;
 bool    MScore::cursorDrawnBehindStaff;
 
 qreal   MScore::systemBracketMultiplier;
+bool    MScore::fingeringTextOmitVoicing;
+bool    MScore::fingeringTextOmitTightening;
 
 qreal   MScore::slurShoulderExtraMax;
 qreal   MScore::slurShoulderExtraMin;

--- a/libmscore/mscore.h
+++ b/libmscore/mscore.h
@@ -370,6 +370,8 @@ class MScore {
       static bool cursorDrawnBehindStaff;
 
       static qreal systemBracketMultiplier;
+      static bool  fingeringTextOmitVoicing;
+      static bool  fingeringTextOmitTightening;
 
       static qreal slurShoulderExtraMax;
       static qreal slurShoulderExtraMin;

--- a/libmscore/navigate.cpp
+++ b/libmscore/navigate.cpp
@@ -25,6 +25,7 @@
 #include "spanner.h"
 #include "staff.h"
 #include "system.h"
+#include "tuplet.h"
 #include "utils.h"
 
 namespace Ms {
@@ -664,8 +665,78 @@ Element* Score::nextElement()
             switch (e->type()) {
                   case ElementType::NOTE:
                   case ElementType::REST:
-                  case ElementType::CHORD:
-                  case ElementType::TUPLET: {
+                  case ElementType::TUPLET:
+                  case ElementType::CHORD: {
+                        if (e->isNote()) {
+                              auto n = toNote(e);
+                              auto c = n->chord();
+                              auto tuple = c->tuplet();
+                              bool ending = (n == c->downNote());
+                              if (ending) {
+                                    if (auto next = c->nextSegmentElement()) {
+                                          if (next->isNote()) {
+                                                auto nn = toNote(next);
+                                                auto nc = nn->chord();
+                                                if (nc != c) {
+                                                      if (auto t = nc->tuplet()) {
+                                                            if (t != tuple) {
+                                                                  return t;
+                                                                  }
+                                                            }
+                                                      }
+                                                }
+                                          else if (next->isRest()) {
+                                                auto rr = toRest(next);
+                                                if (auto t = rr->tuplet()) {
+                                                      if (t != tuple) {
+                                                            return t;
+                                                            }
+                                                      }
+                                                }
+                                          }
+                                    }
+                              }
+                        else if (e->isRest()) {
+                              auto r = toRest(e);
+                              if (!r->isGap()) {
+                                    auto tuple = r->tuplet();
+                                    if (auto next = r->nextSegmentElement()) {
+                                          if (next->isNote()) {
+                                                auto nn = toNote(next);
+                                                auto nc = nn->chord();
+                                                if (auto t = nc->tuplet()) {
+                                                      if (t != tuple) {
+                                                            return t;
+                                                            }
+                                                      }
+                                                }
+                                          else if (next->isRest()) {
+                                                auto rr = toRest(next);
+                                                if (auto t = rr->tuplet()) {
+                                                      if (t != tuple) {
+                                                            return t;
+                                                            }
+                                                      }
+                                                }
+                                          }
+                                    }
+                              }
+                        else if (e->isTuplet()) {
+                              if (auto t = toTuplet(e)) {
+                                    Note* n = nullptr;
+                                    DurationElement* de = t->elements().front();
+                                    if (de->isChord()) {
+                                          auto c = toChord(de);
+                                          n = c->upNote();
+                                          return n;
+                                          }
+                                    else if (de->isRest()) {
+                                          auto r = toRest(de);
+                                          return r;
+                                          }
+                                    }
+                              }
+
                         Element* next = e->nextElement();
                         if (next)
                               return next;

--- a/mscore/editelement.cpp
+++ b/mscore/editelement.cpp
@@ -26,6 +26,7 @@
 #include "libmscore/text.h"
 #include "libmscore/spanner.h"
 #include "libmscore/measure.h"
+#include "libmscore/textedit.h"
 #include "libmscore/textframe.h"
 
 namespace Ms {
@@ -103,6 +104,13 @@ void ScoreView::startEditMode(Element* e)
             changeState(ViewState::NORMAL);
       editData.element = e;
       changeState(ViewState::EDIT);
+      if (e->isTextBase()) {
+            auto txt = toTextBase(e);
+            TextEditData* ted = static_cast<TextEditData*>(editData.getData(e));
+            TextCursor* _cursor = &ted->cursor;
+            txt->selectAll(_cursor);
+            }
+      adjustCanvasPosition(e, false);
       }
 
 //---------------------------------------------------------

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -103,9 +103,11 @@
 #include "libmscore/chord.h"
 #include "libmscore/chordlist.h"
 #include "libmscore/drumset.h"
+#include "libmscore/element.h"
 #include "libmscore/excerpt.h"
 #include "libmscore/fingering.h"
 #include "libmscore/harmony.h"
+#include "libmscore/image.h"
 #include "libmscore/instrtemplate.h"
 #include "libmscore/measure.h"
 #include "libmscore/mscore.h"
@@ -6672,6 +6674,14 @@ void MuseScore::cmd(QAction* a, const QString& cmd)
                               bool invert = !fingering->visible();
                               fingering->setVisible(invert);
                               fingering->triggerLayout();
+                              }
+                        else if (el->isImage()) {
+                              auto img = toImage(el);
+                              if (img->isEmpty()) {
+                                    bool invert = !img->visible();
+                                    img->setVisible(invert);
+                                    img->triggerLayout();
+                                    }
                               }
                        }
                   }

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -104,6 +104,7 @@
 #include "libmscore/chordlist.h"
 #include "libmscore/drumset.h"
 #include "libmscore/excerpt.h"
+#include "libmscore/fingering.h"
 #include "libmscore/harmony.h"
 #include "libmscore/instrtemplate.h"
 #include "libmscore/measure.h"
@@ -6656,6 +6657,29 @@ void MuseScore::cmd(QAction* a, const QString& cmd)
             cs->setShowPageborders(a->isChecked());
             cs->setMarkIrregularMeasures(a->isChecked());
             cs->update();
+            }
+      else if (cmd == "toggle-fingering-visibility") {
+            bool wasNotShowingInvisible = false;
+            if (!cs->showInvisible()) {
+                  wasNotShowingInvisible = true;
+                  cs->setShowInvisible(true);
+                  cs->rebuildBspTree();
+                  }
+            for (auto& page : cs->pages()) {
+                  for (auto el : page->elements()) {
+                        if (el->isFingering()) {
+                              auto fingering = toFingering(el);
+                              bool invert = !fingering->visible();
+                              fingering->setVisible(invert);
+                              fingering->triggerLayout();
+                              }
+                       }
+                  }
+            cs->setLayoutAll();
+            cs->update();
+            if (wasNotShowingInvisible) {
+                  cs->setShowInvisible(false);
+                  }
             }
       else if (cmd == "show-unprintable") {
             cs->setShowUnprintable(a->isChecked());

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -477,6 +477,8 @@ void updateExternalValuesFromPreferences() {
       MScore::cursorDrawnBehindStaff = preferences.getBool(PREF_SCORE_PLAYBACK_CURSOR_BACKGROUND);
 
       MScore::systemBracketMultiplier = preferences.getDouble(PREF_UI_SCORE_BRACKET_MULTIPLIER);
+      MScore::fingeringTextOmitVoicing = preferences.getBool(PREF_UI_SCORE_FINGERING_OMIT_VOICING);
+      MScore::fingeringTextOmitTightening = preferences.getBool(PREF_UI_SCORE_FINGERING_OMIT_TIGHTENING);
 
       MScore::highlightNotes  = preferences.getBool(PREF_SCORE_PLAYBACK_HIGHLIGHT_NOTES);
       MScore::highlightRests  = preferences.getBool(PREF_SCORE_PLAYBACK_HIGHLIGHT_RESTS);

--- a/mscore/preferences.cpp
+++ b/mscore/preferences.cpp
@@ -296,6 +296,8 @@ void Preferences::init(bool storeInMemoryOnly)
             {PREF_UI_SCORE_SLURS_MIN_SHOULDER_EXTRA,               new DoublePreference(1.2)},
             {PREF_UI_SCORE_TIES_ADJUST_FOR_LEDGER_LINES,           new BoolPreference(true)},
             {PREF_UI_SCORE_TIES_UNIFORM_ADJUSTMENTS,               new BoolPreference(false)},
+            {PREF_UI_SCORE_FINGERING_OMIT_VOICING,                 new BoolPreference(false)},
+            {PREF_UI_SCORE_FINGERING_OMIT_TIGHTENING,              new BoolPreference(false)},
             {PREF_UI_THEME_ICONWIDTH,                              new IntPreference(28, false)},
             {PREF_UI_THEME_ICONHEIGHT,                             new IntPreference(24, false)},
             {PREF_UI_THEME_FONTFAMILY,                             new StringPreference(QApplication::font().family(), false) },

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -3710,9 +3710,11 @@ void ScoreView::textTab(bool back)
       if (!editMode())
             return;
       Element* oe = editData.element;
-      auto cr = score()->selection().currentCR();
-      bool fMeasureSkip  = oe->isFingering() && (editData.key == Qt::Key_Tab || editData.key == Qt::Key_Backtab);
-      bool fChordSkip    = oe->isFingering() && (editData.key == Qt::Key_Space && (editData.modifiers & CONTROL_MODIFIER));
+      bool isFingering = oe->isFingering();
+      auto originalEl = score()->selection().element();
+      auto cr = score()->selection().currentCR();// score()->selection().cr();
+      bool fMeasureSkip  = isFingering && (editData.key == Qt::Key_Tab || editData.key == Qt::Key_Backtab);
+      bool fChordSkip    = isFingering && (editData.key == Qt::Key_Space && (editData.modifiers & CONTROL_MODIFIER));
       bool fingeringJump = fMeasureSkip || fChordSkip;
 
       if (!oe || !oe->isTextBase())
@@ -3762,6 +3764,13 @@ void ScoreView::textTab(bool back)
       Tid defaultTid;
       Tid tid;
       auto nextElement = back ? score()->prevElement() : score()->nextElement();
+      if (nextElement) {
+            // qDebug() << "nextElement: " << nextElement->name() << nextElement->tick().print();
+            }
+      bool sameParent = false;
+      if (originalEl && nextElement && (originalEl->parent() == nextElement->parent())) {
+            sameParent = true;
+            }
       if (!fingeringJump) {
             defaultTid = Tid(ot->propertyDefault(Pid::SUB_STYLE).toInt());
             tid = ot->tid();
@@ -3770,13 +3779,14 @@ void ScoreView::textTab(bool back)
             }
       else  {
             type = ElementType::FINGERING;
-            staffIdx = cr->staffIdx();
+            staffIdx = originalEl ? originalEl->staffIdx() : 0;
             tid = toFingering(oe)->tid();
             defaultTid = tid;
             }
 
       // get prev/next element now, as current element may be deleted if empty
       Element* el = fingeringJump ? cr : nextElement;
+      Element* prevEl = el;
 
       // end edit mode
       changeState(ViewState::NORMAL);
@@ -3808,12 +3818,44 @@ void ScoreView::textTab(bool back)
                         break;
                   here = true;
                   }
+            else if (el->isBarLine() && !back) {
+                  auto bl = toBarLine(el);
+                  auto tick = bl->tick();
+                  if (auto m = score()->tick2measure(tick)) {
+                        if (auto seg = m->findFirstR(SegmentType::ChordRest, tick)) {
+                              if (auto fe = seg->firstElement(bl->staffIdx())) {
+                                    el = fe;
+                                    if (el->isNote() || el->tick() < tick)
+                                          break;
+                                    }
+                              }
+                        }
+                  }
+
             // get prev/next note
             score()->select(el);
             Element* el2 = back ? score()->prevElement() : score()->nextElement();
+
+            // SITUATION: On last note of penultimate measure of system: place fingering -- auto move forward
+            /// last measure of system has whole note... and this is skipped for some reason
+            if (!el2) {
+                  auto ns = back ? cr->segment()->prev1(SegmentType::ChordRest) : cr->segment()->next1(SegmentType::ChordRest);
+                  ChordRest* ncr = ns ? ns->nextChordRest(trackZeroVoice(cr->track()), back) : nullptr;
+                  if (ncr) {
+                        if (ncr->isChord())
+                              el2 = toChord(ncr)->upNote();
+                        else el2 = ncr;
+                        }
+                  }
+
             // start/end of score reached
             if (el2 == el)
                   break;
+            else if (el2 == nextElement)
+                  break;
+            else if (el2 == prevEl)
+                  break;
+            prevEl = el;
             el = el2;
             }
       if (!el || !el->isNote()) {

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -6223,8 +6223,25 @@ void ScoreView::cmdAddText(Tid tid, Tid customTid, PropertyFlags pf, Placement p
             case Tid::STRING_NUMBER:
                   {
                   Element* e = _score->getSelectedElement();
-                  if (!e || !e->isNote())
+
+                  if (!e)
                         break;
+
+                  if (!e->isNote()) {
+                        if (e->isRest()) {
+                              while (e && !e->isNote()) {
+                                    bool end = (e->tick() >= score()->lastMeasure()->tick());
+                                    if (end)
+                                          break;
+                                    e = e->nextSegmentElement();
+                                    }
+                              }
+                        else break;
+                        }
+
+                  if (!e->isNote())
+                      break;
+
                   bool isTablature = e->staff()->isTabStaff(e->tick());
                   bool tabFingering = e->staff()->staffType(e->tick())->showTabFingering();
                   if (isTablature && !tabFingering)

--- a/mscore/shortcut.cpp
+++ b/mscore/shortcut.cpp
@@ -2891,6 +2891,16 @@ Shortcut Shortcut::_sc[] = {
       {
          MsWidget::MAIN_WINDOW,
          STATE_NORMAL | STATE_NOTE_ENTRY,
+         "toggle-fingering-visibility",
+         QT_TRANSLATE_NOOP("action","Toggle Visibility Attribute of all Fingering Texts"),
+         QT_TRANSLATE_NOOP("action","Toggle Visibility Attribute of all Fingering Texts"),
+         0,
+         Icons::Invalid_ICON,
+         Qt::WindowShortcut,
+         },
+      {
+         MsWidget::MAIN_WINDOW,
+         STATE_NORMAL | STATE_NOTE_ENTRY,
          "show-unprintable",
          QT_TRANSLATE_NOOP("action","Show Unprintable"),
          QT_TRANSLATE_NOOP("action","Show unprintable"),


### PR DESCRIPTION
TODO: Update messages here.

**Fingering Texts**:

+ **Begin fingering at nearest next note** if invoked upon a rest (instead of doing nothing)
+ Advanced Preference ("hack" instead of an actual style setting) to **disable multi-voiced layout of fingering** and act as if only one voice exists
TODO: Demonstration of before/after
+ If autoplace is off, fingering layout will apply directly above the notehead (often found with beamed notes e.g.)
+ Command: **Toggle Visibility Attribute of all Fingering Texts** to show/hide all fingering texts
+ Command: **Toggle Visibility Attribute of all Fingering Texts** includes show/hide of empty images (which are now used as frames/highlighting
+ **Modified Command: Beam-style** shortcuts  Begin/Middle will toggle LH-Guitar style/Default fingering style on a fingering text
+ **Modified Command: Beam-style** will force/un-force horizontal beam
+ **Modified Behavior:** Entering into **Edit Mode of a Text** will highlight the entire text field, making it easier to begin (left arrow)/end (right arrow) or replace entirely
+ Includes some generic fixes for moving forward in fingering mode