### PR TITLE
Accidentals: Layout - Flats closer to notehead when above staff+ledger line

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -1295,12 +1295,47 @@ void Score::layoutChords3(std::vector<Note*>& notes, const Staff* staff, Segment
                   }
             }
 
+      const float tuck = 8.0;
       for (const AcEl& e : qAsConst(aclist)) {
             // even though we initially calculate accidental position relative to segment
             // we must record pos for accidental relative to note,
             // since pos is always interpreted relative to parent
             Note* note = e.note;
+            int lineOfAcc = note->line();
             qreal x    = e.x + lx - (note->x() + note->chord()->x());
+
+            bool secondAboveExists = false;
+            bool secondHasAcc = false;
+            for (const auto& n : notes) {
+                  auto l = n->line();
+                  if (l == (lineOfAcc - 1) && n->chord() != note->chord()) {
+                        secondAboveExists = true;
+                        if (n->accidentalType() != AccidentalType::NONE)
+                              secondHasAcc = true;
+                        }
+                  }
+            bool ledgerBelow = lineOfAcc > note->staff()->bottomLine(note->tick());
+            bool ledgerAbove = lineOfAcc <= -2;
+            bool accOnStaffSpace = lineOfAcc % 2;
+            if (ledgerBelow && secondAboveExists && !secondHasAcc && !accOnStaffSpace) {
+                  // Second above is on a staff-space
+                  x += tuck;
+                  }
+            else if (ledgerAbove && accOnStaffSpace) {
+                  if (!secondAboveExists) {
+                        if (note->accidentalType() == AccidentalType::FLAT ||
+                            note->accidentalType() == AccidentalType::FLAT2) {
+                              // -44 Magic number for recognizing alterations already existing, needing no extra tuck
+                              x += (x < -44) ? 0.0 : tuck;
+                              }
+                        }
+                  }
+            else if (lineOfAcc == -1 && secondAboveExists && !secondHasAcc) {
+                  // Corner case of accidental not taking into consideration ledger line when
+                  // its note is sitting on top of staff (-1 line) with a 2nd above it in another voice
+                  x -= (note->score()->styleS(Sid::ledgerLineLength).val() * sp);
+                  }
+
             note->accidental()->setPos(x, 0);
             }
       }


### PR DESCRIPTION
+ Also tighten spacing when a second-above in another voice exists on below staff
+ Open spacing of accidental when it exists sitting on top of staff when a second above it in another voice exists and that voices doesn't have an accidental
+ Don't be closer (flats) if already offset by other accidentals (used magic number instead of performing more specific logic)

Demonstrations

### Problem:
![image](https://github.com/user-attachments/assets/88bc5170-a3f5-430c-a6aa-c97b4110b5ea)

**Fixed Result:**
![image](https://github.com/user-attachments/assets/789b112b-3459-425a-83a7-e04be858f2fa)

Isn't a problem when there's an accidental already on the top voice like:
![image](https://github.com/user-attachments/assets/d342f340-b4b6-4980-82d8-8541842b9cf3)

### Problem: 
![image](https://github.com/user-attachments/assets/f536042e-6ef0-4394-8eb2-4a16b871b7cd)

**Fixed Result:**
![image](https://github.com/user-attachments/assets/067fd819-acc2-4ea4-b5f3-f3c0468757d1)


### Problem:
![image](https://github.com/user-attachments/assets/206e4857-88e2-47b8-b4fe-4bcbfd9bbcba)

**Fixed Result:**
![image](https://github.com/user-attachments/assets/ffd724ba-095b-432c-b215-70307f38d0c3)


