### PR TITLE
Color Control: Invisible elements + Option to fade scoreview when not in focus

### DIFF
--- a/global/settings/types/preferencekeys.h
+++ b/global/settings/types/preferencekeys.h
@@ -187,6 +187,7 @@
 #define PREF_UI_SCORE_VOICE2_COLOR                          "ui/score/voice2/color"
 #define PREF_UI_SCORE_VOICE3_COLOR                          "ui/score/voice3/color"
 #define PREF_UI_SCORE_VOICE4_COLOR                          "ui/score/voice4/color"
+#define PREF_UI_SCORE_INVISIBLE_COLOR                       "ui/score/elements/override/color/invisible"
 #define PREF_UI_SCORE_BRACKET_MULTIPLIER                    "ui/score/bracket/multiplier"
 #define PREF_UI_SCORE_SLURS_MAX_SHOULDER_EXTRA              "ui/score/slurs/shoulder/extraHeight"
 #define PREF_UI_SCORE_SLURS_MIN_SHOULDER_EXTRA              "ui/score/slurs/shoulder/extraHeightSmall"

--- a/global/settings/types/preferencekeys.h
+++ b/global/settings/types/preferencekeys.h
@@ -125,6 +125,7 @@
 #define PREF_SCORE_NOTE_INPUT_DISABLE_MOUSE_INPUT           "ui/score/noteEntry/disableMouseEntry"
 #define PREF_UI_SCORE_DISABLE_NOTE_DRAG_VERTICAL            "ui/score/mouse/behavior/disableNoteDragVertical"
 #define PREF_UI_SCORE_LASSO_WITHOUT_SHIFT                   "ui/score/mouse/behavior/enableLassoWithoutShift"
+#define PREF_UI_SCORE_FADE_FOCUS                            "ui/score/fadeFocusUsesInvisibleColor"
 #define PREF_SCORE_NOTE_INPUT_OCTAVE_TENDENCY               "ui/score/noteEntry/octaveTendencyIsTopNote"
 #define PREF_SCORE_NOTE_INPUT_FIFTH_IS_UPWARD               "ui/score/noteEntry/octaveUpwardFifth"
 #define PREF_SCORE_NOTE_INPUT_RESET_PITCH_AT_SYSTEM         "ui/score/noteEntry/resetNoteEntryAtSystemOrCourtesy"

--- a/libmscore/element.cpp
+++ b/libmscore/element.cpp
@@ -569,8 +569,10 @@ QColor Element::curColor(bool isVisible, QColor normalColor) const
                   return QColor(red + tint * (255 - red), green + tint * (255 - green), blue + tint * (255 - blue));
                   }
             }
+
       if (!isVisible)
-            return Qt::gray;
+            return MScore::invisibleElementsColor;
+
       return normalColor;
       }
 

--- a/libmscore/mscore.cpp
+++ b/libmscore/mscore.cpp
@@ -90,6 +90,7 @@ qreal   MScore::horizontalPageGapOdd = 50.0;
 QColor  MScore::selectColor[VOICES];
 QColor  MScore::cursorColor;
 QColor  MScore::defaultColor;
+QColor  MScore::invisibleElementsColor;
 bool    MScore::cursorResetToStart;
 bool    MScore::selectionFollowsCursor;
 

--- a/libmscore/mscore.cpp
+++ b/libmscore/mscore.cpp
@@ -119,6 +119,7 @@ QColor  MScore::dropColor;
 bool    MScore::warnPitchRange;
 bool    MScore::disableMouseEntry;
 int     MScore::pedalEventsMinTicks;
+bool    MScore::fadeFocus;
 
 bool    MScore::cursorMoveByBeat;
 bool    MScore::cursorMoveByMeasure;

--- a/libmscore/mscore.h
+++ b/libmscore/mscore.h
@@ -336,6 +336,7 @@ class MScore {
       static QColor selectColor[VOICES];
       static QColor cursorColor;
       static QColor defaultColor;
+      static QColor invisibleElementsColor;
       static bool   cursorResetToStart;
       static bool   selectionFollowsCursor;
 

--- a/libmscore/mscore.h
+++ b/libmscore/mscore.h
@@ -366,6 +366,8 @@ class MScore {
       static bool disableMouseEntry;
       static int pedalEventsMinTicks;
 
+      static bool fadeFocus;
+
       static bool cursorMoveByBeat;
       static bool cursorMoveByMeasure;
       static bool cursorDrawnBehindStaff;

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -474,6 +474,7 @@ void updateExternalValuesFromPreferences() {
       MScore::selectColor[2] = preferences.getColor(PREF_UI_SCORE_VOICE3_COLOR);
       MScore::selectColor[3] = preferences.getColor(PREF_UI_SCORE_VOICE4_COLOR);
       MScore::cursorColor    = preferences.getColor(PREF_UI_SCORE_CURSOR_COLOR);
+      MScore::invisibleElementsColor = preferences.getColor(PREF_UI_SCORE_INVISIBLE_COLOR);
 
       MScore::cursorMoveByBeat = preferences.getBool(PREF_SCORE_PLAYBACK_CURSOR_MOVE_BY_BEAT);
       MScore::cursorMoveByMeasure = preferences.getBool(PREF_SCORE_PLAYBACK_CURSOR_ENTIRE_MEASURE);

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -465,6 +465,7 @@ void updateExternalValuesFromPreferences() {
       MScore::warnPitchRange = preferences.getBool(PREF_SCORE_NOTE_WARNPITCHRANGE);
       MScore::disableMouseEntry = preferences.getBool(PREF_SCORE_NOTE_INPUT_DISABLE_MOUSE_INPUT);
       MScore::pedalEventsMinTicks = preferences.getInt(PREF_IO_MIDI_PEDAL_EVENTS_MIN_TICKS);
+      MScore::fadeFocus = preferences.getBool(PREF_UI_SCORE_FADE_FOCUS);
       MScore::layoutBreakColor = preferences.getColor(PREF_UI_SCORE_LAYOUTBREAKCOLOR);
       MScore::frameMarginColor = preferences.getColor(PREF_UI_SCORE_FRAMEMARGINCOLOR);
       MScore::setVerticalOrientation(preferences.getBool(PREF_UI_CANVAS_SCROLL_VERTICALORIENTATION));

--- a/mscore/preferences.cpp
+++ b/mscore/preferences.cpp
@@ -224,6 +224,7 @@ void Preferences::init(bool storeInMemoryOnly)
             {PREF_SCORE_NOTE_DEFAULTPLAYDURATION,                  new IntPreference(300 /* ms */, false)},
             {PREF_SCORE_NOTE_WARNPITCHRANGE,                       new BoolPreference(true, false)},
             {PREF_SCORE_NOTE_INPUT_DISABLE_MOUSE_INPUT,            new BoolPreference(false, true)},
+            {PREF_UI_SCORE_FADE_FOCUS,                             new BoolPreference(false, false)},
             {PREF_SCORE_NOTE_INPUT_OCTAVE_TENDENCY,                new BoolPreference(false, true)},
             {PREF_SCORE_NOTE_INPUT_FIFTH_IS_UPWARD,                new BoolPreference(false)},
             {PREF_SCORE_NOTE_INPUT_RETAIN_AUG_RHYTHM_MODE,         new BoolPreference(false)},

--- a/mscore/preferences.cpp
+++ b/mscore/preferences.cpp
@@ -291,6 +291,7 @@ void Preferences::init(bool storeInMemoryOnly)
             {PREF_UI_SCORE_VOICE3_COLOR,                           new ColorPreference(QColor(0xC53F00))},
             {PREF_UI_SCORE_VOICE4_COLOR,                           new ColorPreference(QColor(0xC31989))},
             {PREF_UI_SCORE_CURSOR_COLOR,                           new ColorPreference(QColor(0x0065BF))},
+            {PREF_UI_SCORE_INVISIBLE_COLOR,                        new ColorPreference(QColor(Qt::gray))},
             {PREF_UI_SCORE_BRACKET_MULTIPLIER,                     new DoublePreference(0.25)},
             {PREF_UI_SCORE_SLURS_MAX_SHOULDER_EXTRA,               new DoublePreference(1.8)}, // Use 1.0 for 3.6.2 equivalent
             {PREF_UI_SCORE_SLURS_MIN_SHOULDER_EXTRA,               new DoublePreference(1.2)},

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -1874,6 +1874,16 @@ void ScoreView::paint(const QRect& r, QPainter& p)
       p.setWorldMatrixEnabled(false);
 
       p.restore();
+
+      if (MScore::fadeFocus && !hasFocus()) {
+            auto w = width();
+            auto h = height();
+            QColor c = MScore::invisibleElementsColor;
+            c.setAlpha(50);
+            QBrush b = QBrush(c);
+            p.setPen(Qt::NoPen);
+            p.fillRect(0,0, w, h, b);
+            }
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
**Advanced Preference** : `ui/score/elements/override/color/invisible`
Provides user-control over invisible elements color (originally no control with default color gray in MS3/4)

**Advanced Preference**: `ui/score/fadeFocusUsesInvisibleColor`
**Purpose**: give a strong immediate impression of having lost focus (can be useful when switching between PDFs back to the program etc.). Has the side-effect of fading-out when palettes have focus, but that too could be seen as useful in providing visual feedback to know the score doesn't have keyboard focus.

As the name suggests, the fade-out color is the controllable invisibility color

[FocusFade.webm](https://github.com/user-attachments/assets/2547a025-509b-4a7e-9154-5e12c56573b4)