### PR TITLE
Fix: add interval upon rest

### DIFF
--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -3454,7 +3454,7 @@ void ScoreView::cmd(const char* s)
                         }
                   else  {
                         auto score      = cv->score();
-                        auto selection  = score->selection();
+                        auto& selection = score->selection();
                         auto& is        = score->inputState();
                         auto cr         = selection.currentCR();
 


### PR DESCRIPTION
Resolves: #124 - Add Interval on rest crashes program

Reminder: this whole implementation is an old hack reliant upon repeat-selection and then adding an interval, and then removing all notes besides the added interval. The way the cmdBegin/Ends are with repeat + add interval make it impossible using this method to result in the exact desired phenomenon with the appropriate undo-state, but the new "backspace" functionality to erase an entire chord is a good workaround

It would be cleaner to create a new chord consisting of only the appropriate resulting note...but it may be easier said than done since the existing functions work with score/input states and not virtual concepts
