### PR TITLE
Personal Advanced Preference: JIKL also act as Arrow keys for nudging/slur/textline activity

### DIFF
--- a/global/settings/types/preferencekeys.h
+++ b/global/settings/types/preferencekeys.h
@@ -170,6 +170,7 @@
 #define PREF_UI_SCORE_OVERRIDE_TIES_COLOR                   "ui/score/elements/override/color/ties"
 
 #define PREF_UI_SCORE_BYPASS_ALT_MENU                       "ui/application/altMenu/bypass"
+#define PREF_UI_SCORE_IJKL_NUDGE_MOVEMENT                   "ui/application/nudge/ijkl"
 
 #define PREF_SCORE_PLAYBACK_HIGHLIGHT_NOTES                 "ui/score/playback/highlightNotes"
 #define PREF_SCORE_PLAYBACK_HIGHLIGHT_RESTS                 "ui/score/playback/highlightRests"

--- a/libmscore/line.cpp
+++ b/libmscore/line.cpp
@@ -237,13 +237,13 @@ bool LineSegment::edit(EditData& ed)
                         qDebug("LineSegment::edit: no start/end segment");
                         return true;
                         }
-                  if (ed.key == Qt::Key_Left) {
+                  if (ed.key == Qt::Key_Left || (ed.key == Qt::Key_J && MScore::nudgeUsesIJKL)) {
                         if (moveStart)
                               s1 = prevSeg1(s1, track);
                         else if (moveEnd)
                               s2 = prevSeg1(s2, track2);
                         }
-                  else if (ed.key == Qt::Key_Right) {
+                  else if (ed.key == Qt::Key_Right || (ed.key == Qt::Key_L && MScore::nudgeUsesIJKL)) {
                         if (moveStart)
                               s1 = nextSeg1(s1, track);
                         else if (moveEnd) {
@@ -272,25 +272,33 @@ bool LineSegment::edit(EditData& ed)
                         }
 
                   switch (ed.key) {
-                        case Qt::Key_Left:
+                        case Qt::Key_Left : case Qt::Key_J:
+                              if (ed.key == Qt::Key_J && !MScore::nudgeUsesIJKL)
+                                    return true;
                               if (moveStart)
                                     note1 = prevChordNote(note1);
                               else if (moveEnd)
                                     note2 = prevChordNote(note2);
                               break;
-                        case Qt::Key_Right:
+                        case Qt::Key_Right: case Qt::Key_L:
+                              if (ed.key == Qt::Key_L && !MScore::nudgeUsesIJKL)
+                                    return true;
                               if (moveStart)
                                     note1 = nextChordNote(note1);
                               else if (moveEnd)
                                     note2 = nextChordNote(note2);
                               break;
-                        case Qt::Key_Up:
+                        case Qt::Key_Up:  case Qt::Key_I:
+                              if (ed.key == Qt::Key_I && !MScore::nudgeUsesIJKL)
+                                    return true;
                               if (moveStart)
                                     note1 = toNote(score()->upAlt(note1));
                               else if (moveEnd)
                                     note2 = toNote(score()->upAlt(note2));
                               break;
-                        case Qt::Key_Down:
+                        case Qt::Key_Down:  case Qt::Key_K:
+                              if (ed.key == Qt::Key_K && !MScore::nudgeUsesIJKL)
+                                    return true;
                               if (moveStart)
                                     note1 = toNote(score()->downAlt(note1));
                               else if (moveEnd)
@@ -321,7 +329,7 @@ bool LineSegment::edit(EditData& ed)
                   Measure* m1 = l->startMeasure();
                   Measure* m2 = l->endMeasure();
 
-                  if (ed.key == Qt::Key_Left) {
+                  if (ed.key == Qt::Key_Left || (ed.key == Qt::Key_J && MScore::nudgeUsesIJKL)) {
                         if (moveStart) {
                               if (m1->prevMeasure())
                                     m1 = m1->prevMeasure();
@@ -332,7 +340,7 @@ bool LineSegment::edit(EditData& ed)
                                     m2 = m;
                               }
                         }
-                  else if (ed.key == Qt::Key_Right) {
+                  else if (ed.key == Qt::Key_Right || (ed.key == Qt::Key_L && MScore::nudgeUsesIJKL)) {
                         if (moveStart) {
                               if (m1->nextMeasure())
                                     m1 = m1->nextMeasure();
@@ -535,7 +543,9 @@ void LineSegment::rebaseAnchors(EditData& ed, Grip grip)
             return;
       // don't change anchors on keyboard adjustment or if Ctrl is pressed
       // (Ctrl+Left/Right is handled elsewhere!)
-      if (ed.key == Qt::Key_Left || ed.key == Qt::Key_Right || ed.modifiers & Qt::ControlModifier)
+      if (ed.key == Qt::Key_Left  || (ed.key == Qt::Key_J && MScore::nudgeUsesIJKL) ||
+          ed.key == Qt::Key_Right || (ed.key == Qt::Key_L && MScore::nudgeUsesIJKL) ||
+          ed.modifiers & Qt::ControlModifier)
             return;
 
       switch (grip) {

--- a/libmscore/mscore.cpp
+++ b/libmscore/mscore.cpp
@@ -161,6 +161,7 @@ bool    MScore::currentSystemAlwaysTop;
 bool    MScore::omitAddingLinkedLines;
 
 bool    MScore::bypassAltMenu;
+bool    MScore::nudgeUsesIJKL;
 
 bool    MScore::cursorMoveByBeat;
 bool    MScore::cursorMoveByMeasure;

--- a/libmscore/mscore.h
+++ b/libmscore/mscore.h
@@ -407,6 +407,7 @@ class MScore {
       static bool omitAddingLinkedLines;
 
       static bool bypassAltMenu;
+      static bool nudgeUsesIJKL;
 
       static bool cursorMoveByBeat;
       static bool cursorMoveByMeasure;

--- a/libmscore/slur.cpp
+++ b/libmscore/slur.cpp
@@ -124,17 +124,17 @@ bool SlurSegment::edit(EditData& ed)
             e1 = sl->startCR();
             }
 
-      if (ed.key == Qt::Key_Left)
+      if (ed.key == Qt::Key_Left || (ed.key == Qt::Key_J && MScore::nudgeUsesIJKL))
             cr = prevChordRest(e);
-      else if (ed.key == Qt::Key_Right)
+      else if (ed.key == Qt::Key_Right || (ed.key == Qt::Key_L && MScore::nudgeUsesIJKL))
             cr = nextChordRest(e);
-      else if (ed.key == Qt::Key_Up) {
+      else if (ed.key == Qt::Key_Up || (ed.key == Qt::Key_I && MScore::nudgeUsesIJKL)) {
             Part* part     = e->part();
             int startTrack = part->startTrack();
             int endTrack   = e->track();
             cr = searchCR(e->segment(), endTrack, startTrack);
             }
-      else if (ed.key == Qt::Key_Down) {
+      else if (ed.key == Qt::Key_Down || (ed.key == Qt::Key_K && MScore::nudgeUsesIJKL)) {
             int startTrack = e->track() + 1;
             Part* part     = e->part();
             int endTrack   = part->endTrack();

--- a/mscore/events.cpp
+++ b/mscore/events.cpp
@@ -95,10 +95,18 @@ bool ScoreView::event(QEvent* event)
             case QEvent::ShortcutOverride: {
                   QKeyEvent* ke = static_cast<QKeyEvent*>(event);
                   switch (ke->key()) {
-                        case Qt::Key_Left:
-                        case Qt::Key_Right:
-                        case Qt::Key_Up:
-                        case Qt::Key_Down: {
+                        case Qt::Key_Left  : case Qt::Key_J:
+                        case Qt::Key_Right : case Qt::Key_L:
+                        case Qt::Key_Up    : case Qt::Key_I:
+                        case Qt::Key_Down  : case Qt::Key_K:
+                              {
+                              if (!MScore::nudgeUsesIJKL) {
+                                    if (ke->key() == Qt::Key_I ||
+                                        ke->key() == Qt::Key_J ||
+                                        ke->key() == Qt::Key_K ||
+                                        ke->key() == Qt::Key_L)
+                                          break;
+                                    }
                               if (!hasEditGrips())
                                     break;
                               const auto m = ke->modifiers();
@@ -915,10 +923,17 @@ void ScoreView::keyPressEvent(QKeyEvent* ev)
             const bool shiftModifier = ev->modifiers() & Qt::ShiftModifier;
             if (hasEditGrips() && !(shiftModifier && ev->key() == Qt::Key_Backtab)) {
                   switch (ev->key()) {
-                        case Qt::Key_Left:
-                        case Qt::Key_Right:
-                        case Qt::Key_Up:
-                        case Qt::Key_Down:
+                        case Qt::Key_Left  : case Qt::Key_J:
+                        case Qt::Key_Right : case Qt::Key_L:
+                        case Qt::Key_Up    : case Qt::Key_I:
+                        case Qt::Key_Down  : case Qt::Key_K:
+                              if (!MScore::nudgeUsesIJKL) {
+                                    if (ev->key() == Qt::Key_I ||
+                                        ev->key() == Qt::Key_J ||
+                                        ev->key() == Qt::Key_K ||
+                                        ev->key() == Qt::Key_L)
+                                          break;
+                                    }
                               // Move focus to default grip if arrow keys are pressed and no grip is focused
                               if (editData.curGrip == Grip::NO_GRIP)
                                     editData.curGrip = editData.element->defaultGrip();
@@ -1049,15 +1064,19 @@ bool ScoreView::handleArrowKeyPress(const QKeyEvent* ev)
       // TODO: if raster, then xval/yval should be multiple of raster
 
       switch (ev->key()) {
+            case Qt::Key_J: if (!MScore::nudgeUsesIJKL) return false; // fallthrough
             case Qt::Key_Left:
                   delta = QPointF(-xval, 0);
                   break;
+            case Qt::Key_L: if (!MScore::nudgeUsesIJKL) return false; // fallthrough
             case Qt::Key_Right:
                   delta = QPointF(xval, 0);
                   break;
+            case Qt::Key_I: if (!MScore::nudgeUsesIJKL) return false; // fallthrough
             case Qt::Key_Up:
                   delta = QPointF(0, -yval);
                   break;
+            case Qt::Key_K: if (!MScore::nudgeUsesIJKL) return false; // fallthrough
             case Qt::Key_Down:
                   delta = QPointF(0, yval);
                   break;

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -475,6 +475,7 @@ void updateExternalValuesFromPreferences() {
       MScore::omitAddingLinkedLines = preferences.getBool(PREF_UI_SCORE_OMIT_ADDING_LINKED_LINES);
 
       MScore::bypassAltMenu = preferences.getBool(PREF_UI_SCORE_BYPASS_ALT_MENU);
+      MScore::nudgeUsesIJKL = preferences.getBool(PREF_UI_SCORE_IJKL_NUDGE_MOVEMENT);
 
       MScore::layoutBreakColor = preferences.getColor(PREF_UI_SCORE_LAYOUTBREAKCOLOR);
       MScore::frameMarginColor = preferences.getColor(PREF_UI_SCORE_FRAMEMARGINCOLOR);

--- a/mscore/preferences.cpp
+++ b/mscore/preferences.cpp
@@ -227,6 +227,7 @@ void Preferences::init(bool storeInMemoryOnly)
             {PREF_UI_SCORE_FADE_FOCUS,                             new BoolPreference(false, true)},
             {PREF_UI_SCORE_CURRENT_SYS_ON_TOP,                     new BoolPreference(false, true)},
             {PREF_UI_SCORE_BYPASS_ALT_MENU,                        new BoolPreference(false, true)},
+            {PREF_UI_SCORE_IJKL_NUDGE_MOVEMENT,                    new BoolPreference(false, true)},
             {PREF_UI_SCORE_OMIT_ADDING_LINKED_LINES,               new BoolPreference(false, true)},
             {PREF_SCORE_HOVER_COLOR,                               new ColorPreference(QColor(0,0,0,0), true)},
             {PREF_SCORE_HOVER_COLOR_ENABLE,                        new BoolPreference(false, true)},


### PR DESCRIPTION
P.S. Not sure why the original implementation hard-coded the arrow keys, since these could've been using the "..or move text left/right/up/down" commands