### PR TITLE
Lasso: allow to be drawn behind elements if mainly opaque color

### DIFF
--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -1627,6 +1627,17 @@ void ScoreView::paint(const QRect& r, QPainter& p)
       p.setTransform(_matrix);
       QRectF fr = imatrix.mapRect(QRectF(r));
 
+      if (state == ViewState::LASSO) {
+            if (!lasso->bbox().isEmpty()) {
+                  lassoToDraw = lasso;
+                  bool drawLassoBehindElements = (MScore::lassoColor.alpha() > 200);
+                  if (drawLassoBehindElements) {
+                        lassoToDraw->draw(&p);
+                        lassoToDraw = nullptr;
+                        }
+                  }
+            }
+
       if (MScore::cursorDrawnBehindStaff)
             _cursor->paint(&p);
 


### PR DESCRIPTION
_mainly opaque color_ means greater than 200 (alpha channel from [0..255])
Just another "miniature user control" hack

**Demonstration**:
First pass is opaque (behind elements), second is translucent layered over elements:

[LassoAboveBelow.webm](https://github.com/user-attachments/assets/fda50669-471f-4776-a4b6-b45c40769a86)

Probably should've accompanied the commit when the lasso color was made user-definable. . .

