### PR TITLE
Options to draw noteheads behind stafflines and ledgerlines

### DIFF
--- a/global/settings/types/preferencekeys.h
+++ b/global/settings/types/preferencekeys.h
@@ -172,6 +172,9 @@
 #define PREF_SCORE_PLAYBACK_HIGHLIGHT_MORE                  "ui/score/playback/highlightMore"
 #define PREF_SCORE_PLAYBACK_HIGHLIGHT_LYRICS                "ui/score/playback/highlightLyrics"
 
+#define PREF_UI_SCORE_NOTEHEADS_BEHIND_STAFF_LINES          "ui/score/elements/noteheads/behindStaff"
+#define PREF_UI_SCORE_NOTEHEADS_BEHIND_LEDGER_LINES         "ui/score/elements/noteheads/behindLedgerLines"
+
 #define PREF_SCORE_PLAYBACK_SELECT_POSITION_ON_STOP         "ui/score/playback/selectPlaybackPosition"
 #define PREF_SCORE_PLAYBACK_BRING_POSITION_TO_START         "ui/score/playback/resetToStart"
 #define PREF_UI_CANVAS_BG_USECOLOR                          "ui/canvas/background/useColor"

--- a/libmscore/mscore.cpp
+++ b/libmscore/mscore.cpp
@@ -98,6 +98,9 @@ QColor  MScore::lassoColor;
 bool    MScore::lassoBorderEnabled;
 QColor  MScore::gripsColor;
 
+bool    MScore::noteheadsBehindStaff;
+bool    MScore::noteheadsBehindLedger;
+
 QColor  MScore::overrideAllColor;
 QColor  MScore::overrideBarlinesColor;
 QColor  MScore::overrideBoxTextsColor;

--- a/libmscore/mscore.h
+++ b/libmscore/mscore.h
@@ -343,6 +343,9 @@ class MScore {
       static bool   singleNoteSelectionColorEnabled;
       static QColor gripsColor;
 
+      static bool noteheadsBehindStaff;
+      static bool noteheadsBehindLedger; 
+
       static QColor overrideAllColor;
       static QColor overrideBarlinesColor;
       static QColor overrideBoxTextsColor;

--- a/libmscore/scorefile.cpp
+++ b/libmscore/scorefile.cpp
@@ -1100,16 +1100,70 @@ void Score::print(QPainter* painter, int pageNo)
       MScore::pdfPrinting = true;
       Page* page = pages().at(pageNo);
       QRectF fr  = page->abbox();
+      QList<Element*> elements = page->items(fr);
+      std::stable_sort(elements.begin(), elements.end(), elementLessThan);
 
-      QList<Element*> ell = page->items(fr);
-      std::stable_sort(ell.begin(), ell.end(), elementLessThan);
-      for (const Element* e : qAsConst(ell)) {
+      // PASS #1
+      if (MScore::noteheadsBehindStaff) {
+            // Stems
+            for (const Element* e : elements) {
+                  if (!e->isStem())
+                        continue;
+                  if (!e->visible())
+                        continue;
+                  painter->save();
+                     QPointF pos(e->pagePos());
+                     painter->translate(pos);
+                        e->draw(painter);
+                     painter->translate(-pos);
+                  painter->restore();
+                  }
+            // Noteheads
+            for (const Element* e : elements) {
+                  if (!e->isNote())
+                        continue;
+                  if (!e->visible())
+                        continue;
+                  painter->save();
+                     QPointF pos(e->pagePos());
+                     painter->translate(pos);
+                        e->draw(painter);
+                     painter->translate(-pos);
+                  painter->restore();
+                  }
+            }
+
+      // PASS #2
+      // Regular:
+      for (const Element* e : qAsConst(elements)) {
+            if (MScore::noteheadsBehindLedger && e->isLedgerLine())
+                  continue;
+            if (MScore::noteheadsBehindStaff && (e->isNote() || e->isStem()))
+                  continue;
             if (!e->visible())
                   continue;
             painter->save();
-            painter->translate(e->pagePos());
-            e->draw(painter);
+               painter->translate(e->pagePos());
+                  e->draw(painter);
+               painter->translate(-e->pagePos());
             painter->restore();
+            }
+
+      // PASS #3
+      // Ledger Lines
+      if (MScore::noteheadsBehindLedger) {
+            for (const Element* e : elements) {
+                  if (!e->isLedgerLine())
+                        continue;
+                  if (!e->visible())
+                        continue;
+                  painter->save();
+                     QPointF pos(e->pagePos());
+                     painter->translate(pos);
+                        e->draw(painter);
+                     painter->translate(-pos);
+                  painter->restore();
+                  }
             }
       MScore::pdfPrinting = false;
       _printing = false;

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -509,6 +509,9 @@ void updateExternalValuesFromPreferences() {
       MScore::overrideStaffTextColor = preferences.getColor(PREF_UI_SCORE_OVERRIDE_STAFF_TEXT_COLOR);
       MScore::overrideTextLinesColor = preferences.getColor(PREF_UI_SCORE_OVERRIDE_TEXT_LINES_COLOR);
       MScore::overrideTiesColor = preferences.getColor(PREF_UI_SCORE_OVERRIDE_TIES_COLOR);
+
+      MScore::noteheadsBehindStaff = preferences.getBool(PREF_UI_SCORE_NOTEHEADS_BEHIND_STAFF_LINES);
+      MScore::noteheadsBehindLedger = preferences.getBool(PREF_UI_SCORE_NOTEHEADS_BEHIND_LEDGER_LINES);
       
       MScore::cursorMoveByBeat = preferences.getBool(PREF_SCORE_PLAYBACK_CURSOR_MOVE_BY_BEAT);
       MScore::cursorMoveByMeasure = preferences.getBool(PREF_SCORE_PLAYBACK_CURSOR_ENTIRE_MEASURE);

--- a/mscore/preferences.cpp
+++ b/mscore/preferences.cpp
@@ -244,6 +244,10 @@ void Preferences::init(bool storeInMemoryOnly)
             {PREF_SCORE_PLAYBACK_HIGHLIGHT_RESTS,                  new BoolPreference(true)},
             {PREF_SCORE_PLAYBACK_HIGHLIGHT_MORE,                   new BoolPreference(false)},
             {PREF_SCORE_PLAYBACK_HIGHLIGHT_LYRICS,                 new BoolPreference(false)},
+
+            {PREF_UI_SCORE_NOTEHEADS_BEHIND_STAFF_LINES,           new BoolPreference(false)},
+            {PREF_UI_SCORE_NOTEHEADS_BEHIND_LEDGER_LINES,          new BoolPreference(false)},
+
             {PREF_UI_CANVAS_BG_USECOLOR,                           new BoolPreference(true)},
             {PREF_UI_CANVAS_FG_USECOLOR,                           new BoolPreference(true)},
             {PREF_UI_CANVAS_FG_USECOLOR_IN_PALETTES,               new BoolPreference(false)},

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -1536,6 +1536,37 @@ void ScoreView::drawElements(QPainter& painter, QList<Element*>& el, Element* ed
       if (haveHover && hoverUnder)
             drawHoverHighlight(painter, *dropTarget);
 
+      // Option: Noteheads behind staff-lines
+      // Requires stem to be drawn before noteheads, and a multi-pass approach
+      // Alternatively could sort the element list first...
+      if (MScore::noteheadsBehindStaff) {
+            // Stems
+            for (const Element* e : el) {
+                  e->itemDiscovered = 0;
+                  if (!e->isStem())
+                        continue;
+                  if (!e->visible() && (score()->printing() || !score()->showInvisible()))
+                        continue;
+                  QPointF pos(e->pagePos());
+                  painter.translate(pos);
+                     e->draw(&painter);
+                  painter.translate(-pos);
+                  }
+            // Noteheads
+            for (const Element* e : el) {
+                  e->itemDiscovered = 0;
+                  if (!e->isNote())
+                        continue;
+                  if (!e->visible() && (score()->printing() || !score()->showInvisible()))
+                        continue;
+
+                  QPointF pos(e->pagePos());
+                  painter.translate(pos);
+                     e->draw(&painter);
+                  painter.translate(-pos);
+                  }
+            }
+
       for (const Element* e : el) {
             e->itemDiscovered = 0;
 
@@ -1543,7 +1574,10 @@ void ScoreView::drawElements(QPainter& painter, QList<Element*>& el, Element* ed
             // all normal draw(). Complete drawing is done in drawEditMode()
             if (e == editElement)
                   continue;
-
+            if (MScore::noteheadsBehindLedger && e->isLedgerLine())
+                  continue;
+            if (MScore::noteheadsBehindStaff && (e->isNote() || e->isStem()))
+                  continue;
             if (!e->visible() && (score()->printing() || !score()->showInvisible()))
                   continue;
             if (e->isRest() && toRest(e)->isGap())
@@ -1557,7 +1591,22 @@ void ScoreView::drawElements(QPainter& painter, QList<Element*>& el, Element* ed
                   drawDebugInfo(painter, e);
 #endif
             }
-   
+
+      if (MScore::noteheadsBehindLedger) {
+            for (const Element* e : el) {
+                  e->itemDiscovered = 0;
+                  if (!e->isLedgerLine())
+                        continue;
+                  if (!e->visible() && (score()->printing() || !score()->showInvisible()))
+                        continue;
+
+                  QPointF pos(e->pagePos());
+                  painter.translate(pos);
+                     e->draw(&painter);
+                  painter.translate(-pos);
+                  }
+            }
+
       if (haveHover && !hoverUnder)
             drawHoverHighlight(painter, *dropTarget);
       }


### PR DESCRIPTION
Sounds weird at first, but with the ability to override colors easily and use transparency, there may be some use for having noteheads drawn behind ledgerlines and stafflines if experimenting with color variations




