### PR TITLE
Command: Pitch Up/Down - transpose up/down (including harmony/keysigs) with range selection

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -4379,6 +4379,7 @@ void Score::cmdRemoveEmptyTrailingMeasures()
 
 void Score::cmdPitchUp()
       {
+      bool isRange = selection().isRange();
       Element* el = selection().element();
       if (el && el->isLyrics())
             cmdMoveLyrics(toLyrics(el), Direction::UP);
@@ -4386,6 +4387,10 @@ void Score::cmdPitchUp()
             el->undoChangeProperty(Pid::OFFSET, el->offset() + QPointF(0.0, -MScore::nudgeStep * el->spatium()), PropertyFlags::UNSTYLED);
       else if (el && el->isRest())
             cmdMoveRest(toRest(el), Direction::UP);
+      else if (isRange) {
+            int up = 1;
+            transposeSemitone(up);
+            }
       else
             upDown(true, UpDownMode::CHROMATIC);
       }
@@ -4396,6 +4401,7 @@ void Score::cmdPitchUp()
 
 void Score::cmdPitchDown()
       {
+      bool isRange = selection().isRange();
       Element* el = selection().element();
       if (el && el->isLyrics())
             cmdMoveLyrics(toLyrics(el), Direction::DOWN);
@@ -4403,6 +4409,10 @@ void Score::cmdPitchDown()
             el->undoChangeProperty(Pid::OFFSET, el->offset() + QPointF(0.0, MScore::nudgeStep * el->spatium()), PropertyFlags::UNSTYLED);
       else if (el && el->isRest())
             cmdMoveRest(toRest(el), Direction::DOWN);
+      else if (isRange) {
+            int down = -1;
+            transposeSemitone(down);
+            }
       else
             upDown(false, UpDownMode::CHROMATIC);
       }

--- a/libmscore/navigate.cpp
+++ b/libmscore/navigate.cpp
@@ -402,14 +402,18 @@ ChordRest* Score::upStaff(ChordRest* cr)
       for (int track = (cr->staffIdx() - 1) * VOICES; track >= 0; --track) {
             Element* el = nullptr;
             while (!el) {
-                  el = segment->element(track);
-                  if (el) {
-                        break;
-                        }
-                  segment = segment->prev();
-                  bool sameMeasure = (segment->measure() == cr->measure());
-                  if (!segment || !sameMeasure) {
-                        return nullptr;
+                  if (segment) {
+                        el = segment->element(track);
+                        if (el)
+                              break;
+
+                        segment = segment->prev();
+                        if (!segment)
+                              return nullptr;
+
+                        bool sameMeasure = (segment->measure() == cr->measure());
+                        if (!sameMeasure)
+                              return nullptr;
                         }
                   }
             if (!el)
@@ -419,7 +423,7 @@ ChordRest* Score::upStaff(ChordRest* cr)
             if (el->isChordRest())
                   return toChordRest(el);
             }
-      return 0;
+      return nullptr;
       }
 
 //---------------------------------------------------------
@@ -437,14 +441,18 @@ ChordRest* Score::downStaff(ChordRest* cr)
       for (int track = (cr->staffIdx() + 1) * VOICES; track < tracks; --track) {
             Element* el = nullptr;
             while (!el) {
-                  el = segment->element(track);
-                  if (el) {
-                        break;
-                        }
-                  segment = segment->prev();
-                  bool sameMeasure = (segment->measure() == cr->measure());
-                  if (!segment || !sameMeasure) {
-                        return nullptr;
+                  if (segment) {
+                        el = segment->element(track);
+                        if (el)
+                              break;
+
+                        segment = segment->prev();
+                        if (!segment)
+                              return nullptr;
+
+                        bool sameMeasure = (segment->measure() == cr->measure());
+                        if (!sameMeasure)
+                              return nullptr;
                         }
                   }
             if (el->isNote())
@@ -452,7 +460,7 @@ ChordRest* Score::downStaff(ChordRest* cr)
             if (el->isChordRest())
                   return toChordRest(el);
             }
-      return 0;
+      return nullptr;
       }
 
 //---------------------------------------------------------

--- a/libmscore/transpose.cpp
+++ b/libmscore/transpose.cpp
@@ -650,11 +650,20 @@ void Score::transposeSemitone(int step)
 
       const int interval = intervalListArray[keyType][step > 0 ? 0 : 1];
 
-      if (!transpose(TransposeMode::BY_INTERVAL, dir, Key::C, interval, true, true, false)) {
+      bool includeHarmony =
+            selectionFilter().isFiltered(SelectionFilterType::CHORD_SYMBOL);
+
+      bool includeKeySigs =
+            !noteEntryMode();
+
+      if (!transpose(TransposeMode::BY_INTERVAL, dir, Key::C, interval, includeKeySigs, includeHarmony, false)) {
             qDebug("Score::transposeSemitone: failed");
             // TODO: set error message
             }
-      else setSelectionChanged(true);
+      else {
+            setPlayNote(true); // For when selection is a single note, also playback that note
+            setSelectionChanged(true);
+            }
       }
 
 //---------------------------------------------------------
@@ -743,7 +752,9 @@ void Score::transposeDiatonicAlterations(TransposeDirection direction)
       // Transpose current selection diatonically (up/down) while keeping degree alterations
       // Note: Score::transpose() absolutely requires valid selection before invocation.
       if (!selection().isNone()) {
-            transpose(TransposeMode::DIATONICALLY, direction, Key::C, 1, true, true, true);
+            bool includeChordSymbols =
+                  selectionFilter().isFiltered(SelectionFilterType::CHORD_SYMBOL);
+            transpose(TransposeMode::DIATONICALLY, direction, Key::C, 1, true, includeChordSymbols, true);
             setPlayNote(true); // For when selection is a single note, also playback that note
             setSelectionChanged(true); // This will update the on-screen keyboard
             }

--- a/mscore/shortcut.cpp
+++ b/mscore/shortcut.cpp
@@ -3495,14 +3495,14 @@ Shortcut Shortcut::_sc[] = {
          },
       {
          MsWidget::SCORE_TAB,
-         STATE_NORMAL,
+         STATE_NORMAL | STATE_NOTE_ENTRY,
          "transpose-up",
          QT_TRANSLATE_NOOP("action","Transpose Up"),
          QT_TRANSLATE_NOOP("action","Transpose up")
          },
       {
          MsWidget::SCORE_TAB,
-         STATE_NORMAL,
+         STATE_NORMAL | STATE_NOTE_ENTRY,
          "transpose-down",
          QT_TRANSLATE_NOOP("action","Transpose Down"),
          QT_TRANSLATE_NOOP("action","Transpose down")


### PR DESCRIPTION
**Change of default behavior (personal preference):**

+ If a range selection exists, the chromatic and diatonic up/down commands will trigger a transposition rather than just changing the note pitches. That is, a Harmony text (if not missing in selection due to filtering) and a Key Signature will shift along with the change. 

This might not be desirable, so having a range selection while in Note Entry Mode will omit Key-Signature transposition, and since Note Entry generally doesn't have Harmony texts selected, they also will not be transposed.


1) Regular functioning as usual if Range Selection exists within Note Entry (unless cycling occurred to include selecting Harmony texts)

2) New transpositional behavior if a range selection exists. 

The benefit is obviously to not require shortcut definitions for chromatic/diatonic transpositions, but rather let the same shortcut for chromatic or diatonic pitch shifting also serve for transpositioning.


P.S. Keep Degree Alterations diatonic pitch up/down commands were previously transposing harmony texts already sort of "accidentally", but this change will make it so that no transposition occurs when basic Note Entry Mode + Range

+ Also includes a fix commit of a potential crash "slipping through the cracks". One of the weird things about MS is on occasion having a null prev/next segment of a given segment when it shouldn't be, often associated with having changed a key/time signature and not having a full score relayout (or so it seems... something to try to fix more substantially)

To be observed: Diatonic pitch up/down (keeping degree alterations) with a range-selection _does not_ touch key signatures, but it _does_ transpose a Harmony text, no matter if in note entry or not. Kind of hacky because it's slightly "on purpose" as a personal deal, so it is what it is for now 