### PR TITLE
Toolbar: Advanced Options Drop-down

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -5358,6 +5358,9 @@ bool Score::cmdToggleOptions(const QString& cmd)
             checked = !checked; // inverted: user-interaction versus internals
             updateScore = true;
             }
+      else if (cmd.endsWith("honor-en-passant-visibility")) {
+            preferences.setPreference(PREF_SCORE_PLAYBACK_HONOR_EN_PASSANT_VISIBLE, checked=toggle(MScore::honorEnPassantVisibility));
+            }
       else if (cmd.endsWith("lasso-border")) {
             preferences.setPreference(PREF_UI_SCORE_LASSO_BORDER_ENABLED, checked=toggle(MScore::lassoBorderEnabled));
             }

--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -72,6 +72,7 @@
 #include "volta.h"
 #include "xml.h"
 #include "mscore/preferences.h"
+#include "mscore/shortcut.h"
 
 #include <QColor>
 #include <QColorDialog>
@@ -5322,6 +5323,126 @@ void Score::cmdOverrideColor(const char* what)
 
       else qDebug() << "Override color <%s> not implemented" << what;
       }
+
+//---------------------------------------------------------
+//   cmdToggleOptions
+//---------------------------------------------------------
+            
+bool Score::cmdToggleOptions(const QString& cmd)
+      {
+      auto toggle = [](bool& v) -> bool { return (v = !v); };
+      bool checked = false;
+      bool updateScore = false;
+
+      if (cmd.endsWith("only-all-color")) {
+            preferences.setPreference(PREF_UI_SCORE_OVERRIDE_ONLY_ALL_COLOR, checked=toggle(MScore::overrideOnlyAllColor));
+            updateScore = true;
+            }
+      else if (cmd.endsWith("colored-alteration-noteheads")) {
+            preferences.setPreference(PREF_UI_SCORE_OVERRIDE_NOTEHEAD_ALTERATION_COLOR_ENABLED, checked=toggle(MScore::noteheadsAlterationColorsEnabled));
+            updateScore = true;
+            }
+      else if (cmd.endsWith("current-system-on-top")) {
+            preferences.setPreference(PREF_UI_SCORE_CURRENT_SYS_ON_TOP, checked=toggle(MScore::currentSystemAlwaysTop));
+            }
+      else if (cmd.endsWith("fade-focus")) {
+            preferences.setPreference(PREF_UI_SCORE_FADE_FOCUS, checked=toggle(MScore::fadeFocus));
+            }
+      else if (cmd.endsWith("fingering-tightening-layout")) {
+            preferences.setPreference(PREF_UI_SCORE_FINGERING_OMIT_TIGHTENING, checked=toggle(MScore::fingeringTextOmitTightening));
+            checked = !checked; // inverted: user-interaction versus internals
+            updateScore = true;
+            }
+      else if (cmd.endsWith("fingering-voicing-layout")) {
+            preferences.setPreference(PREF_UI_SCORE_FINGERING_OMIT_VOICING, checked=toggle(MScore::fingeringTextOmitVoicing));
+            checked = !checked; // inverted: user-interaction versus internals
+            updateScore = true;
+            }
+      else if (cmd.endsWith("lasso-border")) {
+            preferences.setPreference(PREF_UI_SCORE_LASSO_BORDER_ENABLED, checked=toggle(MScore::lassoBorderEnabled));
+            }
+      else if (cmd.endsWith("move-cursor-by-beat")) {
+            preferences.setPreference(PREF_SCORE_PLAYBACK_CURSOR_MOVE_BY_BEAT, checked=toggle(MScore::cursorMoveByBeat));
+            }
+      else if (cmd.endsWith("move-cursor-by-measure")) {
+            preferences.setPreference(PREF_SCORE_PLAYBACK_CURSOR_ENTIRE_MEASURE, checked=toggle(MScore::cursorMoveByMeasure));
+            }
+      else if (cmd.endsWith("move-cursor-to-playback-position")) {
+            preferences.setPreference(PREF_SCORE_PLAYBACK_SELECT_POSITION_ON_STOP, checked=toggle(MScore::selectionFollowsCursor));
+            if (checked) {
+                  MScore::cursorResetToStart = false;
+                  preferences.setPreference(PREF_SCORE_PLAYBACK_BRING_POSITION_TO_START, MScore::cursorResetToStart);
+                  Shortcut::getShortcut("toggle-options-move-playback-position-to-start")->checkAction(MScore::cursorResetToStart);
+                  }            
+            }
+      else if (cmd.endsWith("move-playback-position-to-start")) {
+            preferences.setPreference(PREF_SCORE_PLAYBACK_BRING_POSITION_TO_START, checked=toggle(MScore::cursorResetToStart));
+            if (checked) {
+                  MScore::selectionFollowsCursor = false;
+                  preferences.setPreference(PREF_SCORE_PLAYBACK_SELECT_POSITION_ON_STOP, MScore::selectionFollowsCursor);
+                  Shortcut::getShortcut("toggle-options-move-cursor-to-playback-position")->checkAction(MScore::selectionFollowsCursor);
+                  }            
+            }
+      else if (cmd.endsWith("mouse-hover")) {
+            preferences.setPreference(PREF_SCORE_HOVER_COLOR_ENABLE, checked=toggle(MScore::hoverColorEnabled));
+            }
+      else if (cmd.endsWith("noteheads-behind-staff")) {
+            preferences.setPreference(PREF_UI_SCORE_NOTEHEADS_BEHIND_STAFF_LINES, checked=toggle(MScore::noteheadsBehindStaff));
+            updateScore = true;
+            }
+      else if (cmd.endsWith("noteheads-behind-ledger")) {
+            preferences.setPreference(PREF_UI_SCORE_NOTEHEADS_BEHIND_LEDGER_LINES, checked=toggle(MScore::noteheadsBehindLedger));
+            updateScore = true;
+            }
+      else if (cmd.endsWith("octave-tendency")) {
+            preferences.setPreference(PREF_SCORE_NOTE_INPUT_OCTAVE_TENDENCY, checked=toggle(MScore::noteInputOctaveTendencyIsTopNote));
+            }
+      else if (cmd.endsWith("playback-highlight-notes")) {
+            preferences.setPreference(PREF_SCORE_PLAYBACK_HIGHLIGHT_NOTES, checked=toggle(MScore::highlightNotes));
+            }
+      else if (cmd.endsWith("playback-highlight-rests")) {
+            preferences.setPreference(PREF_SCORE_PLAYBACK_HIGHLIGHT_RESTS, checked=toggle(MScore::highlightRests));
+            }
+      else if (cmd.endsWith("playback-highlight-lyrics")) {
+            preferences.setPreference(PREF_SCORE_PLAYBACK_HIGHLIGHT_LYRICS, checked=toggle(MScore::highlightLyrics));
+            }
+      else if (cmd.endsWith("playback-highlight-more")) {
+            preferences.setPreference(PREF_SCORE_PLAYBACK_HIGHLIGHT_MORE, checked=toggle(MScore::highlightMore));
+            }
+      else if (cmd.endsWith("reset-entry-NewSystemOrCourtesy")) {
+            preferences.setPreference(PREF_SCORE_NOTE_INPUT_RESET_PITCH_AT_SYSTEM, checked=toggle(MScore::resetNoteEntryAtSystemOrCourtesy));
+            }
+      else if (cmd.endsWith("retain-augmentation-rhythmMode")) {
+            preferences.setPreference(PREF_SCORE_NOTE_INPUT_RETAIN_AUG_RHYTHM_MODE, checked=toggle(MScore::retainAugmentationInRhythmEntry));
+            }
+      else if (cmd.endsWith("single-note-selection-color")) {
+            preferences.setPreference(PREF_SCORE_SINGLE_SELECTION_COLOR_ENABLED, checked=toggle(MScore::singleNoteSelectionColorEnabled));
+            }
+      else if (cmd.endsWith("ties-consider-ledgers")) {
+            preferences.setPreference(PREF_UI_SCORE_TIES_ADJUST_FOR_LEDGER_LINES, checked=toggle(MScore::tiesAdjustForLedgerLines));
+            updateScore = true;
+            }
+      else if (cmd.endsWith("ties-uniformity")) {
+            preferences.setPreference(PREF_UI_SCORE_TIES_UNIFORM_ADJUSTMENTS, checked=toggle(MScore::uniformTieAdjustments));
+            updateScore = true;
+            }
+      else if (cmd.endsWith("upward-fifth-entry")) {
+            preferences.setPreference(PREF_SCORE_NOTE_INPUT_FIFTH_IS_UPWARD, checked=toggle(MScore::noteInputOctaveUpwardFifth));
+            }
+      else if (cmd.endsWith("vertical-note-drag-allowed")) {
+            preferences.setPreference(PREF_UI_SCORE_DISABLE_NOTE_DRAG_VERTICAL, checked=toggle(MScore::disableVerticalMouseDragOfNotes));
+            }
+
+      else qDebug() << "Toggle option <%s> not implemented" << cmd;
+
+      // Update checkbox in menu
+      if (!cmd.endsWith("null")) {
+            Shortcut::getShortcut(cmd.toStdString().c_str())->checkAction(checked);
+            }
+
+      return updateScore;
+      }
+
 
 //---------------------------------------------------------
 //   cmdToggleMouseEntry

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -798,6 +798,7 @@ class Score : public QObject, public ScoreElement {
       void changeVoice(int);
       void cmdToggleMouseEntry(void);
       void cmdOverrideColor(const char*);
+      bool cmdToggleOptions(const QString&);
 
       void colorItem(Element*);
       QList<Part*>& parts()                { return _parts; }

--- a/mscore/data/icons/options.svg
+++ b/mscore/data/icons/options.svg
@@ -13,9 +13,23 @@
    inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:svg="http://www.w3.org/2000/svg"><defs
-   id="defs17" /><sodipodi:namedview
+   id="defs17"><linearGradient
+     id="linearGradient2939"
+     inkscape:swatch="solid"><stop
+       style="stop-color:#000080;stop-opacity:1;"
+       offset="0"
+       id="stop2937" /></linearGradient><linearGradient
+     inkscape:collect="always"
+     xlink:href="#linearGradient2939"
+     id="linearGradient2941"
+     x1="1.2446464"
+     y1="7.5532614"
+     x2="35.499727"
+     y2="7.5532614"
+     gradientUnits="userSpaceOnUse" /></defs><sodipodi:namedview
    id="namedview15"
    pagecolor="#ffffff"
    bordercolor="#666666"
@@ -25,10 +39,10 @@
    inkscape:pagecheckerboard="0"
    showgrid="false"
    inkscape:zoom="16.270833"
-   inkscape:cx="13.090909"
-   inkscape:cy="-0.092189501"
-   inkscape:window-width="1920"
-   inkscape:window-height="1023"
+   inkscape:cx="-19.451985"
+   inkscape:cy="1.5672215"
+   inkscape:window-width="2560"
+   inkscape:window-height="1382"
    inkscape:window-x="0"
    inkscape:window-y="29"
    inkscape:window-maximized="1"
@@ -41,7 +55,7 @@
 </style>
 <g
    id="g6"
-   transform="translate(-0.44845539,2.8396861)">
+   transform="matrix(1.0921259,0,0,1.166238,0.11047806,-0.00121939)">
 	<path
    class="st0"
    d="M 10.5,3 V 3 3"
@@ -52,13 +66,13 @@
 
 <text
    xml:space="preserve"
-   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.97118px;line-height:1.25;font-family:'Arial Black';-inkscape-font-specification:'Arial Black, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#e6e6e6;fill-opacity:1;stroke:none;stroke-width:1.99498"
-   x="-0.062871687"
-   y="10.758315"
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.49764px;line-height:1.25;font-family:'Arial Black';-inkscape-font-specification:'Arial Black, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#3b3f45;fill-opacity:1;stroke:none;stroke-width:2.14565"
+   x="0.81259894"
+   y="10.645145"
    id="text1361"
-   transform="scale(0.67948756,1.4716973)"><tspan
+   transform="scale(0.68997883,1.4493198)"><tspan
      sodipodi:role="line"
      id="tspan1359"
-     x="-0.062871687"
-     y="10.758315"
-     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.97118px;font-family:'Arial Black';-inkscape-font-specification:'Arial Black, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#e6e6e6;fill-opacity:1;stroke-width:1.99498">OPTIONS</tspan></text></svg>
+     x="0.81259894"
+     y="10.645145"
+     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.49764px;font-family:'Arial Black';-inkscape-font-specification:'Arial Black, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#3b3f45;fill-opacity:1;stroke-width:2.14565">OPTIONS</tspan></text></svg>

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -338,6 +338,7 @@ const std::list<const char*> MuseScore::_allToggleOptionsMenuEntries {
             "toggle-options-playback-highlight-rests",
             "toggle-options-playback-highlight-lyrics",
             "toggle-options-playback-highlight-more",
+            "toggle-options-honor-en-passant-visibility",
 
             "toggle-options-move-cursor-by-beat",
             "toggle-options-move-cursor-by-measure",
@@ -858,6 +859,8 @@ void MuseScore::populateToggleOptionsMenu()
                         pref = MScore::fingeringTextOmitTightening;
                   else if (0==strcmp(option, "fingering-voicing-layout"))
                         pref = MScore::fingeringTextOmitVoicing;
+                  else if (0==strcmp(option, "honor-en-passant-visibility"))
+                        pref = MScore::honorEnPassantVisibility;
                   else if (0==strcmp(option, "lasso-border"))
                         pref = MScore::lassoBorderEnabled;
                   else if (0==strcmp(option, "move-cursor-by-beat"))

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -323,6 +323,44 @@ const std::list<const char*> MuseScore::_allColorControlMenuEntries {
             "color-override-cursor",
             };
 
+const std::list<const char*> MuseScore::_allToggleOptionsMenuEntries {
+            "toggle-options-only-all-color",
+            "toggle-options-single-note-selection-color",
+
+            "separator-Note Entry",
+            "toggle-options-octave-tendency",
+            "toggle-options-upward-fifth-entry",
+            "toggle-options-retain-augmentation-rhythmMode",
+            "toggle-options-reset-entry-NewSystemOrCourtesy",
+
+            "separator-Playback",
+            "toggle-options-playback-highlight-notes",
+            "toggle-options-playback-highlight-rests",
+            "toggle-options-playback-highlight-lyrics",
+            "toggle-options-playback-highlight-more",
+
+            "toggle-options-move-cursor-by-beat",
+            "toggle-options-move-cursor-by-measure",
+            "toggle-options-move-cursor-to-playback-position",
+            "toggle-options-move-playback-position-to-start",
+
+            "separator-Layout",
+            "toggle-options-noteheads-behind-staff", 
+            "toggle-options-noteheads-behind-ledger",
+            "toggle-options-ties-consider-ledgers",
+            "toggle-options-ties-uniformity",
+            "toggle-options-fingering-voicing-layout",
+            "toggle-options-fingering-tightening-layout",
+            "toggle-options-colored-alteration-noteheads",
+            
+            "separator-Interaction",
+            "toggle-options-mouse-hover",
+            "toggle-options-vertical-note-drag-allowed",
+            "toggle-options-lasso-border",
+            "toggle-options-fade-focus",
+            "toggle-options-current-system-on-top",
+            };
+
 const std::list<const char*> MuseScore::_allFileOperationEntries {
             "file-new",
             "file-open",
@@ -780,6 +818,102 @@ void MuseScore::populateColorControlMenu()
                              true);
       w->setObjectName("color-options");
       colorTools->addWidget(w);
+      }
+
+//---------------------------------------------------------
+//   populateToggleOptionsMenu
+//---------------------------------------------------------
+
+void MuseScore::populateToggleOptionsMenu()
+      {
+      toggleTools->clear();
+      QActionGroup* toggleOptionMethods = new QActionGroup(toggleTools);
+      QWidget* w;
+      for (const auto s : _toggleOptionsMenuEntries) {
+            if (!(strcmp(s, "toggle-options-null") == 0)) {
+                  if (strncmp ("separator", s, 9) == 0) {
+                        QAction* separator = new QAction;
+                        QString separatorTitle(&s[10]);
+                              separator->setSeparator(true);
+                              separator->setParent(toggleOptionMethods);
+                              separator->setText(separatorTitle);
+                              toggleOptionMethods->addAction(separator);
+                        continue;
+                        }
+
+                  const char* option = &s[15]; // toggle-options-*
+                  auto action = getAction(s);
+                  bool pref = false;
+                  
+                  // Maintain these with cmdToggleOptions():                                    
+                  if (0==strcmp(option, "only-all-color"))
+                        pref = MScore::overrideOnlyAllColor;
+                  else if (0==strcmp(option, "colored-alteration-noteheads"))
+                        pref = MScore::noteheadsAlterationColorsEnabled;
+                  else if (0==strcmp(option, "current-system-on-top"))
+                        pref = MScore::currentSystemAlwaysTop;
+                  else if (0==strcmp(option, "fade-focus"))
+                        pref = MScore::fadeFocus;
+                  else if (0==strcmp(option, "fingering-tightening-layout"))
+                        pref = MScore::fingeringTextOmitTightening;
+                  else if (0==strcmp(option, "fingering-voicing-layout"))
+                        pref = MScore::fingeringTextOmitVoicing;
+                  else if (0==strcmp(option, "lasso-border"))
+                        pref = MScore::lassoBorderEnabled;
+                  else if (0==strcmp(option, "move-cursor-by-beat"))
+                        pref = MScore::cursorMoveByBeat;
+                  else if (0==strcmp(option, "move-cursor-by-measure"))
+                        pref = MScore::cursorMoveByMeasure;
+                  else if (0==strcmp(option, "move-cursor-to-playback-position"))
+                        pref = MScore::selectionFollowsCursor;
+                  else if (0==strcmp(option, "move-playback-position-to-start"))
+                        pref = MScore::cursorResetToStart;
+                  else if (0==strcmp(option, "mouse-hover"))
+                        pref = MScore::hoverColorEnabled;
+                  else if (0==strcmp(option, "noteheads-behind-staff"))
+                        pref = MScore::noteheadsBehindStaff;
+                  else if (0==strcmp(option, "noteheads-behind-ledger"))
+                        pref = MScore::noteheadsBehindLedger;
+                  else if (0==strcmp(option, "octave-tendency"))
+                        pref = MScore::noteInputOctaveTendencyIsTopNote;
+                  else if (0==strcmp(option, "playback-highlight-notes"))
+                        pref = MScore::highlightNotes;
+                  else if (0==strcmp(option, "playback-highlight-rests"))
+                        pref = MScore::highlightRests;
+                  else if (0==strcmp(option, "playback-highlight-lyrics"))
+                        pref = MScore::highlightLyrics;
+                  else if (0==strcmp(option, "playback-highlight-more"))
+                        pref = MScore::highlightMore;
+                  else if (0==strcmp(option, "reset-entry-NewSystemOrCourtesy"))
+                        pref = MScore::resetNoteEntryAtSystemOrCourtesy;
+                  else if (0==strcmp(option, "retain-augmentation-rhythmMode"))
+                        pref = MScore::retainAugmentationInRhythmEntry;
+                  else if (0==strcmp(option, "single-note-selection-color"))
+                        pref = MScore::singleNoteSelectionColorEnabled;
+                  else if (0==strcmp(option, "ties-consider-ledgers"))
+                        pref = MScore::tiesAdjustForLedgerLines;
+                  else if (0==strcmp(option, "ties-uniformity"))
+                        pref = MScore::uniformTieAdjustments;
+                  else if (0==strcmp(option, "upward-fifth-entry"))
+                        pref = MScore::noteInputOctaveUpwardFifth;
+                  else if (0==strcmp(option, "vertical-note-drag-allowed"))
+                        pref = MScore::disableVerticalMouseDragOfNotes;
+
+                  Shortcut::getShortcut(s)->checkAction(pref);
+                  toggleOptionMethods->addAction(action);
+                  }
+            }
+      connect(toggleOptionMethods, SIGNAL(triggered(QAction*)), this, SLOT(cmd(QAction*)));
+      auto dAct = getAction("toggle-options-null");
+      dAct->setCheckable(false);
+      dAct->setDisabled(true); // Allow the default action not to be within the drop-down list
+      w = new ToolButtonMenu(tr("Toggle Options"),
+                             dAct,
+                             toggleOptionMethods,
+                             this,
+                             false);
+      w->setObjectName("toggle-options");
+      toggleTools->addWidget(w);
       }
 
 //---------------------------------------------------------
@@ -1526,6 +1660,15 @@ MuseScore::MuseScore()
       populateColorControlMenu();
 
       //-------------------------------
+      //    Toggle Options Tool Bar
+      //-------------------------------
+
+      toggleTools = addToolBar("");
+      toggleTools->setObjectName("toggle-tools");
+
+      populateToggleOptionsMenu();
+
+      //-------------------------------
       //    Workspaces Tool Bar
       //-------------------------------
 
@@ -1743,6 +1886,12 @@ MuseScore::MuseScore()
       a->setCheckable(true);
       a->setChecked(colorTools->isVisible());
       connect(colorTools, SIGNAL(visibilityChanged(bool)), a, SLOT(setChecked(bool)));
+      menuToolbars->addAction(a);
+
+      a = getAction("toggle-optionscontrol");
+      a->setCheckable(true);
+      a->setChecked(toggleTools->isVisible());
+      connect(toggleTools, SIGNAL(visibilityChanged(bool)), a, SLOT(setChecked(bool)));
       menuToolbars->addAction(a);
 
       a = getAction("toggle-workspaces-toolbar");
@@ -2319,6 +2468,7 @@ void MuseScore::retranslate()
       fotoTools->setWindowTitle(tr("Image Capture"));
       entryTools->setWindowTitle(tr("Note Input"));
       colorTools->setWindowTitle(tr("Color Control"));
+      toggleTools->setWindowTitle(tr("Toggle Options"));
       workspacesTools->setWindowTitle(tr("Workspaces"));
 
       // keep translatable (con)texts in sync with those from zoombox.cpp
@@ -4664,6 +4814,7 @@ void MuseScore::changeState(ScoreState val)
       zoomBox->setEnabled(enable);
       entryTools->setEnabled(enable);
       colorTools->setEnabled(enable);
+      toggleTools->setEnabled(enable);
 
       if (_sstate == STATE_FOTO)
             updateInspector();
@@ -5023,6 +5174,9 @@ void MuseScore::readSettings()
 
       a = getAction("toggle-colorcontrol");
       a->setChecked(!colorTools->isHidden());
+
+      a = getAction("toggle-optionscontrol");
+      a->setChecked(!toggleTools->isHidden());
       }
 
 //---------------------------------------------------------
@@ -6685,6 +6839,8 @@ void MuseScore::cmd(QAction* a, const QString& cmd)
             entryTools->setVisible(!entryTools->isVisible());
       else if (cmd == "toggle-colorcontrol")
             colorTools->setVisible(!colorTools->isVisible());
+      else if (cmd == "toggle-optionscontrol")
+            toggleTools->setVisible(!toggleTools->isVisible());
       else if (cmd == "toggle-workspaces-toolbar")
             workspacesTools->setVisible(!workspacesTools->isVisible());
       else if (cmd == "create-new-workspace") {
@@ -6921,6 +7077,15 @@ void MuseScore::cmd(QAction* a, const QString& cmd)
             cv->score()->cmdOverrideColor(token);
             genIcons();
             Shortcut::refreshIcons();
+            }
+      else if (cmd.startsWith("toggle-options-")) {
+            bool updateScore = cv->score()->cmdToggleOptions(cmd);
+            genIcons();
+            Shortcut::refreshIcons();
+            if (cs && updateScore) {
+                  cs->setLayoutAll();
+                  cs->update();
+                  }
             }
 #ifndef NDEBUG
       else if (cmd == "no-horizontal-stretch") {

--- a/mscore/musescore.h
+++ b/mscore/musescore.h
@@ -217,6 +217,9 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
       static const std::list<const char*> _allColorControlMenuEntries;
       std::list<const char*> _colorControlMenuEntries { _allColorControlMenuEntries };
 
+      static const std::list<const char*> _allToggleOptionsMenuEntries;
+      std::list<const char*> _toggleOptionsMenuEntries { _allToggleOptionsMenuEntries };
+
       static const std::list<const char*> _allFileOperationEntries;
       std::list<const char*> _fileOperationEntries { _allFileOperationEntries };
 
@@ -261,6 +264,7 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
       QToolBar* transportTools;
       QToolBar* entryTools;
       QToolBar* colorTools;
+      QToolBar* toggleTools;
       QToolBar* workspacesTools;
       TextTools* _textTools                { 0 };
       PianoTools* _pianoTools              { 0 };
@@ -936,6 +940,11 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
       std::list<const char*>* colorControlMenuEntries()                 { return &_colorControlMenuEntries; }
       void setColorControlMenuEntries(std::list<const char*> l)         { _colorControlMenuEntries = l; }
       void populateColorControlMenu();
+
+      static const std::list<const char*>& allToggleOptionsMenuEntries() { return _allToggleOptionsMenuEntries; }
+      std::list<const char*>* toggleOptionsMenuEntries()                 { return &_toggleOptionsMenuEntries; }
+      void setToggleOptionsMenuEntries(std::list<const char*> l)         { _toggleOptionsMenuEntries = l; }
+      void populateToggleOptionsMenu();
 
       static const std::list<const char*>& allFileOperationEntries() { return _allFileOperationEntries; }
       std::list<const char*>* fileOperationEntries()                 { return &_fileOperationEntries; }

--- a/mscore/shortcut.cpp
+++ b/mscore/shortcut.cpp
@@ -2812,6 +2812,17 @@ Shortcut Shortcut::_sc[] = {
       {
          MsWidget::MAIN_WINDOW,
          STATE_HIDDEN | STATE_NORMAL | STATE_NOTE_ENTRY,
+         "toggle-options-honor-en-passant-visibility",
+         QT_TRANSLATE_NOOP("action","Honor En Passant Option of Text Line (Visibility/Highlight)"),
+         QT_TRANSLATE_NOOP("action","Honor En Passant Option of Text Line (Visibility/Highlight)"),
+         0,
+         Icons::checkmark_ICON,
+         Qt::ApplicationShortcut,
+         ShortcutFlags::A_CHECKABLE
+         },
+      {
+         MsWidget::MAIN_WINDOW,
+         STATE_HIDDEN | STATE_NORMAL | STATE_NOTE_ENTRY,
          "toggle-options-null",
          QT_TRANSLATE_NOOP("action","Options"),
          QT_TRANSLATE_NOOP("action","Options"),

--- a/mscore/shortcut.cpp
+++ b/mscore/shortcut.cpp
@@ -2521,6 +2521,306 @@ Shortcut Shortcut::_sc[] = {
          ShortcutFlags::A_CHECKABLE
          },
 // End Color Options
+
+// TOGGLE-OPTIONS
+      {
+         MsWidget::MAIN_WINDOW,
+         STATE_HIDDEN | STATE_NORMAL | STATE_NOTE_ENTRY,
+         "toggle-options-only-all-color",
+         QT_TRANSLATE_NOOP("action","Use Override All Color for all elements"),
+         QT_TRANSLATE_NOOP("action","Use Override All Color for all elements"),
+         0,
+         Icons::checkmark_ICON,
+         Qt::ApplicationShortcut,
+         ShortcutFlags::A_CHECKABLE
+         },
+      {
+         MsWidget::MAIN_WINDOW,
+         STATE_HIDDEN | STATE_NORMAL | STATE_NOTE_ENTRY,
+         "toggle-options-single-note-selection-color",
+         QT_TRANSLATE_NOOP("action","Selection: One color for all (See Color Options)"),
+         QT_TRANSLATE_NOOP("action","Selection: One color for all (See Color Options)"),
+         0,
+         Icons::checkmark_ICON,
+         Qt::ApplicationShortcut,
+         ShortcutFlags::A_CHECKABLE
+         },
+      {
+         MsWidget::MAIN_WINDOW,
+         STATE_HIDDEN | STATE_NORMAL | STATE_NOTE_ENTRY,
+         "toggle-options-vertical-note-drag-allowed",
+         QT_TRANSLATE_NOOP("action","Mouse: Disable dragging of note pitches"),
+         QT_TRANSLATE_NOOP("action","Mouse: Disable dragging of note pitches"),
+         0,
+         Icons::checkmark_ICON,
+         Qt::ApplicationShortcut,
+         ShortcutFlags::A_CHECKABLE
+         },
+      {
+         MsWidget::MAIN_WINDOW,
+         STATE_HIDDEN | STATE_NORMAL | STATE_NOTE_ENTRY,
+         "toggle-options-octave-tendency",
+         QT_TRANSLATE_NOOP("action","Octave tendency is previous top-note"),
+         QT_TRANSLATE_NOOP("action","Octave tendency is previous top-note"),
+         0,
+         Icons::checkmark_ICON,
+         Qt::ApplicationShortcut,
+         ShortcutFlags::A_CHECKABLE
+         },
+      {
+         MsWidget::MAIN_WINDOW,
+         STATE_HIDDEN | STATE_NORMAL | STATE_NOTE_ENTRY,
+         "toggle-options-upward-fifth-entry",
+         QT_TRANSLATE_NOOP("action","Include [fifth] in upward direction"),
+         QT_TRANSLATE_NOOP("action","Include [fifth] in upward direction"),
+         0,
+         Icons::checkmark_ICON,
+         Qt::ApplicationShortcut,
+         ShortcutFlags::A_CHECKABLE
+         },
+      {
+         MsWidget::MAIN_WINDOW,
+         STATE_HIDDEN | STATE_NORMAL | STATE_NOTE_ENTRY,
+         "toggle-options-colored-alteration-noteheads",
+         QT_TRANSLATE_NOOP("action","Noteheads: Enable coloring of ♯/♭ pitches (See Color Options)"),
+         QT_TRANSLATE_NOOP("action","Noteheads: Enable coloring of ♯/♭ pitches (See Color Options)"),
+         0,
+         Icons::checkmark_ICON,
+         Qt::ApplicationShortcut,
+         ShortcutFlags::A_CHECKABLE
+         },
+      {
+         MsWidget::MAIN_WINDOW,
+         STATE_HIDDEN | STATE_NORMAL | STATE_NOTE_ENTRY,
+         "toggle-options-retain-augmentation-rhythmMode",
+         QT_TRANSLATE_NOOP("action","Augmentation stays toggled (Rhythm Duration Mode)"),
+         QT_TRANSLATE_NOOP("action","Augmentation stays toggled (Rhythm Duration Mode)"),
+         0,
+         Icons::checkmark_ICON,
+         Qt::ApplicationShortcut,
+         ShortcutFlags::A_CHECKABLE
+         },
+      {
+         MsWidget::MAIN_WINDOW,
+         STATE_HIDDEN | STATE_NORMAL | STATE_NOTE_ENTRY,
+         "toggle-options-reset-entry-NewSystemOrCourtesy",
+         QT_TRANSLATE_NOOP("action","Use default octave at New System/Courtesy Clef"),
+         QT_TRANSLATE_NOOP("action","Use default octave at New System/Courtesy Clef"),
+         0,
+         Icons::checkmark_ICON,
+         Qt::ApplicationShortcut,
+         ShortcutFlags::A_CHECKABLE
+         },
+      {
+         MsWidget::MAIN_WINDOW,
+         STATE_HIDDEN | STATE_NORMAL | STATE_NOTE_ENTRY,
+         "toggle-options-playback-highlight-notes",
+         QT_TRANSLATE_NOOP("action","Highlight Notes"),
+         QT_TRANSLATE_NOOP("action","Highlight Notes"),
+         0,
+         Icons::checkmark_ICON,
+         Qt::ApplicationShortcut,
+         ShortcutFlags::A_CHECKABLE
+         },
+      {
+         MsWidget::MAIN_WINDOW,
+         STATE_HIDDEN | STATE_NORMAL | STATE_NOTE_ENTRY,
+         "toggle-options-playback-highlight-rests",
+         QT_TRANSLATE_NOOP("action","Highlight Rests"),
+         QT_TRANSLATE_NOOP("action","Highlight Rests"),
+         0,
+         Icons::checkmark_ICON,
+         Qt::ApplicationShortcut,
+         ShortcutFlags::A_CHECKABLE
+         },
+      {
+         MsWidget::MAIN_WINDOW,
+         STATE_HIDDEN | STATE_NORMAL | STATE_NOTE_ENTRY,
+         "toggle-options-playback-highlight-lyrics",
+         QT_TRANSLATE_NOOP("action","Highlight lyrics"),
+         QT_TRANSLATE_NOOP("action","Highlight lyrics"),
+         0,
+         Icons::checkmark_ICON,
+         Qt::ApplicationShortcut,
+         ShortcutFlags::A_CHECKABLE
+         },
+      {
+         MsWidget::MAIN_WINDOW,
+         STATE_HIDDEN | STATE_NORMAL | STATE_NOTE_ENTRY,
+         "toggle-options-playback-highlight-more",
+         QT_TRANSLATE_NOOP("action","Highlight More Elements"),
+         QT_TRANSLATE_NOOP("action","Highlight More Elements"),
+         0,
+         Icons::checkmark_ICON,
+         Qt::ApplicationShortcut,
+         ShortcutFlags::A_CHECKABLE
+         },
+      {
+         MsWidget::MAIN_WINDOW,
+         STATE_HIDDEN | STATE_NORMAL | STATE_NOTE_ENTRY,
+         "toggle-options-move-cursor-by-beat",
+         QT_TRANSLATE_NOOP("action","Move Cursor by Beat"),
+         QT_TRANSLATE_NOOP("action","Move Cursor by Beat"),
+         0,
+         Icons::checkmark_ICON,
+         Qt::ApplicationShortcut,
+         ShortcutFlags::A_CHECKABLE
+         },
+      {
+         MsWidget::MAIN_WINDOW,
+         STATE_HIDDEN | STATE_NORMAL | STATE_NOTE_ENTRY,
+         "toggle-options-move-cursor-by-measure",
+         QT_TRANSLATE_NOOP("action","Move Cursor by Measure"),
+         QT_TRANSLATE_NOOP("action","Move Cursor by Measure"),
+         0,
+         Icons::checkmark_ICON,
+         Qt::ApplicationShortcut,
+         ShortcutFlags::A_CHECKABLE
+         },
+      {
+         MsWidget::MAIN_WINDOW,
+         STATE_HIDDEN | STATE_NORMAL | STATE_NOTE_ENTRY,
+         "toggle-options-noteheads-behind-staff",
+         QT_TRANSLATE_NOOP("action","Noteheads: Draw Behind Staff Lines"),
+         QT_TRANSLATE_NOOP("action","Noteheads: Draw Behind Staff Lines"),
+         0,
+         Icons::checkmark_ICON,
+         Qt::ApplicationShortcut,
+         ShortcutFlags::A_CHECKABLE
+         },
+      {
+         MsWidget::MAIN_WINDOW,
+         STATE_HIDDEN | STATE_NORMAL | STATE_NOTE_ENTRY,
+         "toggle-options-noteheads-behind-ledger",
+         QT_TRANSLATE_NOOP("action","Noteheads: Draw Behind Ledger Lines"),
+         QT_TRANSLATE_NOOP("action","Noteheads: Draw Behind Ledger Lines"),
+         0,
+         Icons::checkmark_ICON,
+         Qt::ApplicationShortcut,
+         ShortcutFlags::A_CHECKABLE
+         },
+      {
+         MsWidget::MAIN_WINDOW,
+         STATE_HIDDEN | STATE_NORMAL | STATE_NOTE_ENTRY,
+         "toggle-options-ties-consider-ledgers",
+         QT_TRANSLATE_NOOP("action","Ties: Avoid Ledger Lines"),
+         QT_TRANSLATE_NOOP("action","Ties: Avoid Ledger Lines"),
+         0,
+         Icons::checkmark_ICON,
+         Qt::ApplicationShortcut,
+         ShortcutFlags::A_CHECKABLE
+         },
+      {
+         MsWidget::MAIN_WINDOW,
+         STATE_HIDDEN | STATE_NORMAL | STATE_NOTE_ENTRY,
+         "toggle-options-ties-uniformity",
+         QT_TRANSLATE_NOOP("action","Ties: Force Uniform Offsets"), // doesn't work for RHS accidentals...
+         QT_TRANSLATE_NOOP("action","Ties: Force Uniform Offsets"),
+         0,
+         Icons::checkmark_ICON,
+         Qt::ApplicationShortcut,
+         ShortcutFlags::A_CHECKABLE
+         },
+      {
+         MsWidget::MAIN_WINDOW,
+         STATE_HIDDEN | STATE_NORMAL | STATE_NOTE_ENTRY,
+         "toggle-options-lasso-border",
+         QT_TRANSLATE_NOOP("action","Lasso: Enable Border"),
+         QT_TRANSLATE_NOOP("action","Lasso: Enable Border"),
+         0,
+         Icons::checkmark_ICON,
+         Qt::ApplicationShortcut,
+         ShortcutFlags::A_CHECKABLE
+         },
+      {
+         MsWidget::MAIN_WINDOW,
+         STATE_HIDDEN | STATE_NORMAL | STATE_NOTE_ENTRY,
+         "toggle-options-fingering-tightening-layout",
+         QT_TRANSLATE_NOOP("action","Fingering: Tightening (Multi-Voicing)"),
+         QT_TRANSLATE_NOOP("action","Fingering: Tightening (Multi-Voicing)"),
+         0,
+         Icons::checkmark_ICON,
+         Qt::ApplicationShortcut,
+         ShortcutFlags::A_CHECKABLE
+         },
+      {
+         MsWidget::MAIN_WINDOW,
+         STATE_HIDDEN | STATE_NORMAL | STATE_NOTE_ENTRY,
+         "toggle-options-fingering-voicing-layout",
+         QT_TRANSLATE_NOOP("action","Fingering: Multi-Voicing"),
+         QT_TRANSLATE_NOOP("action","Fingering: Multi-Voicing"),
+         0,
+         Icons::checkmark_ICON,
+         Qt::ApplicationShortcut,
+         ShortcutFlags::A_CHECKABLE
+         },
+      {
+         MsWidget::MAIN_WINDOW,
+         STATE_HIDDEN | STATE_NORMAL | STATE_NOTE_ENTRY,
+         "toggle-options-mouse-hover",
+         QT_TRANSLATE_NOOP("action","Score View: Enable Mouse Hover Coloring"),
+         QT_TRANSLATE_NOOP("action","Score View: Enable Mouse Hover Coloring"),
+         0,
+         Icons::checkmark_ICON,
+         Qt::ApplicationShortcut,
+         ShortcutFlags::A_CHECKABLE
+         },
+      {
+         MsWidget::MAIN_WINDOW,
+         STATE_HIDDEN | STATE_NORMAL | STATE_NOTE_ENTRY,
+         "toggle-options-fade-focus",
+         QT_TRANSLATE_NOOP("action","Score View: Fade Out When Not Focused"),
+         QT_TRANSLATE_NOOP("action","Score View: Fade Out When Not Focused"),
+         0,
+         Icons::checkmark_ICON,
+         Qt::ApplicationShortcut,
+         ShortcutFlags::A_CHECKABLE
+         },
+      {
+         MsWidget::MAIN_WINDOW,
+         STATE_HIDDEN | STATE_NORMAL | STATE_NOTE_ENTRY,
+         "toggle-options-current-system-on-top",
+         QT_TRANSLATE_NOOP("action","Score View: Current System Is Always Top"),
+         QT_TRANSLATE_NOOP("action","Score View: Current System Is Always Top"),
+         0,
+         Icons::checkmark_ICON,
+         Qt::ApplicationShortcut,
+         ShortcutFlags::A_CHECKABLE
+         },
+      {
+         MsWidget::MAIN_WINDOW,
+         STATE_HIDDEN | STATE_NORMAL | STATE_NOTE_ENTRY,
+         "toggle-options-move-cursor-to-playback-position",
+         QT_TRANSLATE_NOOP("action","Move Score Selection to Playback Cursor on Stop"),
+         QT_TRANSLATE_NOOP("action","Move Score Selection to Playback Cursor on Stop"),
+         0,
+         Icons::checkmark_ICON,
+         Qt::ApplicationShortcut,
+         ShortcutFlags::A_CHECKABLE
+         },
+      {
+         MsWidget::MAIN_WINDOW,
+         STATE_HIDDEN | STATE_NORMAL | STATE_NOTE_ENTRY,
+         "toggle-options-move-playback-position-to-start",
+         QT_TRANSLATE_NOOP("action","Move Cursor to Original Score Position on Stop"),
+         QT_TRANSLATE_NOOP("action","Move Cursor to Original Score Position on Stop"),
+         0,
+         Icons::checkmark_ICON,
+         Qt::ApplicationShortcut,
+         ShortcutFlags::A_CHECKABLE
+         },
+      {
+         MsWidget::MAIN_WINDOW,
+         STATE_HIDDEN | STATE_NORMAL | STATE_NOTE_ENTRY,
+         "toggle-options-null",
+         QT_TRANSLATE_NOOP("action","Options"),
+         QT_TRANSLATE_NOOP("action","Options"),
+         0,
+         Icons::options_ICON,
+         Qt::ApplicationShortcut,
+         ShortcutFlags::NONE
+         },
+// TOGGLE-OPTIONS - END
       {
          MsWidget::SCORE_TAB,
          STATE_NORMAL | STATE_NOTE_ENTRY,
@@ -2743,6 +3043,13 @@ Shortcut Shortcut::_sc[] = {
          "toggle-colorcontrol",
          QT_TRANSLATE_NOOP("action","Color Control"),
          QT_TRANSLATE_NOOP("action","Toggle 'Color Control' toolbar")
+         },
+      {
+         MsWidget::MAIN_WINDOW,
+         STATE_NORMAL | STATE_NOTE_ENTRY | STATE_EDIT ,
+         "toggle-optionscontrol",
+         QT_TRANSLATE_NOOP("action","Toggle Control"),
+         QT_TRANSLATE_NOOP("action","Toggle 'Toggle Options' toolbar")
          },
       {
          MsWidget::MAIN_WINDOW,
@@ -5104,6 +5411,17 @@ void Shortcut::refreshIcon()
       if (QAction* a = this->action()){
             a->setIcon(*icons[int(this->icon())]);
             }
+      }
+
+//---------------------------------------------------------
+//   check/uncheck
+//---------------------------------------------------------
+
+void Shortcut::checkAction(bool check)
+      {
+      _icon = check ? Icons::checkmark_ICON : Icons::empty_ICON;
+      if (_action)
+            _action->setIcon(*icons[int(_icon)]);
       }
 
 //---------------------------------------------------------

--- a/mscore/shortcut.h
+++ b/mscore/shortcut.h
@@ -161,6 +161,7 @@ class Shortcut {
       void setStandardKey(QKeySequence::StandardKey k);
       void setKeys(const QList<QKeySequence>& ks);
       void setKeys(const Shortcut&);
+      void checkAction(bool check);
 
       bool compareKeys(const Shortcut&) const;
       QString keysToString() const;

--- a/mscore/toolbarEditor.cpp
+++ b/mscore/toolbarEditor.cpp
@@ -21,7 +21,8 @@ static const char* toolbars[] = {
       QT_TRANSLATE_NOOP("toolbar", "Note Input"),
       QT_TRANSLATE_NOOP("toolbar", "File Operations"),
       QT_TRANSLATE_NOOP("toolbar", "Playback Controls"),
-      QT_TRANSLATE_NOOP("toolbar", "Color Controls")
+      QT_TRANSLATE_NOOP("toolbar", "Color Controls"),
+      QT_TRANSLATE_NOOP("toolbar", "Toggle Options")
       };
 
 //---------------------------------------------------------
@@ -56,6 +57,7 @@ ToolbarEditor::ToolbarEditor(QWidget* parent)
       new_toolbars->push_back(mscore->fileOperationEntries());
       new_toolbars->push_back(mscore->playbackControlEntries());
       new_toolbars->push_back(mscore->colorControlMenuEntries());
+      new_toolbars->push_back(mscore->toggleOptionsMenuEntries());
 
       connect(toolbarList, SIGNAL(currentRowChanged(int)), SLOT(toolbarChanged(int)));
       connect(add, SIGNAL(clicked()), SLOT(addAction()));
@@ -97,6 +99,7 @@ void ToolbarEditor::init()
       new_toolbars->at(1) = mscore->fileOperationEntries();
       new_toolbars->at(2) = mscore->playbackControlEntries();
       new_toolbars->at(3) = mscore->colorControlMenuEntries();
+      new_toolbars->at(4) = mscore->toggleOptionsMenuEntries();
 
       toolbarChanged(toolbarList->currentRow());  // populate lists
       }
@@ -124,10 +127,12 @@ void ToolbarEditor::accepted()
       mscore->setFileOperationEntries(*(new_toolbars->at(1)));
       mscore->setPlaybackControlEntries(*(new_toolbars->at(2)));
       mscore->setColorControlMenuEntries(*(new_toolbars->at(3)));
+      mscore->setToggleOptionsMenuEntries(*(new_toolbars->at(4)));
       mscore->populateNoteInputMenu();
       mscore->populateFileOperations();
       mscore->populatePlaybackControls();
       mscore->populateColorControlMenu();
+      mscore->populateToggleOptionsMenu();
       WorkspacesManager::currentWorkspace()->setDirty(true);
       }
 
@@ -279,6 +284,9 @@ void ToolbarEditor::toolbarChanged(int tb)
                   break;
             case 3:     //ColorControls
                   populateLists(MuseScore::allColorControlMenuEntries(), new_toolbars->at(tb));
+                  break;
+            case 4:     //ToggleOptions
+                  populateLists(MuseScore::allToggleOptionsMenuEntries(), new_toolbars->at(tb));
                   break;
             }
       }

--- a/mscore/toolbuttonmenu.cpp
+++ b/mscore/toolbuttonmenu.cpp
@@ -33,7 +33,8 @@ ToolButtonMenu::ToolButtonMenu(QString name,
       setPopupMode(QToolButton::MenuButtonPopup);
 
       if (!swapAction) {
-            addAction(defaultAction);
+            if (defaultAction->isEnabled())
+                  addAction(defaultAction);
             addSeparator();
             }
 

--- a/mscore/workspace.cpp
+++ b/mscore/workspace.cpp
@@ -741,6 +741,7 @@ void Workspace::read(XmlReader& e)
       bool foToolbar = false;
       bool pcToolbar = false;
       bool colorToolbar = false;
+      bool toggleOptionsToolbar = false;
       while (e.readNextStartElement()) {
             const QStringRef& tag(e.name());
             if (tag == "name")
@@ -763,6 +764,8 @@ void Workspace::read(XmlReader& e)
                         toolbarEntries = mscore->allPlaybackControlEntries();
                   else if (name == "colorControl")
                         toolbarEntries = mscore->allColorControlMenuEntries();
+                  else if (name == "toggleOptions")
+                        toolbarEntries = mscore->allToggleOptionsMenuEntries();
                   else
                         qDebug() << "Error in loading workspace: " + name + " is not a toolbar";
 
@@ -800,6 +803,11 @@ void Workspace::read(XmlReader& e)
                         mscore->setColorControlMenuEntries(l);
                         mscore->populateColorControlMenu();
                         colorToolbar = true;
+                        }
+                  else if (name == "toggleOptions") {
+                        mscore->setToggleOptionsMenuEntries(l);
+                        mscore->populateToggleOptionsMenu();
+                        toggleOptionsToolbar = true;
                         }
                   }
             else if (tag == "Preferences") {
@@ -901,6 +909,10 @@ void Workspace::read(XmlReader& e)
             if (!colorToolbar) {
                   mscore->setColorControlMenuEntries(mscore->allColorControlMenuEntries());
                   mscore->populateColorControlMenu();
+                  }
+            if (!toggleOptionsToolbar) {
+                  mscore->setToggleOptionsMenuEntries(mscore->allToggleOptionsMenuEntries());
+                  mscore->populateToggleOptionsMenu();
                   }
             }
       else {
@@ -1025,6 +1037,8 @@ void Workspace::readGlobalToolBar()
                                     toolbarEntries = mscore->allPlaybackControlEntries();
                               else if (name == "controlControl")
                                     toolbarEntries = mscore->allColorControlMenuEntries();
+                              else if (name == "toggleOptions")
+                                    toolbarEntries = mscore->allToggleOptionsMenuEntries();
                               else
                                     qDebug() << "Error in loading workspace: " + name + " is not a toolbar";
 
@@ -1058,6 +1072,10 @@ void Workspace::readGlobalToolBar()
                               else if (name == "colorControl") {
                                     mscore->setColorControlMenuEntries(l);
                                     mscore->populateColorControlMenu();
+                                    }
+                              else if (name == "toggleOptions") {
+                                    mscore->setToggleOptionsMenuEntries(l);
+                                    mscore->populateToggleOptionsMenu();
                                     }
                               }
                         else

--- a/thirdparty/beatroot/AgentList.h
+++ b/thirdparty/beatroot/AgentList.h
@@ -36,7 +36,7 @@ class AgentList
       bool empty() const { return list.empty(); }
       Container::iterator begin() { return list.begin(); }
       Container::iterator end() { return list.end(); }
-      size_t size() { return list.size(); }
+      std::size_t size() { return list.size(); }
 
       void push_back(Agent *a) { list.push_back(a); }
 


### PR DESCRIPTION
**Purpose**: Enable/Disable some more experimental options that have been implemented in this personalized "hack" MuseScore 3.x edition quickly and easily via drop-down menu in the toolbar. Can also be used for future options, though the list is getting kind of large:

![image](https://github.com/user-attachments/assets/1729c632-c395-45a4-ab58-79ff193263f7)

Beats the hell out of having to open up Preferences, then go to Advanced Options, then search through, make a change, and then press apply/ok to access some of these things