### PR TITLE
Layout: Tuples - add to skyline without "avoid" staves + personal slope decisions

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -4515,6 +4515,33 @@ void Score::layoutSystemElements(System* system, LayoutContext& lc)
                                     if (e->addToSkyline() || e->isChord())
                                           skyline.add(e->shape().translated(e->pos() + p));
 
+                                    // Allow tuplets to get skyline even when "avoid staves" is disabled
+                                    // (still want to avoid elements via auto-place, e.g. hairpins...)
+                                    if (e->isChordRest()) {
+                                          if (auto t = toChordRest(e)->tuplet()) {
+                                                bool addToSky = true;
+
+                                                // Omit skyline if any cross-staffed elements:
+                                                for (auto& e : t->elements()) {
+
+                                                      if (e->staffIdx() != e->vStaffIdx()) {
+                                                            addToSky = false;
+                                                            // TODO: Figure how to do something like this while finding the right formula
+                                                                // SysStaff* ss = system->staff(e->vStaffIdx());
+                                                                // Skyline& vSkyline = ss->skyline();
+                                                                // vSkyline.add(t->shape().translated(m->pos()));
+                                                            }
+                                                      }
+                                                if (t->addToSkyline() && addToSky) {
+                                                      // Note: layout isn't 100% realtime:
+                                                      QPointF offset(m->pos());
+                                                      offset.rx() += t->offset().x();
+                                                      offset.ry() += t->offset().y();
+                                                      skyline.add(t->shape().translated(offset));
+                                                      }
+                                                }
+                                          }
+
                                     // add tremolo to skyline
                                     if (e->isChord() && toChord(e)->tremolo()) {
                                           Tremolo* t = toChord(e)->tremolo();

--- a/libmscore/tuplet.cpp
+++ b/libmscore/tuplet.cpp
@@ -610,6 +610,20 @@ void Tuplet::layout()
 
       // l2l l2r, mp, _p1, _p2 const
 
+      // Custom: Reset once again if there is a rest to get horizontal tuples
+      if (!cr1->isChord() && cr2->isChord()) {
+            if (p2.y() < p1.y())
+                  p1.setY(p2.y());
+            else
+                  p2.setY(p1.y());
+            }
+      else if (cr1->isChord() && !cr2->isChord()) {
+            if (p1.y() < p2.y())
+                  p2.setY(p1.y());
+            else
+                  p1.setY(p2.y());
+            }
+
       // center number
       qreal x3 = 0.0;
       qreal numberWidth = 0.0;

--- a/libmscore/tuplet.cpp
+++ b/libmscore/tuplet.cpp
@@ -328,7 +328,22 @@ void Tuplet::layout()
                   outOfStaff = false;
             }
 
-      qreal l1  =  score()->styleP(Sid::tupletBracketHookHeight);
+      auto centerOfChord = [](const Chord* cr){
+            qreal l = 0.0;
+            qreal r = 0.0;
+            qreal c = cr->upNote()->abbox().center().x();
+            for (const auto& n : cr->notes()) {
+                  auto nc = n->abbox().center().x();
+                  if (nc < c)
+                      l = nc;
+                  else r = nc;
+                  }
+            if (l == 0.0 || r == 0.0)
+                 return c;
+            else return ( (l + r) * 0.5 );
+            };
+
+      qreal l1  = this->hasBracket() ? score()->styleP(Sid::tupletBracketHookHeight) : 0.0;
       qreal l2l = vHeadDistance;    // left bracket vertical distance
       qreal l2r = vHeadDistance;    // right bracket vertical distance right
 
@@ -357,8 +372,10 @@ void Tuplet::layout()
             if (cr1->isChord()) {
                   const Chord* chord1 = toChord(cr1);
                   Stem* stem = chord1->stem();
-                  if (stem)
+                  if (stem) {
                         xx1 = stem->abbox().x();
+                        p1.rx() = chord1->up() ? chord1->stemPos().x() : centerOfChord(chord1);
+                        }
                   if (chord1->up()) {
                         if (stem) {
                               if (followBeam)
@@ -375,14 +392,14 @@ void Tuplet::layout()
                         }
                   else if (!chord1->up()) {
                         p1.ry() = chord1->upNote()->abbox().top();
-                        if (stem)
-                              p1.rx() = cr1->pagePos().x() - stemLeft;
                         }
                   }
 
             if (cr2->isChord()) {
                   const Chord* chord2 = toChord(cr2);
                   Stem* stem = chord2->stem();
+                  if (stem)
+                        p2.rx() = chord2->up() ? (chord2->stemPos().x() + stemRight) : centerOfChord(chord2);
                   if (stem && chord2->up()) {
                         if (followBeam)
                               p2.ry() = stem->abbox().top() - beamAdjust;
@@ -391,7 +408,6 @@ void Tuplet::layout()
                         else
                               p2.ry() = stem->abbox().top();
                         l2r = vStemDistance;
-                        p2.rx() = chord2->pagePos().x() + chord2->maxHeadWidth() + stemRight;
                         }
                   else {
                         p2.ry() = chord2->upNote()->abbox().top();
@@ -401,7 +417,7 @@ void Tuplet::layout()
             // special case: one of the bracket endpoints is
             // a rest
             //
-            if (cr1->isChord() && cr2->isChord()) {
+            if (!cr1->isChord() && cr2->isChord()) {
                   if (p2.y() < p1.y())
                         p1.setY(p2.y());
                   else
@@ -467,8 +483,10 @@ void Tuplet::layout()
             if (cr1->isChord()) {
                   const Chord* chord1 = toChord(cr1);
                   Stem* stem = chord1->stem();
-                  if (stem)
+                  if (stem) {
                         xx1 = stem->abbox().x();
+                        p1.rx() = !chord1->up() ? chord1->stemPos().x() - stemLeft : centerOfChord(chord1);
+                        }
                   if (!chord1->up()) {
                         if (stem) {
                               if (followBeam)
@@ -478,7 +496,6 @@ void Tuplet::layout()
                               else
                                     p1.ry() = stem->abbox().bottom();
                               l2l = vStemDistance;
-                              p1.rx() = cr1->pagePos().x() - stemLeft;
                               }
                         else {
                               p1.ry() = chord1->downNote()->abbox().bottom(); // whole note
@@ -492,12 +509,14 @@ void Tuplet::layout()
             if (cr2->isChord()) {
                   const Chord* chord2 = toChord(cr2);
                   Stem* stem = chord2->stem();
+                  if (stem)
+                        p2.rx() = !chord2->up() ? chord2->stemPos().x() + stemRight : centerOfChord(chord2);
                   if (stem && !chord2->up()) {
                         // if (chord2->beam())
                         //      p2.setX(stem->abbox().x());
                         if (followBeam)                                          //??
                               p2.ry() = stem->abbox().bottom() + beamAdjust;     //??
-                        if (chord2->beam() && !chord2->staffMove() && !chord2->beam()->cross())
+                        else if (chord2->beam() && !chord2->staffMove() && !chord2->beam()->cross())
                               p2.ry() = chord2->beam()->abbox().bottom();
                         else
                               p2.ry() = stem->abbox().bottom();
@@ -505,8 +524,6 @@ void Tuplet::layout()
                         }
                   else {
                         p2.ry() = chord2->downNote()->abbox().bottom();
-                        if (stem)
-                              p2.rx() = chord2->pagePos().x() + chord2->maxHeadWidth() + stemRight;
                         }
                   }
             //


### PR DESCRIPTION
**Resolves: Skyline problem** to allow for instance (where the slur was sourced from lower staff):

![image](https://github.com/user-attachments/assets/15a4b951-4727-410c-b7a7-af1c1320b930)

**+ Personal Preference: Tuple's beam hooks will be bound to stem position** when stem+tuple's sides coincide (that's when the score setting has 0.00 for after spacing settings. I think default might be like +0.50sp which needs to be set to 0
![image](https://github.com/user-attachments/assets/4cf18e04-e75c-42a5-8657-6df6785c9dec)

**+ Personal Preference: tuplet hooks don't follow a rest for slope:**
![image](https://github.com/user-attachments/assets/22376be4-78ba-4b41-ad71-a315cb1c3409)

**Slope of 3.6.2:**
![image](https://github.com/user-attachments/assets/e5f68bf3-ea47-4b8b-a9b2-c21bfbdd60ff)



+ Consider "center" of entire chord if on opposite side (up tuple/down stems or vice-versa) which will result in positioning between seconds (stem position)

![image](https://github.com/user-attachments/assets/46e9d599-bdc0-4d6c-8bc5-c56952dec3f3)

**instead of 3.6.2 default**:
![image](https://github.com/user-attachments/assets/b4e2e04f-2dbe-4058-8656-81f9f1e66a84)

This might not all be "best engraving practices", but are personal preferences. Probably should've made another style or something, but this is what it is.
