### PR TITLE
Various layout changes (+Reversible flag hooks)

### DIFF
--- a/libmscore/articulation.cpp
+++ b/libmscore/articulation.cpp
@@ -693,7 +693,7 @@ void Articulation::doAutoplace()
             int si     = vStaffIdx();
 
             qreal sp = score()->spatium();
-            qreal md = minDistance().val() * sp;
+            qreal md = minDistance().val();
 
             SysStaff* ss = m->system()->staff(si);
             QRectF r = bbox().translated(chordRest()->pos() + m->pos() + s->pos() + pos());

--- a/libmscore/chord.cpp
+++ b/libmscore/chord.cpp
@@ -3586,6 +3586,20 @@ void Chord::layoutArticulations()
             qreal x = centerX();
             qreal y = 0.0;
 
+            const Note* note = up() ? upNote(true) : downNote(true);
+            qreal overlapMirror;
+            if (this->stem())
+                  overlapMirror = this->stem()->lineWidth();
+            else if (this->durationType().headType() == NoteHead::Type::HEAD_WHOLE)
+                  overlapMirror = styleP(Sid::stemWidth) * this->mag();
+            else
+                  overlapMirror = 0.0;
+            qreal dx = up() ? overlapMirror : -overlapMirror;
+            // Counter mirror from layoutChords3()
+            if (note->mirror()) {
+                  x += dx;
+                  }
+
             if (bottom) {
                   if (!headSide && stem()) {
                         y = upPos() + stem()->stemLen();
@@ -3668,7 +3682,19 @@ void Chord::layoutArticulations2()
       if (_articulations.empty())
             return;
       qreal _spatium  = spatium();
-      qreal x         = centerX();
+      qreal x = centerX();
+      const Note* note = up() ? upNote(true) : downNote(true);
+      qreal overlapMirror = 0.0;
+      if (stem())
+            overlapMirror = stem()->lineWidth();
+      else if (durationType().headType() == NoteHead::Type::HEAD_WHOLE)
+            overlapMirror = styleP(Sid::stemWidth) * this->mag();
+      qreal dx = up() ? overlapMirror : -overlapMirror;
+      // Counter mirror from layoutChords3()
+      if (note->mirror()) {
+            x += dx;
+            }
+
       qreal distance0 = score()->styleP(Sid::propertyDistance);
       qreal distance2 = score()->styleP(Sid::propertyDistanceStem);
 

--- a/libmscore/chord.cpp
+++ b/libmscore/chord.cpp
@@ -3704,23 +3704,26 @@ void Chord::layoutArticulations2()
             if (aa != ArticulationAnchor::CHORD && aa != ArticulationAnchor::TOP_CHORD && aa != ArticulationAnchor::BOTTOM_CHORD)
                   continue;
 
+            qreal counter = a->isAccent() ? 0.5 * _spatium : 0.0;
             if (a->up()) {
                   if (!a->layoutCloseToNote()) {
                         a->layout();
+                        chordTopY += counter;
                         a->setPos(x, chordTopY);
                         a->doAutoplace();
                         }
                   if (a->visible())
-                        chordTopY = a->y() - a->height() - 0.5 * _spatium;
+                        chordTopY = a->y() - a->height() - 0.5 * _spatium - counter;
                   }
             else {
                   if (!a->layoutCloseToNote()) {
                         a->layout();
+                        chordBotY -= counter;
                         a->setPos(x, chordBotY);
                         a->doAutoplace();
                         }
                   if (a->visible())
-                        chordBotY = a->y() + a->height() + 0.5 * _spatium;
+                        chordBotY = a->y() + a->height() + 0.5 * _spatium + counter ;
                   }
             }
       //

--- a/libmscore/chord.cpp
+++ b/libmscore/chord.cpp
@@ -246,6 +246,7 @@ Chord::Chord(Score* s)
       _stem             = 0;
       _hook             = 0;
       _stemDirection    = Direction::AUTO;
+      _hookIsReversed   = false;
       _arpeggio         = 0;
       _tremolo          = 0;
       _endsGlissando    = false;
@@ -291,6 +292,7 @@ Chord::Chord(const Chord& c, bool link)
 
       _graceIndex     = c._graceIndex;
       _noStem         = c._noStem;
+      _hookIsReversed = c._hookIsReversed;
       _playEventType  = c._playEventType;
       _stemDirection  = c._stemDirection;
       _noteType       = c._noteType;
@@ -1072,8 +1074,14 @@ void Chord::write(XmlWriter& xml) const
             xml.tag("noStem", _noStem);
       else if (_stem && (_stem->isUserModified() || !qFuzzyIsNull(_stem->userLen())))
             _stem->write(xml);
-      if (_hook && _hook->isUserModified())
-            _hook->write(xml);
+      if (_hook) {
+            if (_hook->isUserModified()) {
+                  _hook->write(xml);
+                  }
+            if (_hookIsReversed) {
+                  writeProperty(xml, Pid::HOOK_REVERSED);
+                  }
+            }
       if (_stemSlash && _stemSlash->isUserModified())
             _stemSlash->write(xml);
       writeProperty(xml, Pid::STEM_DIRECTION);
@@ -1169,6 +1177,8 @@ bool Chord::readProperties(XmlReader& e)
             }
       else if (readProperty(tag, e, Pid::STEM_DIRECTION))
             ;
+      else if (tag == "hookReverse")
+            _hookIsReversed = e.readBool();
       else if (tag == "noStem")
             _noStem = e.readInt();
       else if (tag == "Arpeggio") {
@@ -2863,6 +2873,8 @@ QVariant Chord::getProperty(Pid propertyId) const
             case Pid::NO_STEM:        return noStem();
             case Pid::SMALL:          return isSmall();
             case Pid::STEM_DIRECTION: return QVariant::fromValue<Direction>(stemDirection());
+            case Pid::HOOK_REVERSED:  return hookIsReversed();
+
             default:
                   return ChordRest::getProperty(propertyId);
             }
@@ -2878,6 +2890,8 @@ QVariant Chord::propertyDefault(Pid propertyId) const
             case Pid::NO_STEM:        return false;
             case Pid::SMALL:          return false;
             case Pid::STEM_DIRECTION: return QVariant::fromValue<Direction>(Direction::AUTO);
+            case Pid::HOOK_REVERSED:  return false;
+
             default:
                   return ChordRest::propertyDefault(propertyId);
             }
@@ -2899,6 +2913,10 @@ bool Chord::setProperty(Pid propertyId, const QVariant& v)
             case Pid::STEM_DIRECTION:
                   setStemDirection(v.value<Direction>());
                   break;
+            case Pid::HOOK_REVERSED:
+                  setHookReversed(v.toBool());
+                  break;
+
             default:
                   return ChordRest::setProperty(propertyId, v);
             }

--- a/libmscore/chord.h
+++ b/libmscore/chord.h
@@ -58,6 +58,7 @@ class Chord final : public ChordRest {
 
       Stem*               _stem;
       Hook*               _hook;
+      bool                _hookIsReversed;
       StemSlash*          _stemSlash;    // for acciacatura
 
       Arpeggio*           _arpeggio;
@@ -233,6 +234,9 @@ class Chord final : public ChordRest {
       QString accessibleExtraInfo() const override;
 
       Note* firstGraceOrNote();
+
+      bool hookIsReversed () const  { return hook() ? _hookIsReversed : false; }
+      void setHookReversed(bool v)  { _hookIsReversed = v; }
 
       Shape shape() const override;
       };

--- a/libmscore/element.cpp
+++ b/libmscore/element.cpp
@@ -1804,6 +1804,11 @@ void Element::undoSetVisible(bool v)
 //   drawSymbol
 //---------------------------------------------------------
 
+void Element::drawSymbolReversed(SymId id, QPainter* p, const QPointF& o, qreal scale) const
+      {
+      score()->scoreFont()->drawReversed(id, p, magS() * scale, o);
+      }
+
 void Element::drawSymbol(SymId id, QPainter* p, const QPointF& o, qreal scale) const
       {
       score()->scoreFont()->draw(id, p, magS() * scale, o);

--- a/libmscore/element.h
+++ b/libmscore/element.h
@@ -477,6 +477,7 @@ class Element : public ScoreElement {
       bool custom(Pid) const;
       virtual bool isUserModified() const;
 
+      void drawSymbolReversed(SymId id, QPainter* p, const QPointF& o = QPointF(), qreal scale = 1.0) const;
       void drawSymbol(SymId id, QPainter* p, const QPointF& o = QPointF(), qreal scale = 1.0) const;
       void drawSymbol(SymId id, QPainter* p, const QPointF& o, int n) const;
       void drawSymbols(const std::vector<SymId>&, QPainter* p, const QPointF& o = QPointF(), qreal scale = 1.0) const;

--- a/libmscore/hook.cpp
+++ b/libmscore/hook.cpp
@@ -80,7 +80,15 @@ void Hook::draw(QPainter* painter) const
             return;
 
       painter->setPen(curColor());
-      drawSymbol(_sym, painter);
+
+      if (chord()->hookIsReversed()) {
+            qreal scale = 1.0;
+            qreal dx = chord()->hook()->width() + (1.5 * chord()->stem()->lineWidthMag());
+            QPointF offset = QPointF(-dx, 0.0);
+            drawSymbolReversed(_sym, painter, offset, scale);
+            }
+      else drawSymbol(_sym, painter);
+
       }
 
 }

--- a/libmscore/keysig.cpp
+++ b/libmscore/keysig.cpp
@@ -159,7 +159,7 @@ void KeySig::layout()
       if (measure() && measure()->system() && measure()->isFirstInSystem()
           && prevMeasure && prevMeasure->findSegment(SegmentType::KeySigAnnounce, tick())
           && !segment()->isKeySigAnnounceType())
-            naturalsOn = false;
+            naturalsOn = (keySigEvent().key() == Key::C);
       if (track() == -1)
             naturalsOn = false;
 

--- a/libmscore/property.cpp
+++ b/libmscore/property.cpp
@@ -78,6 +78,7 @@ static constexpr PropertyMetaData propertyList[] = {
       { Pid::DIRECTION,               false, "direction",             P_TYPE::DIRECTION,           DUMMY_QT_TRANSLATE_NOOP("propertyName", "direction")        },
       { Pid::STEM_DIRECTION,          false, "StemDirection",         P_TYPE::DIRECTION,           DUMMY_QT_TRANSLATE_NOOP("propertyName", "stem direction")   },
       { Pid::NO_STEM,                 false, "noStem",                P_TYPE::INT,                 DUMMY_QT_TRANSLATE_NOOP("propertyName", "no stem")          },
+      { Pid::HOOK_REVERSED,           false, "hookReverse",           P_TYPE::BOOL,                DUMMY_QT_TRANSLATE_NOOP("propertyName", "reverse hook")     },
       { Pid::SLUR_DIRECTION,          false, "up",                    P_TYPE::DIRECTION,           DUMMY_QT_TRANSLATE_NOOP("propertyName", "up")               },
       { Pid::LEADING_SPACE,           false, "leadingSpace",          P_TYPE::SPATIUM,             DUMMY_QT_TRANSLATE_NOOP("propertyName", "leading space")    },
       { Pid::DISTRIBUTE,              false, "distribute",            P_TYPE::BOOL,                DUMMY_QT_TRANSLATE_NOOP("propertyName", "distributed")      },

--- a/libmscore/property.h
+++ b/libmscore/property.h
@@ -85,6 +85,7 @@ enum class Pid {
       DIRECTION,
       STEM_DIRECTION,
       NO_STEM,
+      HOOK_REVERSED,
       SLUR_DIRECTION,
       LEADING_SPACE,
       DISTRIBUTE,

--- a/libmscore/stem.cpp
+++ b/libmscore/stem.cpp
@@ -415,7 +415,7 @@ QPointF Stem::hookPos() const
             p.ry() += accommodate * direction;
             }
 
-      qreal xoff = 0.5 * lineWidthMag();
+      qreal xoff = !chord()->hookIsReversed() ? 0.5 * lineWidthMag() : -chord()->hook()->width();
       p.rx() += xoff;
       return p;
       }

--- a/libmscore/sym.cpp
+++ b/libmscore/sym.cpp
@@ -11,6 +11,8 @@
 //=============================================================================
 
 #include <QDirIterator>
+#include <QPainter>
+#include <QString>
 
 #include "mscore.h"
 #include "score.h"
@@ -6401,6 +6403,15 @@ void ScoreFont::draw(SymId id, QPainter* painter, const QSizeF& mag, const QPoin
       {
       qreal worldScale = painter->worldTransform().m11();
       draw(id, painter, mag, pos, worldScale);
+      }
+
+void ScoreFont::drawReversed(SymId id, QPainter* painter, qreal mag, const QPointF& pos) const
+      {
+      qreal worldScale = painter->worldTransform().m11();
+      painter->save();
+         painter->scale(-1.0, +1.0);
+         draw(id, painter, QSizeF(mag, mag), pos, worldScale);
+      painter->restore();
       }
 
 void ScoreFont::draw(SymId id, QPainter* painter, qreal mag, const QPointF& pos, qreal worldScale) const

--- a/libmscore/sym.h
+++ b/libmscore/sym.h
@@ -3195,6 +3195,8 @@ class ScoreFont {
       QString toString(SymId) const;
       QPixmap sym2pixmap(SymId, qreal) { return QPixmap(); }      // TODOxxxx
 
+      void drawReversed
+               (SymId id,                  QPainter*, qreal mag,         const QPointF& pos) const;
       void draw(SymId id,                  QPainter*, const QSizeF& mag, const QPointF& pos, qreal scale) const;
       void draw(SymId id,                  QPainter*, qreal mag,         const QPointF& pos, qreal scale) const;
       void draw(SymId id,                  QPainter*, qreal mag,         const QPointF& pos) const;

--- a/mscore/inspector/inspectorNote.cpp
+++ b/mscore/inspector/inspectorNote.cpp
@@ -112,6 +112,7 @@ InspectorNote::InspectorNote(QWidget* parent)
             { Pid::SMALL,          1, c.isSmall,       c.resetSmall         },
             { Pid::NO_STEM,        1, c.stemless,      c.resetStemless      },
             { Pid::STEM_DIRECTION, 1, c.stemDirection, c.resetStemDirection },
+            { Pid::HOOK_REVERSED,  1, c.reverseHook,   c.resetReverseHook   },
 
             { Pid::LEADING_SPACE,  2, s.leadingSpace,  s.resetLeadingSpace  },
             };

--- a/mscore/inspector/inspector_chord.ui
+++ b/mscore/inspector/inspector_chord.ui
@@ -49,7 +49,6 @@
      </property>
      <property name="font">
       <font>
-       <weight>75</weight>
        <bold>true</bold>
       </font>
      </property>
@@ -76,66 +75,6 @@
       <property name="spacing">
        <number>3</number>
       </property>
-      <item row="3" column="1">
-       <widget class="QComboBox" name="stemDirection">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="accessibleName">
-         <string>Stem direction</string>
-        </property>
-        <item>
-         <property name="text">
-          <string>Auto</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Up</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Down</string>
-         </property>
-        </item>
-       </widget>
-      </item>
-      <item row="3" column="0">
-       <widget class="QLabel" name="label">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="text">
-         <string>Stem direction:</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-        </property>
-        <property name="buddy">
-         <cstring>stemDirection</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="2">
-       <widget class="Ms::ResetButton" name="resetStemless" native="true">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="accessibleName">
-         <string>Reset 'Stemless' value</string>
-        </property>
-       </widget>
-      </item>
       <item row="3" column="2">
        <widget class="Ms::ResetButton" name="resetStemDirection" native="true">
         <property name="sizePolicy">
@@ -148,6 +87,42 @@
          <string>Reset 'Stem direction' value</string>
         </property>
        </widget>
+      </item>
+      <item row="1" column="0" colspan="2">
+       <layout class="QHBoxLayout" name="horizontalLayout_2">
+        <item>
+         <widget class="QLabel" name="label_2">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>Offset:</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+          </property>
+          <property name="buddy">
+           <cstring>offset</cstring>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="Ms::OffsetSelect" name="offset" native="true">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="accessibleName">
+           <string>Offset</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
       </item>
       <item row="2" column="0" colspan="2">
        <layout class="QHBoxLayout" name="horizontalLayout">
@@ -205,6 +180,34 @@
         </item>
        </layout>
       </item>
+      <item row="3" column="1">
+       <widget class="QComboBox" name="stemDirection">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="accessibleName">
+         <string>Stem direction</string>
+        </property>
+        <item>
+         <property name="text">
+          <string>Auto</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Up</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Down</string>
+         </property>
+        </item>
+       </widget>
+      </item>
       <item row="1" column="2">
        <widget class="Ms::ResetButton" name="resetOffset" native="true">
         <property name="sizePolicy">
@@ -218,41 +221,47 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="0" colspan="2">
-       <layout class="QHBoxLayout" name="horizontalLayout_2">
-        <item>
-         <widget class="QLabel" name="label_2">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="text">
-           <string>Offset:</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-          </property>
-          <property name="buddy">
-           <cstring>offset</cstring>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="Ms::OffsetSelect" name="offset" native="true">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="accessibleName">
-           <string>Offset</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
+      <item row="2" column="2">
+       <widget class="Ms::ResetButton" name="resetStemless" native="true">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="accessibleName">
+         <string>Reset 'Stemless' value</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="label">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Stem direction:</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+        </property>
+        <property name="buddy">
+         <cstring>stemDirection</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0">
+       <widget class="QCheckBox" name="reverseHook">
+        <property name="text">
+         <string>Reversed hook</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="1">
+       <widget class="Ms::ResetButton" name="resetReverseHook" native="true"/>
       </item>
      </layout>
     </widget>


### PR DESCRIPTION
+ **Layout: Articulations layout closer to notehead** when style option is at 0.0sp (can always increase this to be further away, the point is to decrease its minima):
**This**:
![image](https://github.com/user-attachments/assets/b6deba0f-b462-40b3-861d-1d8da5fb5df5)
**Versus 3.6.2**:
![image](https://github.com/user-attachments/assets/5cdd3631-a288-4a99-b52f-02a9753ba71d)

+ **Key signature (Personal preference) will show courtesy naturals of C Major on first system** when applied at the beginning of a system (instead of showing only as a courtesy at the end of the previous system). The user can always _select + make invisible_ if the result is undesirable, whereas to get this result is not supported by 3.6/4.x at the moment
![image](https://github.com/user-attachments/assets/d40ee63e-dc2b-43bf-8a1a-0496da2d8684)

+ **Fix articulation receiving a slight stem-offset** when applied to a chord with existing mirrored intervals:
**The problem demonstrated (3.6.2):**

https://github.com/user-attachments/assets/0c76cd93-28da-4a96-9f54-d9b8e70b0ee8


+ **Feature:  Reversible hook flags** (Kind of a gimmicke, but why not)
![image](https://github.com/user-attachments/assets/9ee4bc56-c839-40f0-af3a-6c376e24cd9b)

