### PR TITLE
Allow Alt-Menu to not have access to Alt-Modifier to allow for more keyboard shortcuts

### DIFF
--- a/global/settings/types/preferencekeys.h
+++ b/global/settings/types/preferencekeys.h
@@ -169,6 +169,8 @@
 #define PREF_UI_SCORE_OVERRIDE_TEXT_LINES_COLOR             "ui/score/elements/override/color/textLines"
 #define PREF_UI_SCORE_OVERRIDE_TIES_COLOR                   "ui/score/elements/override/color/ties"
 
+#define PREF_UI_SCORE_BYPASS_ALT_MENU                       "ui/application/altMenu/bypass"
+
 #define PREF_SCORE_PLAYBACK_HIGHLIGHT_NOTES                 "ui/score/playback/highlightNotes"
 #define PREF_SCORE_PLAYBACK_HIGHLIGHT_RESTS                 "ui/score/playback/highlightRests"
 #define PREF_SCORE_PLAYBACK_HIGHLIGHT_MORE                  "ui/score/playback/highlightMore"

--- a/libmscore/mscore.cpp
+++ b/libmscore/mscore.cpp
@@ -160,6 +160,8 @@ bool    MScore::fadeFocus;
 bool    MScore::currentSystemAlwaysTop;
 bool    MScore::omitAddingLinkedLines;
 
+bool    MScore::bypassAltMenu;
+
 bool    MScore::cursorMoveByBeat;
 bool    MScore::cursorMoveByMeasure;
 bool    MScore::cursorDrawnBehindStaff;

--- a/libmscore/mscore.h
+++ b/libmscore/mscore.h
@@ -406,6 +406,8 @@ class MScore {
       static bool currentSystemAlwaysTop;
       static bool omitAddingLinkedLines;
 
+      static bool bypassAltMenu;
+
       static bool cursorMoveByBeat;
       static bool cursorMoveByMeasure;
       static bool cursorDrawnBehindStaff;

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -653,6 +653,8 @@ void MuseScore::preferencesChanged(bool fromWorkspace, bool changeUI)
 
       if (seq)
             seq->preferencesChanged();
+
+      if (mscore) mscore->updateMenus();
       }
 
 //---------------------------------------------------------

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -473,7 +473,9 @@ void updateExternalValuesFromPreferences() {
       MScore::fadeFocus = preferences.getBool(PREF_UI_SCORE_FADE_FOCUS);
       MScore::currentSystemAlwaysTop = preferences.getBool(PREF_UI_SCORE_CURRENT_SYS_ON_TOP);
       MScore::omitAddingLinkedLines = preferences.getBool(PREF_UI_SCORE_OMIT_ADDING_LINKED_LINES);
-            
+
+      MScore::bypassAltMenu = preferences.getBool(PREF_UI_SCORE_BYPASS_ALT_MENU);
+
       MScore::layoutBreakColor = preferences.getColor(PREF_UI_SCORE_LAYOUTBREAKCOLOR);
       MScore::frameMarginColor = preferences.getColor(PREF_UI_SCORE_FRAMEMARGINCOLOR);
       MScore::setVerticalOrientation(preferences.getBool(PREF_UI_CANVAS_SCROLL_VERTICALORIENTATION));
@@ -2279,33 +2281,33 @@ void MuseScore::setMenuTitles()
       // The list below is not static, both strings
       // and menu pointers need refreshing.
       const std::initializer_list<std::pair<QMenu*, QString>> titles {
-            { menuFile,             tr("&File")             },
-            { openRecent,           tr("Open &Recent")      },
-            { menuEdit,             tr("&Edit")             },
-            { menuView,             tr("&View")             },
-            { menuToolbars,         tr("&Toolbars")         },
-            { menuWorkspaces,       tr("W&orkspaces")       },
-            { menuAdd,              tr("&Add")              },
-            { menuAddMeasures,      tr("&Measures")         },
-            { menuAddFrames,        tr("&Frames")           },
-            { menuAddText,          tr("&Text")             },
-            { menuAddLines,         tr("&Lines")            },
-            { menuAddPitch,         tr("N&otes")            },
-            { menuAddInterval,      tr("&Intervals")        },
-            { menuTuplet,           tr("T&uplets")          },
-            { menuFormat,           tr("F&ormat")           },
-            { menuStretch,          tr("&Stretch")          },
-            { menuTools,            tr("&Tools")            },
-            { menuVoices,           tr("&Voices")           },
-            { menuMeasure,          tr("&Measure")          },
+            { menuFile,             tr(MScore::bypassAltMenu ? "File" : "&File")                },
+            { openRecent,           tr(MScore::bypassAltMenu ? "Open Recent" : "Open &Recent")  },
+            { menuEdit,             tr(MScore::bypassAltMenu ? "Edit" : "&Edit")                },
+            { menuView,             tr(MScore::bypassAltMenu ? "View" : "&View")                },
+            { menuToolbars,         tr(MScore::bypassAltMenu ? "Toolbars" : "&Toolbars")        },
+            { menuWorkspaces,       tr(MScore::bypassAltMenu ? "Workspaces" : "W&orkspaces")    },
+            { menuAdd,              tr(MScore::bypassAltMenu ? "Add" : "&Add")                  },
+            { menuAddMeasures,      tr(MScore::bypassAltMenu ? "Measures" : "&Measures")        },
+            { menuAddFrames,        tr(MScore::bypassAltMenu ? "Frames" : "&Frames")            },
+            { menuAddText,          tr(MScore::bypassAltMenu ? "Text" : "&Text")                },
+            { menuAddLines,         tr(MScore::bypassAltMenu ? "Lines" : "&Lines")              },
+            { menuAddPitch,         tr(MScore::bypassAltMenu ? "Notes" : "N&otes")              },
+            { menuAddInterval,      tr(MScore::bypassAltMenu ? "Intervals" : "&Intervals")      },
+            { menuTuplet,           tr(MScore::bypassAltMenu ? "Tuplets" : "T&uplets")          },
+            { menuFormat,           tr(MScore::bypassAltMenu ? "Format" : "F&ormat")            },
+            { menuStretch,          tr(MScore::bypassAltMenu ? "Stretch" : "&Stretch")          },
+            { menuTools,            tr(MScore::bypassAltMenu ? "Tools" : "&Tools")              },
+            { menuVoices,           tr(MScore::bypassAltMenu ? "Voices" : "&Voices")            },
+            { menuMeasure,          tr(MScore::bypassAltMenu ? "Measure" : "&Measure")          },
 #ifdef SCRIPT_INTERFACE
-            { menuPlugins,          tr("&Plugins")          },
+            { menuPlugins,          tr(MScore::bypassAltMenu ? "Plugins" : "&Plugins")          },
 #endif
 #ifndef NDEBUG
             { menuDebug,            "Debug"                 }, // not translated
 #endif
-            { menuHelp,             tr("&Help")             },
-            { menuTours,            tr("&Tours")            }
+            { menuHelp,             tr(MScore::bypassAltMenu ? "Help" : "&Help")                },
+            { menuTours,            tr(MScore::bypassAltMenu ? "Tours" : "&Tours")              }
             };
 
       for (const auto& t : titles) {
@@ -4208,9 +4210,23 @@ bool MuseScore::eventFilter(QObject *obj, QEvent *event)
                   }
             case QEvent::StatusTip:
                   return true; // prevent updates to the status bar
+            case QEvent::KeyRelease:
+                  {
+                  QKeyEvent* e = static_cast<QKeyEvent*>(event);
+                  if (e->key() == Qt::Key_Alt) {
+                        focusScoreView();
+                        return true;
+                        }
+                  }
+                  break;
             case QEvent::KeyPress: // Note: [Return] is not registered here
                   {
                   QKeyEvent* e = static_cast<QKeyEvent*>(event);
+                  if (e->key() == Qt::Key_Alt) {
+                        // Omit singular alt-modifier
+                        e->ignore();
+                        return true;
+                        }
                   if(obj->isWidgetType()) {
                         if (e->key() == Qt::Key_Escape && e->modifiers() == Qt::NoModifier) {
                               // Close the search dialog when Escape is pressed:

--- a/mscore/preferences.cpp
+++ b/mscore/preferences.cpp
@@ -226,6 +226,7 @@ void Preferences::init(bool storeInMemoryOnly)
             {PREF_SCORE_NOTE_INPUT_DISABLE_MOUSE_INPUT,            new BoolPreference(false, true)},
             {PREF_UI_SCORE_FADE_FOCUS,                             new BoolPreference(false, true)},
             {PREF_UI_SCORE_CURRENT_SYS_ON_TOP,                     new BoolPreference(false, true)},
+            {PREF_UI_SCORE_BYPASS_ALT_MENU,                        new BoolPreference(false, true)},
             {PREF_UI_SCORE_OMIT_ADDING_LINKED_LINES,               new BoolPreference(false, true)},
             {PREF_SCORE_HOVER_COLOR,                               new ColorPreference(QColor(0,0,0,0), true)},
             {PREF_SCORE_HOVER_COLOR_ENABLE,                        new BoolPreference(false, true)},


### PR DESCRIPTION
Enable/Disable via:
`ui/application/altMenu/bypass`

![image](https://github.com/user-attachments/assets/c6d786ba-ddb9-4ea0-b581-a030ba44bd0e)

When enabled, no more underlines show and won't activate via alt-modifier

Point is to be able to have **Alt+A-Z/0-9** at the user's discretion for custom shortcuts if desired.
For example, **Alt+#** is nice for **_add interval below_**, and **Alt+[A-G]** is nice for **Add Pitch below** which would normally have triggered File/Edit/Debug, etc possibly. Also I think Alt generically activated the alt-menu so the ScoreView would lose focus

+ No restart required when enabling/disabling

+ If a keyboard shortcut is defined by [alt+letter], where [letter] coincides with a shortcut to the alt-menu (like Alt-F for File menu),  and this preference is off (like default), then there occurs an internal shortcut ambiguity which requires two activations for the alt-menu to activate, which is obviously not desirable, so either:
1) Make sure to have no defined shortcuts that coincide with the file menu, or
2) Enable this bypass preference and there shouldn't be a problem at the expense of needing to use mouse/pointer device to activate the "alt-menu"
