### PR TITLE
Mouse Hover coloring of elements

### DIFF
--- a/global/settings/types/preferencekeys.h
+++ b/global/settings/types/preferencekeys.h
@@ -122,6 +122,8 @@
 #define PREF_SCORE_NOTE_PLAYONCLICK                         "score/note/playOnClick"
 #define PREF_SCORE_NOTE_DEFAULTPLAYDURATION                 "score/note/defaultPlayDuration"
 #define PREF_SCORE_NOTE_WARNPITCHRANGE                      "score/note/warnPitchRange"
+#define PREF_SCORE_HOVER_COLOR                              "ui/score/mouse/behavior/hoverColor"
+#define PREF_SCORE_HOVER_COLOR_ENABLE                       "ui/score/mouse/behavior/hoverEnabled"
 #define PREF_SCORE_NOTE_INPUT_DISABLE_MOUSE_INPUT           "ui/score/noteEntry/disableMouseEntry"
 #define PREF_UI_SCORE_DISABLE_NOTE_DRAG_VERTICAL            "ui/score/mouse/behavior/disableNoteDragVertical"
 #define PREF_UI_SCORE_LASSO_WITHOUT_SHIFT                   "ui/score/mouse/behavior/enableLassoWithoutShift"

--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -1043,6 +1043,8 @@ ChordRest* Score::searchNote(const Fraction& tick, int track) const
       {
       ChordRest* ipe = 0;
       SegmentType st = SegmentType::ChordRest;
+      if (track < 0)
+            track = 0;
       for (Segment* segment = firstSegment(st); segment; segment = segment->next1(st)) {
             ChordRest* cr = segment->cr(track);
             if (!cr)

--- a/libmscore/ledgerline.cpp
+++ b/libmscore/ledgerline.cpp
@@ -40,6 +40,8 @@ LedgerLine::LedgerLine(Score* s)
 QPointF LedgerLine::pagePos() const
       {
       System* system = chord()->measure()->system();
+      if (!system)
+            return canvasPos();
       qreal yp = y() + system->staff(staffIdx())->y() + system->y();
       return QPointF(pageX(), yp);
       }

--- a/libmscore/mscore.cpp
+++ b/libmscore/mscore.cpp
@@ -150,6 +150,8 @@ QColor  MScore::bgColor;
 QColor  MScore::dropColor;
 bool    MScore::warnPitchRange;
 bool    MScore::disableMouseEntry;
+QColor  MScore::hoverColor;
+bool    MScore::hoverColorEnabled;
 int     MScore::pedalEventsMinTicks;
 bool    MScore::fadeFocus;
 

--- a/libmscore/mscore.h
+++ b/libmscore/mscore.h
@@ -395,6 +395,8 @@ class MScore {
       static QColor bgColor;
       static bool warnPitchRange;
       static bool disableMouseEntry;
+      static QColor hoverColor;
+      static bool   hoverColorEnabled;
       static int pedalEventsMinTicks;
 
       static bool fadeFocus;

--- a/libmscore/mscoreview.h
+++ b/libmscore/mscoreview.h
@@ -61,7 +61,7 @@ class MuseScoreView {
       virtual void startEdit(Element*, Grip /*startGrip*/) {}
       virtual void startNoteEntryMode() {}
       virtual void drawBackground(QPainter*, const QRectF&) const = 0;
-      virtual void setDropTarget(const Element*) {}
+      virtual void setDropTarget(const Element*, bool highlight=true) {}
       virtual void drawBackgroundOffset(QPainter*, const QRectF&, const QRectF&, const Element* el=nullptr) const = 0;
 
       virtual void textTab(bool /*back*/) {}

--- a/libmscore/shape.cpp
+++ b/libmscore/shape.cpp
@@ -284,6 +284,16 @@ void Shape::paint(QPainter& p) const
             p.drawRect(r);
       }
 
+//---------------------------------------------------------
+//   paint with adjustment on rectangle
+//---------------------------------------------------------
+
+void Shape::paint(QPainter& p, qreal adjust) const
+      {
+      for (const QRectF& r : *this)
+            p.drawRect(r.adjusted(-adjust, -adjust, adjust, adjust));
+      }
+
 #ifndef NDEBUG
 //---------------------------------------------------------
 //   dump

--- a/libmscore/shape.h
+++ b/libmscore/shape.h
@@ -87,6 +87,7 @@ class Shape : public std::vector<ShapeElement> {
       bool intersects(const QRectF& rr) const;
       bool intersects(const Shape&) const;
       void paint(QPainter&) const;
+      void paint(QPainter&, qreal adjust) const;
 
 #ifndef NDEBUG
       void dump(const char*) const;

--- a/libmscore/stafflines.cpp
+++ b/libmscore/stafflines.cpp
@@ -49,8 +49,16 @@ StaffLines::StaffLines(Score* s)
 
 QPointF StaffLines::pagePos() const
       {
-      System* system = measure()->system();
-      return QPointF(measure()->x() + system->x(), system->staff(staffIdx())->y() + system->y());
+      auto m = measure();
+      auto s = m ? m->system() : nullptr;
+      qreal x = 0.0;
+      qreal y = 0.0;
+      if (m && s) {
+            auto staff = s->staff(staffIdx());
+            x += m->x() + s->x();
+            y += staff->y() + s->y();
+            }
+      return QPointF(x, y);
       }
 
 //---------------------------------------------------------

--- a/mscore/dragdrop.cpp
+++ b/mscore/dragdrop.cpp
@@ -34,7 +34,7 @@ namespace Ms {
 //   setDropTarget
 //---------------------------------------------------------
 
-void ScoreView::setDropTarget(const Element* el)
+void ScoreView::setDropTarget(const Element* el, bool highlight)
       {
       if (dropTarget != el) {
             if (dropTarget) {
@@ -43,7 +43,8 @@ void ScoreView::setDropTarget(const Element* el)
                   }
             dropTarget = el;
             if (dropTarget) {
-                  dropTarget->setDropTarget(true);
+                  if (highlight)
+                        dropTarget->setDropTarget(true);
                   }
             }
       if (!m_dropAnchorLines.isEmpty())

--- a/mscore/events.cpp
+++ b/mscore/events.cpp
@@ -247,6 +247,10 @@ void ScoreView::wheelEvent(QWheelEvent* event)
 
       scroll(dx, dy, QRect(0, 0, width(), height()));
       update (-10, 0, width() + 10, height());
+
+      QPointF mousePos(event->posF()); // P.S. posF() deprecated @ Qt 5.15 for position()
+      updateHover(mousePos);
+
       emit offsetChanged(_matrix.dx(), _matrix.dy());
       emit viewRectChanged();
       }
@@ -429,6 +433,8 @@ void ScoreView::mousePressEventNormal(QMouseEvent* ev)
       if (e) {
             if (keyState == (Qt::ShiftModifier | Qt::ControlModifier)) {
                   cloneElement(e);
+                  editData.buttons   = qApp->mouseButtons();
+                  editData.modifiers = qApp->keyboardModifiers();
                   return;
                   }
             if (e->isKeySig() && (keyState != Qt::ControlModifier) && st == SelectType::SINGLE) {
@@ -490,6 +496,7 @@ void ScoreView::mousePressEventNormal(QMouseEvent* ev)
                         }
                   }
             if (e) {
+                  setDropTarget(nullptr);
                   if (e->isNote() || e->isHarmony()) {
                         e->score()->updateCapo();
                         mscore->play(e);
@@ -590,7 +597,10 @@ void ScoreView::mousePressEvent(QMouseEvent* ev)
                         toTextBase(editData.element)->setPrimed(false);
                         }
 
-                  setEditElement(elementNear(editData.startMove));
+                  auto en = elementNear(editData.startMove);
+                  if (en && (en->isStaffLines() || en->isStaff()))
+                        en = nullptr;
+                  setEditElement(en);
                   mousePressEventNormal(ev);
                   }
                   break;
@@ -617,7 +627,6 @@ void ScoreView::mousePressEvent(QMouseEvent* ev)
                   if (ev->button() == Qt::RightButton)
                         _score->inputState().setRest(!restMode);
                   if (MScore::disableMouseEntry) {
-                        int track = _score->inputTrack();
                         if (auto el = elementAt(editData.pos)) {
                               if (!el->isStaffLines()) {
                                     _score->select(el);
@@ -636,7 +645,6 @@ void ScoreView::mousePressEvent(QMouseEvent* ev)
                                                 _score->inputState().moveInputPos(cr);
                                                 // Default into a voice-1 measure selection when in Note Entry
                                                 // Alternatively, pass track for retaining current voice
-                                                (void) track;
                                                 _score->cmdCycleVoiceFilter();
                                                 }
                                           }
@@ -719,6 +727,9 @@ void ScoreView::adjustCursorForTextEditing(QMouseEvent* mouseEvent)
 
 void ScoreView::mouseMoveEvent(QMouseEvent* me)
       {
+      if (MScore::hoverColorEnabled && me->buttons() == Qt::NoButton)
+            updateHover(me->localPos());
+
       adjustCursorForTextEditing(me);
 
       if (state != ViewState::NOTE_ENTRY && editData.buttons == Qt::NoButton)
@@ -1098,6 +1109,10 @@ void ScoreView::contextMenuEvent(QContextMenuEvent* ev)
             e = score()->selection().element();
       else
             e = elementNear(editData.startMove);
+
+      if (e && e->isStaffLines())
+            e = nullptr;
+
       if (e) {
             if (!e->selected()) {
                   // bool control = (ev->modifiers() & Qt::ControlModifier) ? true : false;
@@ -1270,7 +1285,9 @@ void ScoreView::changeState(ViewState s)
                   seq->stop();
                   break;
             case ViewState::EDIT:
+                  #if 0
                   setMouseTracking(false);
+                  #endif
                   break;
             default:
                   break;

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -467,6 +467,8 @@ void updateExternalValuesFromPreferences() {
       MScore::playbackSpeedIncrement = preferences.getInt(PREF_APP_PLAYBACK_SPEEDINCREMENT);
       MScore::warnPitchRange = preferences.getBool(PREF_SCORE_NOTE_WARNPITCHRANGE);
       MScore::disableMouseEntry = preferences.getBool(PREF_SCORE_NOTE_INPUT_DISABLE_MOUSE_INPUT);
+      MScore::hoverColor = preferences.getColor(PREF_SCORE_HOVER_COLOR);
+      MScore::hoverColorEnabled = preferences.getBool(PREF_SCORE_HOVER_COLOR_ENABLE);
       MScore::pedalEventsMinTicks = preferences.getInt(PREF_IO_MIDI_PEDAL_EVENTS_MIN_TICKS);
       MScore::fadeFocus = preferences.getBool(PREF_UI_SCORE_FADE_FOCUS);
       MScore::layoutBreakColor = preferences.getColor(PREF_UI_SCORE_LAYOUTBREAKCOLOR);
@@ -5199,6 +5201,7 @@ void MuseScore::undoRedo(bool undo)
       cv->startUndoRedo(undo);
       updateInputState(cs);
       endCmd(/* undoRedo */ true);
+      cv->setDropTarget(nullptr);
       if (pianorollEditor)
             pianorollEditor->update();
       if (tempVoiceFilter) {

--- a/mscore/preferences.cpp
+++ b/mscore/preferences.cpp
@@ -225,6 +225,8 @@ void Preferences::init(bool storeInMemoryOnly)
             {PREF_SCORE_NOTE_WARNPITCHRANGE,                       new BoolPreference(true, false)},
             {PREF_SCORE_NOTE_INPUT_DISABLE_MOUSE_INPUT,            new BoolPreference(false, true)},
             {PREF_UI_SCORE_FADE_FOCUS,                             new BoolPreference(false, false)},
+            {PREF_SCORE_HOVER_COLOR,                               new ColorPreference(QColor(0,0,0,0), true)},
+            {PREF_SCORE_HOVER_COLOR_ENABLE,                        new BoolPreference(false, false)},
             {PREF_SCORE_NOTE_INPUT_OCTAVE_TENDENCY,                new BoolPreference(false, true)},
             {PREF_SCORE_NOTE_INPUT_FIFTH_IS_UPWARD,                new BoolPreference(false)},
             {PREF_SCORE_NOTE_INPUT_RETAIN_AUG_RHYTHM_MODE,         new BoolPreference(false)},

--- a/mscore/scoreaccessibility.cpp
+++ b/mscore/scoreaccessibility.cpp
@@ -9,6 +9,7 @@
 #include "libmscore/spanner.h"
 #include "libmscore/sig.h"
 #include "libmscore/staff.h"
+#include "libmscore/stafflines.h"
 #include "libmscore/part.h"
 #include "libmscore/sym.h"
 #include "inspector/inspector.h"
@@ -226,7 +227,7 @@ void ScoreAccessibility::clearAccessibilityInfo()
       _oldStaff = -1;
       }
 
-void ScoreAccessibility::currentInfoChanged()
+void ScoreAccessibility::currentInfoChanged(Element* hover)
       {
       ScoreView* scoreView =  static_cast<MuseScore*>(mainWindow)->currentScoreView();
       Score* score = scoreView->score();
@@ -237,8 +238,8 @@ void ScoreAccessibility::currentInfoChanged()
       QString oldStatus = statusBarLabel->text();
       QString oldScreenReaderInfo = score->accessibleInfo();
       clearAccessibilityInfo();
-      if (score->selection().isSingle()) {
-            Element* e = score->selection().element();
+      if (score->selection().isSingle() || hover) {
+            Element* e = hover ? hover : score->selection().element();
             if (!e) {
                   return;
                   }
@@ -274,7 +275,19 @@ void ScoreAccessibility::currentInfoChanged()
                   std::pair<int, float>bar_beat = el->barbeat();
                   if (bar_beat.first) {
                         _oldBar = bar_beat.first;
-                        barsAndBeats += " " + tr("Measure: %1").arg(QString::number(bar_beat.first));
+                        if (el->isStaffLines()) {
+                              auto sl = toStaffLines(el);
+                              if (auto m = sl->measure()) {
+                                    auto relMeasureNumber = bar_beat.first;
+                                    auto absMeasureNumber = 1 + m->measureIndex();
+                                    auto finMeasureNumber = 1 + score->lastMeasure()->measureIndex();
+                                    barsAndBeats += " " + tr("Measure: %1 ").arg(QString::number(absMeasureNumber));
+                                    if (relMeasureNumber != absMeasureNumber)
+                                          barsAndBeats += tr("(Relative: %1) ").arg(QString::number(relMeasureNumber));
+                                    barsAndBeats += tr("/ %1").arg(QString::number(finMeasureNumber));
+                                    }
+                              }
+                        else barsAndBeats += " " + tr("Measure: %1").arg(QString::number(bar_beat.first));
                         if (bar_beat.first != oldBar)
                               optimizedBarsAndBeats += " " + tr("Measure: %1").arg(QString::number(bar_beat.first));
                         if (bar_beat.second) {
@@ -369,6 +382,11 @@ void ScoreAccessibility::currentInfoChanged()
 ScoreAccessibility* ScoreAccessibility::instance()
       {
       return inst;
+      }
+
+void ScoreAccessibility::updateLabel(QString s)
+      {
+      statusBarLabel->setText(s);
       }
 
 void ScoreAccessibility::updateAccessibilityInfo()

--- a/mscore/scoreaccessibility.h
+++ b/mscore/scoreaccessibility.h
@@ -81,10 +81,11 @@ class ScoreAccessibility : public QObject {
    public:
       ~ScoreAccessibility();
       void updateAccessibilityInfo();
+      void updateLabel(QString);
       void clearAccessibilityInfo();
       static void createInstance(QMainWindow* statusBar);
       static ScoreAccessibility* instance();
-      void currentInfoChanged();
+      void currentInfoChanged(Element* hover=nullptr);
       static void makeReadable(QString&);
 
    private slots:

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -109,6 +109,7 @@ ScoreView::ScoreView(QWidget* parent)
       setObjectName("scoreview");
       setStatusTip("scoreview");
       setAcceptDrops(true);
+      setMouseTracking(true);
 #ifndef Q_OS_MAC
       setAttribute(Qt::WA_OpaquePaintEvent);
 #endif
@@ -1489,12 +1490,52 @@ static void drawDebugInfo(QPainter& p, const Element* _e)
 #endif
 
 //---------------------------------------------------------
+//   drawHoverHighlight
+//   Highlight the element "to be selected" with a little
+//   bounding box
+//---------------------------------------------------------
+
+void ScoreView::drawHoverHighlight(QPainter& p, const Element& el)
+      {
+      auto x = std::max(0.0, el.pagePos().x());
+      auto y = std::max(0.0, el.pagePos().y());
+      qreal adj = 5.0;
+      QPointF pos(x,y);
+      if (pos.isNull())
+            return;
+
+      p.translate(pos);
+
+      // Highlight box:
+      p.setBrush(QBrush(MScore::hoverColor));
+      p.setPen(Qt::NoPen);
+
+      // Alternatively only draw border:
+      //    p.setBrush(Qt::NoBrush);
+      //    p.setPen(QPen(Qt::blue, 0.0)););
+
+      if (el.isSlurTieSegment())
+            el.shape().paint(p, +adj);
+      else
+            p.drawRect(el.bbox().adjusted(-adj, -adj, +adj, +adj));
+
+      p.translate(-pos);
+      }
+
+//---------------------------------------------------------
 //   drawElements
 //---------------------------------------------------------
 
 void ScoreView::drawElements(QPainter& painter, QList<Element*>& el, Element* editElement)
       {
       std::stable_sort(el.begin(), el.end(), elementLessThan);
+      bool opaqueHoverColor = (MScore::hoverColor.alpha() == 255); 
+      bool hoverUnder = opaqueHoverColor;
+      bool haveHover = MScore::hoverColorEnabled && dropTarget; 
+      
+      if (haveHover && hoverUnder)
+            drawHoverHighlight(painter, *dropTarget);
+
       for (const Element* e : el) {
             e->itemDiscovered = 0;
 
@@ -1516,6 +1557,9 @@ void ScoreView::drawElements(QPainter& painter, QList<Element*>& el, Element* ed
                   drawDebugInfo(painter, e);
 #endif
             }
+   
+      if (haveHover && !hoverUnder)
+            drawHoverHighlight(painter, *dropTarget);
       }
 
 //---------------------------------------------------------
@@ -2028,6 +2072,38 @@ void ScoreView::constraintCanvas (int* dxx, int* dyy)
             }
       *dxx = dx;
       *dyy = dy;
+      }
+
+//---------------------------------------------------------
+//   updateHover
+//---------------------------------------------------------
+
+void ScoreView::updateHover(const QPointF& position)
+      {
+      QPoint point = position.toPoint();
+
+      auto selected     = score()->selection().element();
+      auto pastHover    = dropTarget;
+      auto presentHover = elementNear(toLogical(point));
+
+      auto logicalPos = toLogical(point);
+      editData.pos = logicalPos;
+      editData.startMove = logicalPos;
+
+      QRectF view;
+      if (pastHover != presentHover) {
+            if (presentHover && (presentHover != selected)) {
+                  view = presentHover->canvasBoundingRect();
+                  setDropTarget(presentHover, false /*no highlight*/);
+                  }
+            else if (pastHover) {
+                  view = pastHover->canvasBoundingRect();
+                  setDropTarget(nullptr);
+                  }
+            const int margin = 2;
+            update(toPhysical(view).adjusted(-margin, -margin, +margin, +margin));
+            update();
+            }
       }
 
 //---------------------------------------------------------
@@ -2873,10 +2949,30 @@ void ScoreView::cmd(const char* s)
             {{"sticking-text"}, [](ScoreView* cv, const QByteArray&) {
                   cv->cmdAddText(Tid::STICKING);
                   }},
-            {{"edit-element"}, [](ScoreView* cv, const QByteArray&) {
-                  Element* e = cv->score()->selection().element();
-                  if (e && e->isEditable() && !cv->popupActive) {
-                        cv->startEditMode(e);
+            {{"edit-element"}, [&](ScoreView* cv, const QByteArray&) {
+                  if (auto e = cv->score()->selection().element()) {
+                        if (e->isEditable() && !cv->popupActive)
+                              cv->startEditMode(e);
+                        }
+                  else if (dropTarget && MScore::hoverColorEnabled) {
+                        QRectF r = dropTarget->canvasBoundingRect();
+                        if (dropTarget->isEditable() && !cv->popupActive) {
+                              if (dropTarget->isStaff() || dropTarget->isStaffLines()) {;}
+                              else cv->startEditMode(const_cast<Element*>(dropTarget));
+                              }
+
+                        if (auto e = editData.element) {
+                              if (e->isTextBase()) {
+                                    toTextBase(e)->mousePress(editData);
+                                    }
+                              }
+
+                        // Remove highlight:
+                        setDropTarget(nullptr);
+
+                        const int margin = 2;
+                        update(toPhysical(r).adjusted(-margin, -margin, +margin, +margin));
+                        update();
                         }
                   }},
             {{"select-similar"}, [](ScoreView* cv, const QByteArray&) {
@@ -4191,7 +4287,9 @@ void ScoreView::endNoteEntry()
                   el.front()->setSelected(false);
             is.setSlur(0);
             }
+      #if 0
       setMouseTracking(false);
+      #endif
       shadowNote->setVisible(false);
       setCursorOn(false);
       _score->setUpdateAll();
@@ -4572,6 +4670,18 @@ void ScoreView::adjustCanvasPosition(const Element* el, bool playBack, int staff
       if (!mscore->panDuringPlayback())
             return;
 
+      setDropTarget(nullptr);
+
+      if (noteEntryMode() && el && el->isChordRest() && !score()->selection().isRange()) {
+            if (auto current = score()->selection().cr()) {
+                  auto cr = toChordRest(el);
+                  auto selectionSys = current->measure() ? current->measure()->system() : nullptr;
+                  auto questionableSys = cr->measure() ? cr->measure()->system() : nullptr;
+                  if (questionableSys != selectionSys)
+                        return;
+                  }
+            }
+
       if (score()->layoutMode() == LayoutMode::LINE) {
 
             if (!el)
@@ -4805,6 +4915,9 @@ void ScoreView::adjustCanvasPosition(const Element* el, bool playBack, int staff
             cx = (x < 0) ? x : cx + _matrix.dx();
             }
       setOffset(cx, y);
+
+      const QPoint mousePos = mapFromGlobal(QCursor::pos());
+      updateHover(QPointF(mousePos));
       update();
       }
 
@@ -6820,7 +6933,8 @@ QList<Element*> ScoreView::elementsNear(QPointF p)
       for (Element* e : qAsConst(el)) {
             e->itemDiscovered = 0;
             if (!e->selectable() || e->isPage())
-                  continue;
+                  if (!(e->isStaff() || e->isStaffLines()))
+                        continue;
             if (e->contains(p))
                   ll.append(e);
             }

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -2095,14 +2095,27 @@ void ScoreView::updateHover(const QPointF& position)
             if (presentHover && (presentHover != selected)) {
                   view = presentHover->canvasBoundingRect();
                   setDropTarget(presentHover, false /*no highlight*/);
+                  ScoreAccessibility::instance()->currentInfoChanged(presentHover);
                   }
             else if (pastHover) {
                   view = pastHover->canvasBoundingRect();
                   setDropTarget(nullptr);
+                  ScoreAccessibility::instance()->updateAccessibilityInfo();
                   }
             const int margin = 2;
             update(toPhysical(view).adjusted(-margin, -margin, +margin, +margin));
             update();
+            }
+      if (!selected && !presentHover) {
+            if (Page* currentPage = point2page(editData.startMove)) {
+                  int currentPageNumber = currentPage->no() + 1;
+                  int totalPages = score()->npages();
+                  QString s = "Page: "
+                              + QString::number(currentPageNumber)
+                              + "/"
+                              + QString::number(totalPages);
+                  ScoreAccessibility::instance()->updateLabel(s);
+                  }
             }
       }
 

--- a/mscore/scoreview.h
+++ b/mscore/scoreview.h
@@ -283,6 +283,7 @@ class ScoreView : public QWidget, public MuseScoreView {
       void constraintCanvas(int *dxx, int *dyy);
 
       void setShadowNote(const QPointF&);
+      void drawHoverHighlight(QPainter&, const Element&);
       void drawElements(QPainter& p,QList<Element*>& el, Element* editElement);
       bool dragTimeAnchorElement(const QPointF& pos);
       bool dragMeasureAnchorElement(const QPointF& pos);
@@ -455,7 +456,7 @@ class ScoreView : public QWidget, public MuseScoreView {
       bool fotoMode() const;
 
       virtual void setDropRectangle(const QRectF&) override;
-      virtual void setDropTarget(const Element*) override;
+      virtual void setDropTarget(const Element*, bool highlight=true) override;
       void setDropAnchorLines(const QVector<QLineF> &anchorList);
       const QTransform& matrix() const  { return _matrix; }
 
@@ -533,6 +534,7 @@ class ScoreView : public QWidget, public MuseScoreView {
       void moveViewportToLastEdit();
 
       void updateShadowNotes();
+      void updateHover(const QPointF&);
 
       OmrView* omrView() const        { return _omrView; }
       void setOmrView(OmrView* v)     { _omrView = v;    }


### PR DESCRIPTION
### Mouse Hovering coloration:
`ui/score/mouse/behavior/hoverColor` **to define color**
`ui/score/mouse/behavior/hoverEnabled` **to enable/disable**

+ Also **applies to staff-lines**
+ **Updates Score Accessibility toolbar** as if having selected the hovered-over element
+ Hover color is **drawn "below" musical staff _if opaque_**, otherwise on top of all elements
+ **Mini Feature**: if no element is selected or is the same element hovered over, user can enter into edit mode via shortcut command while hovering (rather than needing to select + double-clicking)
+ New accessibility information includes:
  + **_Measures as relative/absolute_** and **_current/complete_**
  + **_Page number current/out of total_**

    [hover.webm](https://github.com/user-attachments/assets/d47785f1-44d4-4929-ba2b-4f811b725c35)
