### PR TITLE
Text Lines: Centered & Centered Broken, Single note anchor lines

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -385,14 +385,40 @@ void Score::cmdAddSpanner(Spanner* spanner, const QPointF& pos, bool firstStaffO
             Fraction tick2 = qMin(segment->measure()->tick() + segment->measure()->ticks(), lastTick);
             spanner->setTick2(tick2);
             }
-      else {      // Anchor::MEASURE, Anchor::CHORD, Anchor::NOTE
+      else {
+            // Anchor::MEASURE, Anchor::CHORD, Anchor::NOTE
             Measure* m = toMeasure(mb);
             QRectF b(m->canvasBoundingRect());
 
             if (pos.x() >= (b.x() + b.width() * .5) && m != lastMeasureMM() && m->nextMeasure()->system() == m->system())
                   m = m->nextMeasure();
-            spanner->setTick(m->tick());
-            spanner->setTick2(m->endTick());
+
+            if (spanner->anchor() == Spanner::Anchor::NOTE) {
+                  // Single Note Anchor Line
+                  // Will copy a SNAL, but won't keep offsets when applying to palette
+                  if (spanner->isTextLine()) {
+                        auto tl = toTextLine(spanner);
+                        auto cr = segment->nextChordRest(track);
+                        if (cr && cr->isChord()) {
+                              auto chord = toChord(segment->nextChordRest(track));
+                              auto firstNote = chord->notes().front();
+                              auto lastNote = firstNote;
+                              tl->setParent(firstNote);
+                              tl->setStartElement(firstNote);
+                              tl->setDiagonal(true);
+                              tl->setAnchor(Spanner::Anchor::NOTE);
+                              tl->setTick(chord->tick());
+                              tl->setEndElement(lastNote);
+                              undoAddElement(tl);
+                              select(tl, SelectType::SINGLE, 0);
+                              }
+                        return;
+                        }
+                  else {
+                        spanner->setTick(segment->tick());
+                        spanner->setTick2(segment->tick());
+                        }
+                  }
             }
 
       bool isTextLineBase = spanner->isTextLineBase();

--- a/libmscore/line.cpp
+++ b/libmscore/line.cpp
@@ -1026,6 +1026,17 @@ QPointF SLine::linePos(Grip grip, System** sys) const
                   QPointF p = n->pagePos() - s->pagePos();
                   if (!isGlissando())
                         p.rx() += n->headWidth() * 0.5;
+
+                  if (startElement() == endElement()) {
+                        // Single note anchor line potential options:
+                        if (grip == Grip::START) {
+                              ;
+                              }
+                        if (grip == Grip::END) {
+                              ;
+                              }
+                        }
+
                   return p;
                   }
 

--- a/libmscore/mscore.h
+++ b/libmscore/mscore.h
@@ -117,7 +117,7 @@ enum class BracketType : signed char {
 //---------------------------------------------------------
 
 enum class PlaceText : char {
-      AUTO, ABOVE, BELOW, LEFT
+      AUTO, ABOVE, BELOW, LEFT, CENTERED, CENTERED_BROKEN
       };
 
 //---------------------------------------------------------

--- a/libmscore/property.cpp
+++ b/libmscore/property.cpp
@@ -538,6 +538,10 @@ QVariant propertyFromString(Pid id, QString value)
                         return QVariant(int(PlaceText::BELOW));
                   else if (value == "left")
                         return QVariant(int(PlaceText::LEFT));
+                  else if (value == "centered")
+                        return QVariant(int(PlaceText::CENTERED));
+                  else if (value == "centeredbroken")
+                        return QVariant(int(PlaceText::CENTERED_BROKEN));
                   }
                   break;
             case P_TYPE::BARLINE_TYPE: {
@@ -834,6 +838,10 @@ QString propertyToString(Pid id, QVariant value, bool mscx)
                               return "below";
                         case PlaceText::LEFT:
                               return "left";
+                        case PlaceText::CENTERED:
+                              return "centered";
+                        case PlaceText::CENTERED_BROKEN:
+                              return "centeredbroken";
                         }
                   break;
             case P_TYPE::SYMID:

--- a/libmscore/spanner.cpp
+++ b/libmscore/spanner.cpp
@@ -1473,8 +1473,11 @@ void SpannerSegment::autoplaceSpannerSegment()
       if (isStyled(Pid::OFFSET))
             setOffset(spanner()->propertyDefault(Pid::OFFSET).toPointF());
 
-      if (spanner()->anchor() == Spanner::Anchor::NOTE)
-            return;
+      bool singleNoteAnchor = (spanner()->startElement() == spanner()->endElement());
+      if (spanner()->anchor() == Spanner::Anchor::NOTE) {
+            if (!singleNoteAnchor)
+                  return;
+            }
 
       // rebase vertical offset on drag
       qreal rebase = 0.0;
@@ -1510,6 +1513,9 @@ void SpannerSegment::autoplaceSpannerSegment()
                         rebaseMinDistance(md, yd, sp, rebase, above, inStaff);
                         }
                   rypos() += yd;
+                  }
+            if (singleNoteAnchor) {
+                  // Placeholder
                   }
             }
       setOffsetChanged(false);

--- a/libmscore/textbase.cpp
+++ b/libmscore/textbase.cpp
@@ -776,6 +776,7 @@ void TextFragment::draw(QPainter* p, const TextBase* t) const
             }
 
 #ifndef Q_OS_MACOS
+      // Internal H-Alignment offset is included in pos
       TextBase::drawTextWorkaround(p, f, pos, text);
 #else
       p->setFont(f);
@@ -846,6 +847,7 @@ void TextBase::drawTextWorkaround(QPainter* p, QFont& f, const QPointF pos, cons
                         }
                   else
                         glyphrun2.setRawFont(fRaw);
+                  // TODO: Angling with bold?
                   p->drawGlyphRun(QPointF(pos.x() / factor, pos.y() / factor - offset),glyphrun2);
                   positions2.clear();
                   }
@@ -928,6 +930,7 @@ QFont TextFragment::font(const TextBase* t) const
 
 void TextBlock::draw(QPainter* p, const TextBase* t) const
       {
+      // Translate to V-alignment
       p->translate(0.0, _y);
       for (const TextFragment& f : _fragments)
             f.draw(p, t);
@@ -1907,7 +1910,7 @@ void TextBase::layout1()
       for (TextBlock& t : _layout)
             t.setY(t.y() + yoff);
 
-      bb.translate(0.0, yoff);
+      bb.translate(0.0, yoff + getVAlignOffset());
 
       setbbox(bb);
       if (hasFrame())

--- a/libmscore/textbase.h
+++ b/libmscore/textbase.h
@@ -261,6 +261,7 @@ class TextBase : public Element {
       int  hexState = -1;
       bool _primed = false;
       qreal _vAlignOffset = 0.0;
+      qreal _angle = 0.0;
       void drawSelection(QPainter*, const QRectF&) const;
       void insert(TextCursor*, uint code);
       void genText() const;
@@ -390,6 +391,9 @@ class TextBase : public Element {
       bool hasFrame() const                      { return _frameType != FrameType::NO_FRAME; }
       bool circle() const                        { return _frameType == FrameType::CIRCLE; }
       bool square() const                        { return _frameType == FrameType::SQUARE; }
+
+      qreal angle() const                        { return _angle; }
+      void setAngle(qreal a)                     { _angle = a; }
 
       void setVAlignOffset(qreal v)              { _vAlignOffset = v;    }
       qreal getVAlignOffset()                    { return _vAlignOffset; }

--- a/libmscore/textlinebase.cpp
+++ b/libmscore/textlinebase.cpp
@@ -22,6 +22,10 @@
 #include "utils.h"
 #include "xml.h"
 
+#include <QLineF>
+#include <QRectF>
+#include <QPointF>
+
 namespace Ms {
 
 //---------------------------------------------------------
@@ -75,6 +79,8 @@ void TextLineBaseSegment::draw(QPainter* painter) const
       TextLineBase* tl = textLineBase();
       QColor lineColor = curColor(tl->visible() && tl->lineVisible(), tl->lineColor());      
       QColor textColor = tl->color();
+      qreal strokeWidth = tl->lineWidth();
+      qreal lineAngle = -(textLine.angle());
 
       // Playback marked color:
       auto t1 = spanner()->tick();
@@ -96,20 +102,46 @@ void TextLineBaseSegment::draw(QPainter* painter) const
 
       if (!_text->empty()) {
             _text->setVisible(tl->visible());
-            _text->setColor(textColor);
+            bool isCenteredText = (tl->beginTextPlace() == PlaceText::CENTERED) || (tl->beginTextPlace() == PlaceText::CENTERED_BROKEN);
+            auto horizon = isCenteredText ? textLine.center() : _text->ipos();
+            auto userOffset = _text->offset();
+            auto lineStrokeOffset = QPointF(0.0, _text->getVAlignOffset());
+            // Note: TextBase stores angle, yet is unused at the moment. Separate angles in future?
+            auto angle  = isCenteredText ? lineAngle : 0.0;
 
-            painter->translate(_text->pos());
-               _text->draw(painter);
-            painter->translate(-_text->pos());
+            // Apply user x-y + line width offsets after rotation
+            painter->translate(horizon);
+            painter->rotate(angle);
+            painter->translate(lineStrokeOffset);
+            painter->translate(userOffset);
+
+                  _text->draw(painter);
+
+            painter->translate(-userOffset);
+            painter->translate(-lineStrokeOffset);
+            painter->rotate(-angle);
+            painter->translate(-horizon);
             }
 
       if (!_endText->empty()) {
             _endText->setVisible(tl->visible());
-            _endText->setColor(textColor);
+            auto horizon = textLine.p2();
+            auto userOffset = _endText->offset();
+            auto lineStrokeOffset = QPointF(0.0, _endText->getVAlignOffset());
+            auto angle = lineAngle;
 
-            painter->translate(_endText->pos());
-               _endText->draw(painter);
-            painter->translate(-_endText->pos());
+            // Apply user x-y + line-width offsets after rotation
+            painter->translate(horizon);
+            painter->rotate(angle);
+            painter->translate(lineStrokeOffset);
+            painter->translate(userOffset);
+
+                  _endText->draw(painter);
+            
+            painter->translate(-userOffset);
+            painter->translate(-lineStrokeOffset);
+            painter->rotate(-angle);
+            painter->translate(-horizon);
             }
 
       if ((npoints == 0) || (score() && (score()->printing() || !score()->showInvisible()) && !tl->lineVisible()))
@@ -124,20 +156,26 @@ void TextLineBaseSegment::draw(QPainter* painter) const
             color = tl->lineColor();
 #endif
 
-      qreal textlineLineWidth = tl->lineWidth();
       if (staff())
-            textlineLineWidth *= mag();
-      QPen pen(lineColor, textlineLineWidth, tl->lineStyle());
-      QPen solidPen(lineColor, textlineLineWidth, Qt::SolidLine);
+            strokeWidth *= mag();
+      QPen pen(lineColor, strokeWidth, tl->lineStyle());
+      QPen solidPen(lineColor, strokeWidth, Qt::SolidLine);
 
+
+      // Δ from 3.6.2: MiterJoined Polylines for each segment + round-capped single-lined hooks for pedals
+      pen.setCapStyle(Qt::FlatCap);
+      solidPen.setCapStyle(Qt::FlatCap);
+      solidPen.setJoinStyle(Qt::MiterJoin);
+      pen.setJoinStyle(Qt::MiterJoin);
       //Replace generic Qt dash patterns with improved equivalents to show true dots
       QVector<qreal> dotted        = { 0.01, 1.99 }; // 0.01 for cap dots. tighter than default Qt Dotline (would be { 0.01, 2.99 }). 
+// QUESTION: should just be 0.01 + 1.99 like dotted:?>    
+      QVector<qreal> squared       = { 1.0, 2.00 }; // 0.01 for cap dots. tighter than default Qt Dotline (would be { 0.01, 2.99 }).      
       QVector<qreal> dashed        = { 3.0, 3.0 };   // Compensating for caps. Qt default DashLine is { 4.0, 2.0 }
       QVector<qreal> dashDotted    = { 3.0, 3.0, 0.01, 2.99 };
       QVector<qreal> dashDotDotted = { 3.0, 3.0, 0.01, 2.99, 0.01, 2.99 };
       QVector<qreal> customDashes  = { tl->dashLineLen(), tl->dashGapLen() };
 
-      pen.setCapStyle(Qt::SquareCap);
       switch (tl->lineStyle()) {
             case Qt::DashLine:
                 pen.setDashPattern(dashed);
@@ -151,36 +189,59 @@ void TextLineBaseSegment::draw(QPainter* painter) const
                 break;
             case Qt::DashDotDotLine:
                 // Square dots instead:
-                pen.setDashPattern(dotted);
+                pen.setDashPattern(squared);
                 break;
             case Qt::CustomDashLine:
                 pen.setDashPattern(customDashes);
+                break;
+            case Qt::SolidLine:
                 break;
             default:
                   break;
             }
 
-      //Draw lines
-      if (twoLines) {   // hairpins
+      if (twoLines) {
+            // Draw Hairpins
+            // Need more precise control over terminal-points:
             pen.setJoinStyle(Qt::BevelJoin);
             painter->setPen(pen);
 
             if (!joinedHairpin.isEmpty() && tl->lineStyle() == Qt::SolidLine)
                   painter->drawPolyline(joinedHairpin);
-            else
+            else  // Non solid-lines look better not joined?
                   painter->drawLines(&points[0], 2);
             }
       else {
             int start = 0;
             int end = npoints;
-            //draw centered hooks as solid
-            painter->setPen(solidPen);
+            auto angle = lineAngle;
+            auto dx = textLine.p1().x();
+
+            // Centered hooks are always solid
             if (tl->beginHookType() == HookType::HOOK_90T && (isSingleType() || isBeginType())) {
-                  painter->drawLines(&points[0], 1);
+                  painter->setPen(solidPen);
+                  painter->save();
+                  painter->translate(+dx, 0.0);
+                  painter->rotate(angle);
+                  painter->translate(-dx, 0.0);
+
+                        painter->drawLine(beginHookLine);
+
+                  painter->rotate(-angle);
+                  painter->restore();
                   start++;
                   }
             if (tl->endHookType() == HookType::HOOK_90T && (isSingleType() || isEndType())) {
-                  painter->drawLines(&points[npoints-1], 1);
+                  painter->setPen(solidPen);
+                  painter->save();
+                  painter->translate(+dx, 0.0);
+                  painter->rotate(angle);
+                  painter->translate(-dx, 0.0);
+                  
+                        painter->drawLine(endHookLine);
+
+                  painter->rotate(-angle); // superfluous before a restore?
+                  painter->restore();
                   end--;
                   }
 #if 0 // experiment
@@ -189,48 +250,158 @@ void TextLineBaseSegment::draw(QPainter* painter) const
                   painter->setPen(pen);
                   painter->drawLines(&points[0], 1);
                   start++;
-            }
+                  }
             if (tl->endHookType() == HookType::HOOK_45 && (isSingleType() || isEndType())) {
                   pen.setCapStyle(Qt::RoundCap);
                   painter->setPen(pen);
                   painter->drawLines(&points[npoints-1], 1);
                   end--;
-            }
+                  }
 #endif
-            //draw rest of line as regular
-            //calculate new gap
-            if (tl->lineStyle() == Qt::CustomDashLine) {
-                  qreal adjustedLineLength = lineLength / textlineLineWidth;
-                  qreal dash = tl->dashLineLen();
-                  qreal gap = tl->dashGapLen();
-                  int numPairs;
-                  qreal newGap = 0;
-                  QVector<qreal> nDashes { dash, newGap };
-                  if (tl->beginHookType() == HookType::HOOK_45 || tl->beginHookType() == HookType::HOOK_90) {
-                        qreal absD = sqrt(QPointF::dotProduct(points[start+1]-points[start], points[start+1]-points[start])) / textlineLineWidth;
-                        numPairs = std::max(qreal(1), absD / (dash + gap));
-                        nDashes[1] = (absD - dash * (numPairs + 1)) / numPairs;
-                        pen.setDashPattern(nDashes);
-                        painter->setPen(pen);
-                        painter->drawLine(points[start+1], points[start]);
+            if (tl->anchor() == Spanner::Anchor::NOTE) {
+                  if (tl->startElement() != tl->endElement()) {
+                        pen.setCapStyle(Qt::RoundCap);
+                        }
+                  }
+            if (tl->isPedal() || tl->isPedalSegment()) {
+                  pen.setCapStyle(Qt::RoundCap);
+                  pen.setJoinStyle(Qt::MiterJoin);
+                  }
+
+            painter->setPen(pen);
+
+            // Calculate dash-gap and draw hooks if not solid line
+            auto adjustedLineLength = lineLength / strokeWidth;
+            auto dash = tl->dashLineLen();
+            auto gap = tl->dashGapLen();
+            int numPairs;
+            qreal newGap = 0;
+            bool separateHooks = (tl->lineStyle() == Qt::DashDotDotLine) || (tl->lineStyle() == Qt::DotLine);
+            bool square = tl->lineStyle() == Qt::DashDotDotLine;
+
+            QVector<qreal> nDashes { dash, newGap };
+            if (tl->beginHookType() == HookType::HOOK_45 || tl->beginHookType() == HookType::HOOK_90) {
+                  qreal absD = sqrt(QPointF::dotProduct(points[start+1]-points[start], points[start+1]-points[start])) / strokeWidth;
+                  numPairs = std::max(qreal(1), absD / (dash + gap));
+                  nDashes[1] = (absD - dash * (numPairs + 1)) / numPairs;
+
+                  // Alternative:
+                  // if (tl->lineStyle() == Qt::CustomDashLine)
+                        // painter->setPen(solidPen);
+
+                  if (separateHooks) {
+                        painter->save();
+                        painter->translate(+dx, 0.0);
+                        painter->rotate(angle);
+                        painter->translate(-dx, 0.0);
+                        QLineF reversedBeginHookLine(beginHookLine.p2(), beginHookLine.p1());
+                        if (square) {
+                              reversedBeginHookLine.translate(strokeWidth * 0.5, -strokeWidth * 0.5);
+                              }
+
+                        painter->drawLine(reversedBeginHookLine);
+
+                        painter->rotate(-angle);
+                        painter->restore();
                         start++;
                         }
-                  if (tl->endHookType() == HookType::HOOK_45 || tl->endHookType() == HookType::HOOK_90) {
-                        qreal absD = sqrt(QPointF::dotProduct(points[end]-points[end-1], points[end]-points[end-1])) / textlineLineWidth;
-                        numPairs = std::max(qreal(1), absD / (dash + gap));
-                        nDashes[1] = (absD - dash * (numPairs + 1)) / numPairs;
-                        pen.setDashPattern(nDashes);
-                        painter->setPen(pen);
-                        painter->drawLines(&points[end-1], 1);
+                  }
+            if (tl->endHookType() == HookType::HOOK_45 || tl->endHookType() == HookType::HOOK_90) {
+                  qreal absD = sqrt(QPointF::dotProduct(points[end]-points[end-1], points[end]-points[end-1])) / strokeWidth;
+                  numPairs = std::max(qreal(1), absD / (dash + gap));
+                  nDashes[1] = (absD - dash * (numPairs + 1)) / numPairs;
+
+                  // if (tl->lineStyle() == Qt::CustomDashLine)
+                        // painter->setPen(solidPen);
+
+                  if (separateHooks) {
+                        painter->save();
+                        painter->translate(+dx, 0.0);
+                        painter->rotate(angle);
+                        painter->translate(-dx, 0.0);
+                        QLineF correctedHook = endHookLine;
+                        if (square) {
+                              correctedHook.translate(-strokeWidth * 0.5, -strokeWidth * 0.5);
+                              }
+
+                        painter->drawLine(correctedHook);
+
+                        painter->rotate(-angle);
+                        painter->restore();
                         end--;
                         }
-                  numPairs = std::max(qreal(1), adjustedLineLength / (dash + gap));
-                  nDashes[1] = (adjustedLineLength - dash * (numPairs + 1)) / numPairs;
+                  }
+
+            numPairs = std::max(qreal(1), adjustedLineLength / (dash + gap));
+            nDashes[1] = (adjustedLineLength - dash * (numPairs + 1)) / numPairs;
+
+            if (tl->lineStyle() != Qt::SolidLine) {
                   pen.setDashPattern(nDashes);
                   }
-            painter->setPen(pen);
-            for (int i = start; i < end; ++i)
-                  painter->drawLines(&points[i], 1);
+            if (tl->lineStyle() == Qt::CustomDashLine) {
+                  // pen.setCapStyle(Qt::FlatCap);
+                  painter->setPen(pen);
+                  }
+
+            QPolygonF totalLine;
+            bool centeredBrokenText = (tl->beginTextPlace() == PlaceText::CENTERED_BROKEN && !_text->empty());
+            auto unangledTextLine = textLine;
+            unangledTextLine.setAngle(0.0);
+
+            painter->translate(+unangledTextLine.p1());
+            painter->rotate(angle);
+            painter->translate(-unangledTextLine.p1());
+
+            if (endHookLine.length() && !separateHooks) {
+                  if (tl->endHookType() == HookType::HOOK_45 || tl->endHookType() == HookType::HOOK_90)
+                        totalLine << endHookLine.p2();
+                  }
+
+            if (centeredBrokenText) {
+                  totalLine << brokenPoints[3] << brokenPoints[2];
+
+                  painter->drawPolyline(totalLine);
+
+                  totalLine.clear();
+                  totalLine << brokenPoints[1] << brokenPoints[0];
+                  }
+            else {
+                  totalLine << unangledTextLine.p2() << unangledTextLine.p1();
+                  }
+
+            if (beginHookLine.length() && !separateHooks) {
+                  if (tl->beginHookType() == HookType::HOOK_45 || tl->beginHookType() == HookType::HOOK_90)
+                        totalLine << beginHookLine.p1();
+                        }
+
+            painter->drawPolyline(totalLine);
+
+            painter->translate(+unangledTextLine.p1());
+            painter->rotate(-angle);
+            painter->translate(-unangledTextLine.p1());
+
+            if (totalLine.isEmpty()) {
+                  // Left-over for non-joined polylines. 90T hooks and custom dash lined hooks were already drawn
+                  if (tl->endHookType() != HookType::NONE && tl->endHookType() != HookType::HOOK_90T && tl->lineStyle() != Qt::CustomDashLine) {
+                        if (endHookLine.length()) {
+                              painter->rotate(angle);
+                              painter->drawLine(endHookLine);
+                              painter->rotate(-angle);
+                              }
+                        }
+                  QLineF reverseLine(textLine.p2(), textLine.p1());
+                  if (tl->lineStyle() == Qt::DashDotDotLine || tl->lineStyle() == Qt::DotLine)
+                        painter->drawLine(reverseLine);
+                  else painter->drawLine(textLine);
+                  if (tl->beginHookType() != HookType::NONE && tl->beginHookType() != HookType::HOOK_90T && tl->lineStyle() != Qt::CustomDashLine) {
+                        if (beginHookLine.length()) {
+                              painter->rotate(angle);
+                              painter->drawLine(beginHookLine);
+                              painter->rotate(-angle);
+                              }
+                        }
+                  }
+
             }
       }
 
@@ -241,23 +412,29 @@ void TextLineBaseSegment::draw(QPainter* painter) const
 Shape TextLineBaseSegment::shape() const
       {
       Shape shape;
-      if (!_text->empty())
-            shape.add(_text->bbox().translated(_text->pos()));
-      if (!_endText->empty())
-            shape.add(_endText->bbox().translated(_endText->pos()));
+      auto  tl = textLineBase();
       qreal lw  = textLineBase()->lineWidth();
-      qreal lw2 = lw * .5;
-      if (twoLines) {   // hairpins
+      qreal lw2 = (lw * 0.5);
+
+      if (!_text->empty())
+            shape.add(_text->bbox());
+      if (!_endText->empty())
+            shape.add(_endText->bbox());
+
+      if (twoLines) {
+            // Hairpins:
             shape.add(QRectF(points[0].x(), points[0].y() - lw2,
                points[1].x() - points[0].x(), points[1].y() - points[0].y() + lw));
             shape.add(QRectF(points[2].x(), points[2].y() - lw2,
                points[3].x() - points[2].x(), points[3].y() - points[2].y() + lw));
             }
-      else if (textLineBase()->lineVisible()) {
-            for (int i = 0; i < npoints; ++i) {
-                  shape.add(QRectF(points[i].x() - lw2, points[i].y() - lw2,
-                     points[i+1].x() - points[i].x() + lw, points[i+1].y() - points[i].y() + lw));
-                  }
+      else if (tl->lineVisible()) {
+            if (!beginHookLine.isNull())
+                  shape.add(beginHookBB);
+            if (!textLine.isNull())
+                  shape.add(lineBB);
+            if (!endHookLine.isNull())
+                  shape.add(endHookBB);
             }
       return shape;
       }
@@ -268,12 +445,64 @@ Shape TextLineBaseSegment::shape() const
 
 void TextLineBaseSegment::layout()
       {
+
+      // Lazy Functor Helpers: Form bounding box from line with "margins" (e.g. line stroke width)
+      auto formBoundingBox = [](const QLineF& line, qreal xo, qreal yo, qreal wo, qreal ho) {
+            qreal x = line.x1() + xo;
+            qreal y = line.y1() + yo;
+            qreal w = line.dx() + wo;
+            qreal h = line.dy() + ho;
+            return QRectF(x, y, w, h);
+            };
+
+      // Would be nice to have rectangle and point in one function, but for that would need templates
+      auto rotateRectangle = [](auto& in, QPointF t1, qreal angle, QPointF t2) {
+            QPolygonF polygonInput(in);
+            auto theta = -(angle);
+            QTransform transform = QTransform()
+                  .translate(t1.x(), t1.y())
+                  .rotate(theta)
+                  .translate(t2.x(), t2.y())
+                  ;
+            QPolygonF rotatedPolygon = transform.map(polygonInput);
+            return rotatedPolygon.boundingRect();
+            };
+
+//      auto rotatePoint = [](QPointF in, QPointF t1, qreal angle, QPointF t2) {
+//            auto theta = -(angle);
+//            QTransform transform = QTransform()
+//                  .translate(t1.x(), t1.y())
+//                  .rotate(theta)
+//                  .translate(t2.x(), t2.y())
+//                  ;
+//            return transform.map(in);
+//            };
+
       npoints      = 0;
       TextLineBase* tl = textLineBase();
       qreal lineStrokeWidth = tl->lineWidth();
       QColor textColor = tl->color();
       qreal _spatium = tl->spatium();
       bool isSingleOrBegin = isSingleBeginType();
+
+      bool singleNoteAnchor = (tl->startElement() == tl->endElement());
+      auto beginHookType = tl->beginHookType();
+      auto endHookType = tl->endHookType();
+      bool hasBeginHook = beginHookType != HookType::NONE;
+      bool hasEndHook = endHookType != HookType::NONE;
+      bool hasNoHooks = !hasBeginHook && !hasEndHook;
+      bool isCenteredText = (tl->beginTextPlace() == PlaceText::CENTERED || tl->beginTextPlace() == PlaceText::CENTERED_BROKEN);
+      bool isBroken       = (tl->beginTextPlace() == PlaceText::CENTERED_BROKEN);
+
+      // Reset lines
+      if (!beginHookLine.isNull())
+            beginHookLine.setLine(0.0, 0.0, 0.0, 0.0);
+
+      if (!endHookLine.isNull())
+            endHookLine.setLine(0.0, 0.0, 0.0, 0.0);
+
+      if (!textLine.isNull())
+            textLine.setLine(0.0, 0.0, 0.0, 0.0);
 
       if (spanner()->placeBelow())
             rypos() = staff() ? staff()->height() : 0.0;
@@ -284,6 +513,18 @@ void TextLineBaseSegment::layout()
 
       if (!tl->diagonal())
             _offset2.setY(0);
+
+      // Initialization of line information:
+      QPointF pp1;
+      QPointF pp2(pos2());
+      bool isHorizontallyBackwards = pp1.x() > pp2.x();
+      bool isDiagonal = (pp2.y() != 0);
+      bool hasNoText = _text->empty() && _endText->empty();
+      textLine.setPoints(pp1, pp2);
+      lineLength = textLine.length();
+
+      // Bounding-box: first phase
+      setbbox(QRectF(pp1, pp2).normalized());
 
       if (isSingleOrBegin) {
             _text->setXmlText(tl->beginText());
@@ -307,10 +548,12 @@ void TextLineBaseSegment::layout()
             _text->setUnderline(tl->continueFontStyle() & FontStyle::Underline);
             _text->setStrike(tl->continueFontStyle() & FontStyle::Strike);
             }
+
       _text->setPlacement(Placement::ABOVE);
       _text->setTrack(track());
-      _text->setColor(textColor);
       _text->setVAlignOffset(lineStrokeWidth);
+      _text->setAngle(isCenteredText ? textLine.angle() : 0.0);
+      _text->setColor(textColor);
       _text->layout();
 
       if ((isSingleType() || isEndType())) {
@@ -325,70 +568,49 @@ void TextLineBaseSegment::layout()
             _endText->setStrike(tl->endFontStyle() & FontStyle::Strike);
             _endText->setPlacement(Placement::ABOVE);
             _endText->setTrack(track());
-            _endText->setColor(textColor);
             _endText->setVAlignOffset(lineStrokeWidth);
+            _endText->setAngle(textLine.angle());
+            _endText->setColor(textColor);
             _endText->layout();
             }
       else {
             _endText->setXmlText("");
             }
 
-      QPointF pp1;
-      QPointF pp2(pos2());
-
-      // diagonal line with no text or hooks - just use the basic rectangle for line
-      if (_text->empty() && _endText->empty() && pp2.y() != 0
-          && (!isSingleOrBegin || textLineBase()->beginHookType() == HookType::NONE)
-          && (!isSingleEndType() || textLineBase()->endHookType() == HookType::NONE)) {
-            npoints = 1; // 2 points, but only one line must be drawn
-            points[0] = pp1;
-            points[1] = pp2;
-            lineLength = sqrt(QPointF::dotProduct(pp2-pp1, pp2-pp1));
-
-            setbbox(QRectF(pp1, pp2).normalized());
+      if (isDiagonal && hasNoText && hasNoHooks && !singleNoteAnchor) {
+            npoints = 1;
+            qreal w = abs(bbox().width());
+            qreal h = abs(bbox().height());
+            bool zeroWidth  = (w < 0.01);
+            bool zeroHeight = (h < 0.01);
+            w = zeroWidth  ? lineStrokeWidth : w;
+            h = zeroHeight ? lineStrokeWidth : h;
+            bbox().setWidth(w);
+            bbox().setHeight(h);
+            lineBB = bbox();
             return;
             }
 
-      // line has text or hooks or is not diagonal - calculate reasonable bbox
-
+      // Calculate dimensions of bounding-box based on initial text positioning and hooks [[or is not diagonal]]
       qreal x1 = qMin(0.0, pp2.x());
       qreal x2 = qMax(0.0, pp2.x());
-      qreal y0 = -textLineBase()->lineWidth();
+      qreal y0 = -lineStrokeWidth;
       qreal y1 = qMin(0.0, pp2.y()) + y0;
       qreal y2 = qMax(0.0, pp2.y()) - y0;
 
-      qreal l1 = 0.0;
-      qreal l2 = 0.0;
-      qreal textlineTextDistance = _spatium * .5;
-
-      bool alignBeginText = tl->beginTextPlace() == PlaceText::LEFT || tl->beginTextPlace() == PlaceText::AUTO;
-      bool alignContinueText = tl->continueTextPlace() == PlaceText::LEFT || tl->continueTextPlace() == PlaceText::AUTO;
-      //bool alignEndText = tl->endTextPlace() == PlaceText::LEFT || tl->endTextPlace() == PlaceText::AUTO;
-      //bool hasBeginText = !_text->empty() && isSingleOrBegin;
-      //bool hasContinueText = !_text->empty() && !isSingleOrBegin;
-      //bool hasEndText = !_endText->empty() && isSingleEndType();
+      qreal l = 0.0;
 
       if (!_text->empty()) {
-            if ((isSingleOrBegin && alignBeginText) || (!isSingleOrBegin && alignContinueText)) {
-                  l1 = textlineTextDistance;
-                  auto txtPlace = textLineBase()->beginTextPlace();
-                  if (txtPlace == PlaceText::AUTO || txtPlace == PlaceText::LEFT)
-                        l1 += _text->bbox().right();
-                  switch (_text->align()) {
-                        case Align::LEFT:
-                              l1 += _text->bbox().width();
-                              break;
-                        case Align::HCENTER:
-                              l1 += _text->bbox().width() / 2;
-                              break;
-                        default:
-                              break;
-                        }
+            qreal textlineTextDistance = _spatium * 0.5;
+            if (((isSingleType() || isBeginType())
+               && (tl->beginTextPlace() == PlaceText::LEFT || tl->beginTextPlace() == PlaceText::AUTO))
+               || ((isMiddleType() || isEndType()) && (tl->continueTextPlace() == PlaceText::LEFT))) {
+                  l = _text->pos().x() + _text->bbox().width() + textlineTextDistance;
                   }
             qreal h = _text->height();
-            if (textLineBase()->beginTextPlace() == PlaceText::ABOVE)
+            if (tl->beginTextPlace() == PlaceText::ABOVE)
                   y1 = qMin(y1, -h);
-            else if (textLineBase()->beginTextPlace() == PlaceText::BELOW)
+            else if (tl->beginTextPlace() == PlaceText::BELOW)
                   y2 = qMax(y2, h);
             else {
                   y1 = qMin(y1, -h * .5);
@@ -397,91 +619,209 @@ void TextLineBaseSegment::layout()
             x2 = qMax(x2, _text->width());
             }
 
-      if (textLineBase()->endHookType() != HookType::NONE) {
-            qreal h = pp2.y() + textLineBase()->endHookHeight().val() * _spatium;
+      if (hasEndHook) {
+            qreal h = pp2.y() + tl->endHookHeight().val() * _spatium;
             if (h > y2)
                   y2 = h;
             else if (h < y1)
                   y1 = h;
             }
 
-      if (textLineBase()->beginHookType() != HookType::NONE) {
-            qreal h = textLineBase()->beginHookHeight().val() * _spatium;
+      if (hasBeginHook) {
+            qreal h = tl->beginHookHeight().val() * _spatium;
             if (h > y2)
                   y2 = h;
             else if (h < y1)
                   y1 = h;
             }
-      bbox().setRect(x1, y1, x2 - x1, y2 - y1);
-      if (!_text->empty())
-            bbox() |= _text->bbox().translated(_text->pos());  // DEBUG
-      // set end text position and extend bbox
-      if (!_endText->empty()) {
-            l2 = textlineTextDistance;
-            switch (_endText->align()) {
-                  case Align::RIGHT:
-                        l2 += _endText->bbox().width();
-                        break;
-                  case Align::HCENTER:
-                        l2 += _endText->bbox().width() / 2;
-                        break;
-                  default:
-                        break;
-                  }
-            _endText->setPos(bbox().right(), 0);
-            bbox() |= _endText->bbox().translated(_endText->pos());
-            }
 
-      if (!(tl->lineVisible() || score()->showInvisible()))
-            return;
+      // Bounding-box: second phase (accommodate for potential zero width/height [horizontal/vertical line])
+      qreal w = abs(x2 - x1);
+      qreal h = abs(y2 - y1);
+      bool zeroWidth  = (w < 0.01);
+      bool zeroHeight = (h < 0.01);
+      w = zeroWidth  ? lineStrokeWidth : w;
+      h = zeroHeight ? lineStrokeWidth : h;
 
+      // Convert "close-enough" verticality to absolute:
+      bool isVertical = abs(textLine.dx()) < 1;
+      if (isVertical)
+            pp2.setX(pp1.x());
+
+      // Bounding-box before further textual positioning:
+      bbox().setRect(x1, y1, w, h);
+
+      // Hook handling
+      qreal beginHookWidth = 0.0;
+      qreal endHookWidth   = 0.0;
       if (tl->lineVisible() || !score()->printing()) {
-            pp1 = QPointF(l1, 0.0);
-            pp2.rx() -= l2;
+            pp1 = QPointF(l, 0.0);
 
-            qreal beginHookWidth;
-            qreal endHookWidth;
-
-            if (tl->beginHookType() == HookType::HOOK_45) {
+            // 45-degree hooks slightly shorten textline for angle-width accommodation
+            if (beginHookType == HookType::HOOK_45) {
                   beginHookWidth = fabs(tl->beginHookHeight().val() * _spatium * .4);
                   pp1.rx() += beginHookWidth;
+                  textLine.setLine(pp1.x(), pp1.y(), pp2.x(), pp2.y());
                   }
-            else
-                  beginHookWidth = 0;
-
-            if (tl->endHookType() == HookType::HOOK_45) {
+            else beginHookWidth = 0;
+            if (endHookType == HookType::HOOK_45) {
                   endHookWidth = fabs(tl->endHookHeight().val() * _spatium * .4);
                   pp2.rx() -= endHookWidth;
+                  textLine.setLine(pp1.x(), pp1.y(), pp2.x(), pp2.y());
                   }
-            else
-                  endHookWidth = 0;
+            else endHookWidth = 0;
+
+            textLine.setP1(pp1);
+
+            QPointF hookP1, hookP2;
+            if (hasBeginHook && (isSingleType() || isBeginType())) {
+                  qreal beginHookHeight = tl->beginHookHeight().val() * _spatium;
+                  qreal x1 = pp1.x() - beginHookWidth;
+                  qreal y1 = pp1.y() + beginHookHeight;
+                  qreal x2 = pp1.x();
+                  qreal y2 = (beginHookType == HookType::HOOK_90T) ? (pp1.y() - beginHookHeight) : pp1.y();
+                  beginHookLine.setPoints(QPointF(x1, y1), QPointF(x2, y2));
+
+                  if (beginHookType == HookType::HOOK_90T)
+                        points[npoints++] = QPointF(x1, y1);
+                  else  points[npoints++] = QPointF(x2, y2);
+
+                  points[npoints] = pp1;
+                  }
 
             // don't draw backwards lines (or hooks) if text is longer than nominal line length
-            bool backwards = !_text->empty() && pp1.x() > pp2.x() && !tl->diagonal();
+            bool backwardsWithText = isHorizontallyBackwards && !_text->empty() && !isDiagonal;
+            if (!backwardsWithText) {
+                  points[npoints++] = pp1;
+                  points[npoints]   = pp2;
 
-            if (isSingleOrBegin && tl->beginHookType() != HookType::NONE) {
-                  qreal hh = tl->beginHookHeight().val() * _spatium;
-                  if (tl->beginHookType() == HookType::HOOK_90T)
-                        points[npoints++] = QPointF(pp1.x() - beginHookWidth, pp1.y() - hh);
-                  points[npoints] = QPointF(pp1.x() - beginHookWidth, pp1.y() + hh);
-                  ++npoints;
-                  points[npoints] = pp1;
-                  }
-            if (!backwards) {
-                  points[npoints] = pp1;
-                  ++npoints;
-                  points[npoints] = pp2;
+                  textLine.setPoints(pp1, pp2);
                   lineLength = sqrt(QPointF::dotProduct(pp2-pp1, pp2-pp1));
-                  // painter->drawLine(QLineF(pp1.x(), pp1.y(), pp2.x(), pp2.y()));
 
-                  if ((tl->endHookType() != HookType::NONE) && (isSingleType() || isEndType())) {
+                  if (hasEndHook && (isSingleType() || isEndType())) {
                         ++npoints;
-                        qreal hh = tl->endHookHeight().val() * _spatium;
-                        // painter->drawLine(QLineF(pp2.x(), pp2.y(), pp2.x() + endHookWidth, pp2.y() + hh));
-                        points[npoints] = QPointF(pp2.x() + endHookWidth, pp2.y() + hh);
+                        qreal endHookHeight = tl->endHookHeight().val() * _spatium;
+                        qreal x1 = textLine.length() + beginHookWidth + l;
+                        // Rotation will later handle y-positioning
+                        qreal y1 = (endHookType == HookType::HOOK_90T) ? (0.0 + endHookHeight) : 0.0;
+                        qreal x2 = x1 + endHookWidth;
+                        qreal y2 = (endHookType == HookType::HOOK_90T) ? (0.0 - endHookHeight) : (0.0 + endHookHeight);
+                        endHookLine.setPoints(QPointF(x1, y1), QPointF(x2, y2));
+
+                        points[npoints++] = QPointF(x1, y1);
                         if (tl->endHookType() == HookType::HOOK_90T)
-                              points[++npoints] = QPointF(pp2.x() + endHookWidth, pp2.y() - hh);
+                              points[++npoints] = hookP2;
                         }
+                  }
+
+            }
+
+      if (!_text->empty()) {
+            qreal xo = 0.0;
+            qreal yo = 0.0;
+            auto bb = _text->bbox();
+            if (isCenteredText) {
+                  xo = textLine.center().x() + _text->rxoffset();
+                  yo = textLine.center().y() + _text->ryoffset();
+                  if (isBroken) {
+                        // Compute broken lines
+                        //   Let painter rotate the broken-lines after forming
+                        //   the points based on line length without reference to angle
+                        QLineF horizontalTextLine(textLine);
+                        horizontalTextLine.setAngle(0.0);
+                        auto xUserOffset          = _text->offset().x();
+                        auto textWidth            = _text->bbox().width();
+                        auto lineWidth            = horizontalTextLine.length();
+                        auto xCenter              = horizontalTextLine.center().x();
+
+                        auto textLeftEdge         = xCenter - (textWidth * 0.5) - lineStrokeWidth - beginHookWidth + xUserOffset - (spatium() * 0.5);
+                        auto textRightEdge        = xCenter + (textWidth * 0.5) + lineStrokeWidth - beginHookWidth + xUserOffset + (spatium() * 0.5);
+
+                        auto leftProportion       = textLeftEdge  / lineWidth;
+                        auto rightProportion      = textRightEdge / lineWidth;
+
+                        auto beginEdgePoint = horizontalTextLine.pointAt(leftProportion);
+                        auto endEdgePoint   = horizontalTextLine.pointAt(rightProportion);
+
+                        brokenPoints[0] = horizontalTextLine.p1();
+                        brokenPoints[1] = beginEdgePoint;
+                        brokenPoints[2] = endEdgePoint;
+                        brokenPoints[3] = horizontalTextLine.p2();
+                        }
+                  }
+            _text->setPos(xo, yo);
+            if (isCenteredText) {
+                  auto aboutSelf = QPointF(0,0);
+                  auto translate = _text->offset();
+                  auto angle = textLine.angle();
+
+                  // Z-Axis rotation, then apply user-offsets
+                  bb = rotateRectangle(bb, aboutSelf, angle, translate);
+                  bb.translate(textLine.center());
+                  }
+            else {
+                  bb = _text->bbox().translated(_text->pos());
+                  }
+            _text->setbbox(bb);
+            bbox() |= bb;
+            }
+
+      if (!_endText->empty()) {
+            auto xo = bbox().right();
+            auto yo = _endText->getVAlignOffset();
+            auto bb = _endText->bbox();
+            auto angle = textLine.angle();
+            auto aboutSelf = QPointF(0,0);
+            auto translate = _endText->offset();
+            translate.rx() += (lineStrokeWidth * 0.5);
+
+            // Z-Axis rotation, then apply user-offsets
+            bb = rotateRectangle(bb, aboutSelf, angle, translate);
+            bb.translate(textLine.p2());
+
+            _endText->setPos(xo, yo);
+            _endText->setbbox(bb);
+            bbox() |= bb;
+            }
+
+      // MS3.6 didn't incorporate hooks or prepare for rotated objects into the main bounding-box.
+      // Calculate rotation and position here, then store the results so that Shape() can add them easily:
+      if (tl->lineVisible()) {
+            auto angle = textLine.angle();
+            auto translate = QPointF(textLine.p1().x(), 0.0);
+            auto lw = lineStrokeWidth;
+            auto lw2 = (lw * 0.5);
+            if (!textLine.isNull()) {
+                  QLineF flatLine = textLine;
+                  flatLine.setAngle(0.0);
+                  lineBB = formBoundingBox(flatLine, -lw2, -lw2, +lw, +lw);
+                  auto translate = flatLine.p1();
+                  lineBB = rotateRectangle(lineBB, translate, angle, -translate);
+
+                  bbox() |= lineBB;
+                  }
+            if (!beginHookLine.isNull()) {
+                  auto foeD5 = (tl->beginHookType() == HookType::HOOK_45);
+                  QLineF swappedLine(beginHookLine.p1(), beginHookLine.p2());
+                  swappedLine.setAngle(swappedLine.angle() + angle);
+                  beginHookBB = formBoundingBox(swappedLine,
+                                                foeD5 ? +lw2 : -lw2,
+                                                foeD5 ? -lw2 : -lw2,
+                                                foeD5 ? -lw  : +lw,
+                                                foeD5 ? +lw  : +lw);
+                  // If swappedLine's angle wasn't updated, then:
+                  //    beginHookBB = rotateRectangle(beginHookBB, translate, angle, -translate);
+
+                  bbox() |= beginHookBB;
+                  }
+            if (!endHookLine.isNull()) {
+                  // Lacks "best practice" for 45's bounding-box, but works well enough:
+                  auto fowtyFive = (tl->endHookType() == HookType::HOOK_45);
+                  QLineF swappedLine(endHookLine.p2(), endHookLine.p1());
+                  endHookBB = formBoundingBox(fowtyFive ? endHookLine : swappedLine, -lw2, -lw2, +lw, +lw);
+                  endHookBB = rotateRectangle(endHookBB, translate, angle, -translate);
+
+                  bbox() |= endHookBB;
                   }
             }
       }

--- a/libmscore/textlinebase.cpp
+++ b/libmscore/textlinebase.cpp
@@ -82,6 +82,11 @@ void TextLineBaseSegment::draw(QPainter* painter) const
       qreal strokeWidth = tl->lineWidth();
       qreal lineAngle = -(textLine.angle());
 
+      auto lineColorAlpha = lineColor.alpha();
+      bool transparentLine = (lineColorAlpha == 0);
+      QColor opaqueLineColor = lineColor;
+      opaqueLineColor.setAlpha(255);
+
       // Playback marked color:
       auto t1 = spanner()->tick();
       auto t2 = spanner()->tick2();
@@ -160,7 +165,6 @@ void TextLineBaseSegment::draw(QPainter* painter) const
             strokeWidth *= mag();
       QPen pen(lineColor, strokeWidth, tl->lineStyle());
       QPen solidPen(lineColor, strokeWidth, Qt::SolidLine);
-
 
       // Δ from 3.6.2: MiterJoined Polylines for each segment + round-capped single-lined hooks for pedals
       pen.setCapStyle(Qt::FlatCap);
@@ -352,57 +356,72 @@ void TextLineBaseSegment::draw(QPainter* painter) const
             painter->rotate(angle);
             painter->translate(-unangledTextLine.p1());
 
-            if (endHookLine.length() && !separateHooks) {
-                  if (tl->endHookType() == HookType::HOOK_45 || tl->endHookType() == HookType::HOOK_90)
-                        totalLine << endHookLine.p2();
-                  }
+            if (transparentLine && !qFuzzyCompare(strokeWidth, 0.0)) {
+                  QRectF r(0.0, -strokeWidth * 0.5, lineLength, strokeWidth);
+                  solidPen.setColor(opaqueLineColor);
+                  solidPen.setWidth(3);
+                  solidPen.setStyle(Qt::SolidLine);
+                  painter->setBrush(Qt::NoBrush);
+                  painter->setPen(solidPen);
 
-            if (centeredBrokenText) {
-                  totalLine << brokenPoints[3] << brokenPoints[2];
+                        painter->drawRect(r);
+
+                  painter->translate(+unangledTextLine.p1());
+                  painter->rotate(-angle);
+                  painter->translate(-unangledTextLine.p1());
+                  }
+            else {
+                  if (endHookLine.length() && !separateHooks) {
+                        if (tl->endHookType() == HookType::HOOK_45 || tl->endHookType() == HookType::HOOK_90)
+                              totalLine << endHookLine.p2();
+                        }
+
+                  if (centeredBrokenText) {
+                        totalLine << brokenPoints[3] << brokenPoints[2];
+
+                        painter->drawPolyline(totalLine);
+
+                        totalLine.clear();
+                        totalLine << brokenPoints[1] << brokenPoints[0];
+                        }
+                  else totalLine << unangledTextLine.p2() << unangledTextLine.p1();
+
+                  if (beginHookLine.length() && !separateHooks) {
+                        if (tl->beginHookType() == HookType::HOOK_45 || tl->beginHookType() == HookType::HOOK_90)
+                              totalLine << beginHookLine.p1();
+                        }
 
                   painter->drawPolyline(totalLine);
 
-                  totalLine.clear();
-                  totalLine << brokenPoints[1] << brokenPoints[0];
-                  }
-            else {
-                  totalLine << unangledTextLine.p2() << unangledTextLine.p1();
-                  }
+                  painter->translate(+unangledTextLine.p1());
+                  painter->rotate(-angle);
+                  painter->translate(-unangledTextLine.p1());
 
-            if (beginHookLine.length() && !separateHooks) {
-                  if (tl->beginHookType() == HookType::HOOK_45 || tl->beginHookType() == HookType::HOOK_90)
-                        totalLine << beginHookLine.p1();
-                        }
-
-            painter->drawPolyline(totalLine);
-
-            painter->translate(+unangledTextLine.p1());
-            painter->rotate(-angle);
-            painter->translate(-unangledTextLine.p1());
-
-            if (totalLine.isEmpty()) {
-                  // Left-over for non-joined polylines. 90T hooks and custom dash lined hooks were already drawn
-                  if (tl->endHookType() != HookType::NONE && tl->endHookType() != HookType::HOOK_90T && tl->lineStyle() != Qt::CustomDashLine) {
-                        if (endHookLine.length()) {
-                              painter->rotate(angle);
-                              painter->drawLine(endHookLine);
-                              painter->rotate(-angle);
+                  if (totalLine.isEmpty()) {
+                        // Left-over for non-joined polylines. 90T hooks and custom dash lined hooks were already drawn
+                        if (tl->endHookType() != HookType::NONE && tl->endHookType() != HookType::HOOK_90T && tl->lineStyle() != Qt::CustomDashLine) {
+                              if (endHookLine.length()) {
+                                    painter->rotate(angle);
+                                    painter->drawLine(endHookLine);
+                                    painter->rotate(-angle);
+                                    }
                               }
-                        }
-                  QLineF reverseLine(textLine.p2(), textLine.p1());
-                  if (tl->lineStyle() == Qt::DashDotDotLine || tl->lineStyle() == Qt::DotLine)
-                        painter->drawLine(reverseLine);
-                  else painter->drawLine(textLine);
-                  if (tl->beginHookType() != HookType::NONE && tl->beginHookType() != HookType::HOOK_90T && tl->lineStyle() != Qt::CustomDashLine) {
-                        if (beginHookLine.length()) {
-                              painter->rotate(angle);
-                              painter->drawLine(beginHookLine);
-                              painter->rotate(-angle);
+                        QLineF reverseLine(textLine.p2(), textLine.p1());
+                        if (tl->lineStyle() == Qt::DashDotDotLine || tl->lineStyle() == Qt::DotLine)
+                              painter->drawLine(reverseLine);
+                        else painter->drawLine(textLine);
+                        if (tl->beginHookType() != HookType::NONE && tl->beginHookType() != HookType::HOOK_90T && tl->lineStyle() != Qt::CustomDashLine) {
+                              if (beginHookLine.length()) {
+                                    painter->rotate(angle);
+                                    painter->drawLine(beginHookLine);
+                                    painter->rotate(-angle);
+                                    }
                               }
                         }
                   }
 
             }
+
       }
 
 //---------------------------------------------------------

--- a/libmscore/textlinebase.h
+++ b/libmscore/textlinebase.h
@@ -33,10 +33,16 @@ class TextLineBaseSegment : public LineSegment {
       Text* _text;
       Text* _endText;
       QPointF points[6];
+      QPointF brokenPoints[4];
       int npoints;
       qreal lineLength;
       bool twoLines { false };
+      
+      QLineF beginHookLine;
+      QLineF endHookLine;
+      QLineF textLine;
       QPolygonF joinedHairpin;
+      QRectF beginHookBB, endHookBB, lineBB;
 
    public:
       TextLineBaseSegment(Spanner*, Score* s, ElementFlags f = ElementFlag::NOTHING);

--- a/libmscore/xmlreader.cpp
+++ b/libmscore/xmlreader.cpp
@@ -425,6 +425,10 @@ PlaceText readPlacement(XmlReader& e)
             return PlaceText::BELOW;
       if (s == "left" || s == "3")
             return PlaceText::LEFT;
+      if (s == "centered" || s == "4")
+            return PlaceText::CENTERED;
+      if (s == "centeredbroken" || s == "5")
+            return PlaceText::CENTERED_BROKEN;
       qDebug("unknown placement value <%s>", qPrintable(s));
       return PlaceText::AUTO;
       }

--- a/libmscore/xmlwriter.cpp
+++ b/libmscore/xmlwriter.cpp
@@ -45,7 +45,7 @@ XmlWriter::XmlWriter(Score* s, QIODevice* device)
 void XmlWriter::pTag(const char* name, PlaceText place)
       {
       const char* tags[] = {
-            "auto", "above", "below", "left"
+            "auto", "above", "below", "left", "centered", "centeredbroken"
             };
       tag(name, tags[int(place)]);
       }

--- a/mscore/dragdrop.cpp
+++ b/mscore/dragdrop.cpp
@@ -437,6 +437,7 @@ void ScoreView::dropEvent(QDropEvent* event)
             switch (editData.dropElement->type()) {
                   case ElementType::TEXTLINE:
                         firstStaffOnly = editData.dropElement->systemFlag();
+                        applyUserOffset = true; // It's the thought that counts...
                         // fall-thru
                   case ElementType::VOLTA:
                         // voltas drop to first staff by default, or closest staff if Control is held

--- a/mscore/inspector/inspectorTextLineBase.cpp
+++ b/mscore/inspector/inspectorTextLineBase.cpp
@@ -34,13 +34,17 @@ void populateHookType(QComboBox* b)
 //   populateTextPlace
 //---------------------------------------------------------
 
-void populateTextPlace(QComboBox* b)
+void populateTextPlace(QComboBox* b, bool showCenteringOptions)
       {
       b->clear();
       b->addItem(b->QObject::tr("Auto"),  int(PlaceText::AUTO));
       b->addItem(b->QObject::tr("Above"), int(PlaceText::ABOVE));
       b->addItem(b->QObject::tr("Below"), int(PlaceText::BELOW));
       b->addItem(b->QObject::tr("Left"),  int(PlaceText::LEFT));
+      if (showCenteringOptions) {
+            b->addItem(b->QObject::tr("Centered"), int(PlaceText::CENTERED));
+            b->addItem(b->QObject::tr("Centered (Broken)"), int(PlaceText::CENTERED_BROKEN));
+            }
       }
 
 //---------------------------------------------------------
@@ -103,9 +107,9 @@ InspectorTextLineBase::InspectorTextLineBase(QWidget* parent)
 
       populateHookType(tl.beginHookType);
       populateHookType(tl.endHookType);
-      populateTextPlace(tl.beginTextPlacement);
-      populateTextPlace(tl.continueTextPlacement);
-      populateTextPlace(tl.endTextPlacement);
+      populateTextPlace(tl.beginTextPlacement, true);
+      populateTextPlace(tl.continueTextPlacement, false);
+      populateTextPlace(tl.endTextPlacement, false);
 
       connect(tl.hasBeginText,    &QCheckBox::clicked, this, &InspectorTextLineBase::hasBeginTextClicked);
       connect(tl.hasContinueText, &QCheckBox::clicked, this, &InspectorTextLineBase::hasContinueTextClicked);

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -1816,6 +1816,7 @@ MuseScore::MuseScore()
       menuAddLines->addAction(getAction("add-8va"));
       menuAddLines->addAction(getAction("add-8vb"));
       menuAddLines->addAction(getAction("add-noteline"));
+      menuAddLines->addAction(getAction("add-noteline-alt"));
       menuAdd->addMenu(menuAddLines);
 
       //---------------------

--- a/mscore/palette.cpp
+++ b/mscore/palette.cpp
@@ -640,8 +640,28 @@ bool Palette::applyPaletteElement(Element* element, Qt::KeyboardModifiers modifi
                   Spanner* spanner = static_cast<Spanner*>(Element::create(type, score));
                   spanner->read(e);
                   spanner->styleChanged();
-                  score->cmdAddSpanner(spanner, cr1->staffIdx(), startSegment, endSegment);
-                  spanner->isVoiceSpecific();
+                  if (element->isTextLine()) {
+                        // Allow for drag-copying a (single) note-anchor line
+                        auto tl = toTextLine(spanner);
+                        if (tl->anchor() == Spanner::Anchor::NOTE) {
+                              if (cr1 && cr1->isChord()) {
+                                    auto chord = toChord(cr1);
+                                    auto note = chord->notes().front();
+                                    tl->setParent(note);
+                                    tl->setStartElement(note);
+                                    tl->setDiagonal(true);
+                                    tl->setTick(chord->tick());
+                                    tl->setEndElement(note);
+                                    score->startCmd();
+                                          score->undoAddElement(tl);
+                                    score->endCmd();
+                                    }
+                              }
+                        }
+                  else  {
+                        score->cmdAddSpanner(spanner, cr1->staffIdx(), startSegment, endSegment);
+                        spanner->isVoiceSpecific();
+                        }
                   }
             else {
                   bool finished = false;

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -2970,7 +2970,10 @@ void ScoreView::cmd(const char* s)
                         cv->cmdAddPedal(HookType::HOOK_90, HookType::HOOK_90);
                   }},
             {{"add-noteline"}, [](ScoreView* cv, const QByteArray&) {
-                  cv->cmdAddNoteLine();
+                  cv->cmdAddNoteLine(false);
+                  }},
+            {{"add-noteline-alt"}, [](ScoreView* cv, const QByteArray&) {
+                  cv->cmdAddNoteLine(true);
                   }},
             {{"chord-text"}, [](ScoreView* cv, const QByteArray&) {
                   cv->changeState(ViewState::NORMAL);
@@ -5805,9 +5808,11 @@ void ScoreView::cmdAddPedal(HookType beginHook, HookType endHook)
 
 //---------------------------------------------------------
 //   cmdAddNoteLine
+//     hiddenLineWithText (if true) will give 0 width line
+//     + a centered text letter "H"
 //---------------------------------------------------------
 
-void ScoreView::cmdAddNoteLine()
+void ScoreView::cmdAddNoteLine(bool hiddenLineWithText)
       {
       Note* firstNote = 0;
       Note* lastNote  = 0;
@@ -5824,32 +5829,101 @@ void ScoreView::cmdAddNoteLine()
                   }
             }
       else {
-            for (Note* n : _score->selection().noteList()) {
-                  if (firstNote == 0 || firstNote->chord()->tick() > n->chord()->tick())
-                        firstNote = n;
-                  if (lastNote == 0 || lastNote->chord()->tick() < n->chord()->tick())
-                        lastNote = n;
+            if (_score->selection().isList() && !_score->selection().noteList().empty()) {
+                  auto noteList = _score->selection().noteList();
+                  firstNote = noteList.front();
+                  lastNote  = noteList.back();
+                  if (firstNote->chord() == lastNote->chord()) {
+                        // 1) Same chord, one/same note  -> Single vertical line anchored above note (arrows/etc)
+                        // 2) Same chord, different note -> 3.x Will allow (Also grace notes) for clusters / more options
+                        }
+
+                  // Update: Allow lines to be drawn to more than one pair of noteheads at a time using a
+                  //         LIST selection: (appropiate to select top notes only first, etc.)
+                  std::size_t listSize = _score->selection().noteList().size();
+                  if (listSize > 2) {
+
+                        _score->startCmd();
+
+                        for (std::size_t idx = 0; idx < listSize-1; idx++) {
+                              firstNote = noteList.at(idx);
+                              lastNote = noteList.at(idx+1);
+                              // 1) Omit drawing line from one note to the next in the same chord
+                              // 2) Only draw to the same voice
+                              if (firstNote->chord() != lastNote->chord() && (firstNote->voice() == lastNote->voice())) {
+                                    TextLine* tl = new TextLine(_score);
+                                    tl->setParent(firstNote);
+                                    tl->setStartElement(firstNote);
+                                    tl->setDiagonal(true);
+                                    tl->setAnchor(Spanner::Anchor::NOTE);
+                                    tl->setSystemFlag(false);
+                                    tl->setTick(firstNote->chord()->tick());
+                                    tl->setEndElement(lastNote);
+
+                                    // --- Workaround for Hammer-on/Pull-off text
+                                    if (hiddenLineWithText) {
+                                          tl->setBeginText("H");
+                                          tl->setBeginTextPlace(PlaceText::CENTERED);
+                                          tl->setLineWidth(0.0); // Hidden line
+                                          tl->setLineColor(QColor(255, 255, 255, 0));
+                                          tl->setBeginTextOffset(QPointF(0.0, -75.0));
+                                          // Lame, but it works for now since ->offset doesn't do shit for some reason
+                                          }
+                                    _score->undoAddElement(tl);
+                                    }
+                              }
+                        _score->endCmd();
+
+                        return;
+                        }
+                  }
+            else  {
+                  // qDebug() << "Invalid Selection to add Note-Anchored Line (rests, etc)";
+                  return;
                   }
             }
       if (!firstNote || !lastNote) {
             qDebug("addNoteLine: no note %p %p", firstNote, lastNote);
             return;
             }
-      if (firstNote == lastNote) {
-            qDebug("addNoteLine: no support for note to same note line %p", firstNote);
-            return;
-            }
+
       TextLine* tl = new TextLine(_score);
       tl->setParent(firstNote);
       tl->setStartElement(firstNote);
       tl->setDiagonal(true);
       tl->setAnchor(Spanner::Anchor::NOTE);
       tl->setTick(firstNote->chord()->tick());
+      tl->setSystemFlag(false);
       tl->setEndElement(lastNote);
+
+      // --- Workaround for Hammer-on/Pull-off text (sloppy for now)
+      if (hiddenLineWithText) {
+            tl->setBeginText("H");
+            tl->setBeginTextPlace(PlaceText::CENTERED);
+            tl->setLineWidth(0.0); // Hidden line
+            tl->setLineColor(QColor(255, 255, 255, 0));
+            tl->setBeginTextOffset(QPointF(0.0, -75.0));
+            }
+
       _score->startCmd();
-      _score->undoAddElement(tl);
+            _score->undoAddElement(tl);
       _score->endCmd();
-      tl->setEndElement(lastNote);
+
+      if (firstNote == lastNote) {
+            // Single-note anchor line
+            tl->setProperty(Pid::AUTOPLACE, false);
+            tl->setPropertyFlags(Pid::OFFSET, PropertyFlags::UNSTYLED);
+            tl->setPropertyFlags(Pid::OFFSET2, PropertyFlags::UNSTYLED);
+            if (auto tls = tl->frontSegment()) {
+                  tls->setUserOff2(QPointF(0.0, -125.0));
+                  }
+            // Automatically select without edit mode: allowing up/down placement changes
+            deselectAll();
+            if (!tl->spannerSegments().empty()) {
+                  score()->select(tl->spannerSegments().front(), SelectType::SINGLE, 0);
+                  }
+            }
+
       }
 
 //---------------------------------------------------------

--- a/mscore/scoreview.h
+++ b/mscore/scoreview.h
@@ -443,7 +443,7 @@ class ScoreView : public QWidget, public MuseScoreView {
       void addSlur(ChordRest*, ChordRest*, const Slur*) override;
       virtual void cmdAddHairpin(HairpinType);
       virtual void cmdAddPedal(HookType, HookType);
-      void cmdAddNoteLine();
+      void cmdAddNoteLine(bool);
       void cmdAddEmptyImage(bool, bool);
 
       void setEditElement(Element*);

--- a/mscore/shortcut.cpp
+++ b/mscore/shortcut.cpp
@@ -3590,6 +3590,13 @@ Shortcut Shortcut::_sc[] = {
          QT_TRANSLATE_NOOP("action","Note anchored line")
          },
       {
+         MsWidget::SCORE_TAB,
+         STATE_NORMAL | STATE_NOTE_ENTRY,
+         "add-noteline-alt",
+         QT_TRANSLATE_NOOP("action","Note Anchored (Hidden) Line: Centered Text H"),
+         QT_TRANSLATE_NOOP("action","Note anchored (Hidden) line: Centered Text H")
+         },
+      {
          MsWidget::MAIN_WINDOW,
          STATE_NORMAL | STATE_LOCK,
          "lock",


### PR DESCRIPTION
Experimental:

+ Allow for centered text of a text-line, or centered-broken (empty space for the text)
Broken:
![image](https://github.com/user-attachments/assets/6d5261e1-d4ce-4b1c-bbd6-e740949f58d8)

Hooks follow angle:
![image](https://github.com/user-attachments/assets/c01be6e7-ec04-4bbc-b5ce-240aa7ff669f)


+ End-text will follow the rotation of its line to allow for arrows etc. to follow suit, and it will offset _through_ the line instead of using absolute x-y co-ordinates

[angleLineArrow.webm](https://github.com/user-attachments/assets/d84269ec-be52-411b-84f4-da7a2a60d79a)


+ Also allow Note Anchor Lines to be applied to just one note as a vertical "floating line". Totally incompatible with 3.6.2/4.x. 
Will begin like so:
![image](https://github.com/user-attachments/assets/66e881ae-fd24-4ec1-88bf-a3d042a7a59f)

+ Line with total transparency will draw a small frame around line-width, the color of which being the opaque version of the transparent color. No control over the frame width, however - "it's a hack" ™
![image](https://github.com/user-attachments/assets/2f0ef08f-ed14-4624-a770-fd07a0c9b7cc)



Apparently I already put in a custom command to place a line, but here this enables  making a make-shift "hammer-on": **Note anchored (Hidden) line: Centered Text H**

Of course  all of this is incompatible with 3.6.2 or 4x, but shouldn't cause any internal problems

+ Uses Polylines with Mitre-joints 
+ Pedal lines get round-caps to allow for clean joining between 45-degree angles between separate segments
+  Note-anchor lines use round-caps (usually hidden within a note-head, but may show when notes are hidden, or margins added) 

+ **Known issue:** Haven't got angling with bold text to work because the way `TextBase::drawTextWorkaround()` is handled makes it not a basic operation,