### PR TITLE
Text Lines: new playback attribute "En Passant Visibility"

### DIFF
--- a/global/settings/types/preferencekeys.h
+++ b/global/settings/types/preferencekeys.h
@@ -176,6 +176,7 @@
 #define PREF_SCORE_PLAYBACK_HIGHLIGHT_RESTS                 "ui/score/playback/highlightRests"
 #define PREF_SCORE_PLAYBACK_HIGHLIGHT_MORE                  "ui/score/playback/highlightMore"
 #define PREF_SCORE_PLAYBACK_HIGHLIGHT_LYRICS                "ui/score/playback/highlightLyrics"
+#define PREF_SCORE_PLAYBACK_HONOR_EN_PASSANT_VISIBLE        "ui/score/playback/enPassantVisibility"
 
 #define PREF_UI_SCORE_NOTEHEADS_BEHIND_STAFF_LINES          "ui/score/elements/noteheads/behindStaff"
 #define PREF_UI_SCORE_NOTEHEADS_BEHIND_LEDGER_LINES         "ui/score/elements/noteheads/behindLedgerLines"

--- a/libmscore/element.cpp
+++ b/libmscore/element.cpp
@@ -555,6 +555,42 @@ QColor Element::curColor(bool isVisible, QColor normalColor) const
       if (MScore::highlightNotes && isNote()) {
             auto n = toNote(this);
             marked = n->mark();
+
+            if (MScore::honorEnPassantVisibility && marked) {
+                  auto c         = n->chord();
+                  auto s         = c->segment();
+                  auto noteTick  = s->tick().ticks();
+                  auto noteTrack = n->track();
+                  auto overlappingSpanners = score()->spannerMap().findOverlapping(0, noteTick);
+                  for (auto i : overlappingSpanners) {
+                        auto s = i.value;
+                        if (s->isTextLineBase() && s->track() == noteTrack) {
+                              auto tlb = toTextLineBase(s);
+                              bool enPassant = tlb->enPassantManifest();
+                              if (enPassant) {
+                                    bool withinPlaybackPosition = (noteTick >= tlb->tick().ticks() && noteTick <= tlb->tick2().ticks());
+                                    if (withinPlaybackPosition) {
+                                          if (!tlb->visible()) {
+                                                tlb->setVisible(true);
+                                                tlb->setTemporarilyShowing(true);                                                
+                                                // BSP Tree needs updating if already invisible
+                                                // TODO TEST this on large scores to verify everything's okay.
+                                                score()->masterScore()->rebuildBspTree();
+                                                score()->masterScore()->setUpdateAll();
+                                                }
+                                          else if (!tlb->isTemporarilyShowing()) {
+                                                tlb->frontSegment()->setSelected(true);
+                                                }
+                                          }
+                                    else if (tlb->isTemporarilyShowing())
+                                          tlb->setVisible(false);
+                                    else {
+                                          tlb->frontSegment()->setSelected(false);
+                                          }
+                                    }
+                              }
+                        }
+                  }
             }
 
       if (MScore::highlightRests && isRest()) {

--- a/libmscore/element.h
+++ b/libmscore/element.h
@@ -173,6 +173,7 @@ class Element : public ScoreElement {
       mutable ElementFlags _flags;
                                   ///< valid after call to layout()
       uint _tag;                  ///< tag bitmask
+      bool _temporarilyShowing = false;
 
    public:
       enum class EditBehavior {
@@ -388,6 +389,9 @@ class Element : public ScoreElement {
       virtual void setColor(const QColor& c)     { _color = c;    }
       void undoSetColor(const QColor& c);
       void undoSetVisible(bool v);
+
+      bool isTemporarilyShowing(void) const { return _temporarilyShowing; }
+      void setTemporarilyShowing(bool v) { _temporarilyShowing = v; }
 
       static ElementType readType(XmlReader& node, QPointF*, Fraction*);
       static Element* readMimeData(Score* score, const QByteArray& data, QPointF*, Fraction*);

--- a/libmscore/mscore.cpp
+++ b/libmscore/mscore.cpp
@@ -130,6 +130,7 @@ bool    MScore::highlightNotes;
 bool    MScore::highlightRests;
 bool    MScore::highlightMore;
 bool    MScore::highlightLyrics;
+bool    MScore::honorEnPassantVisibility;
 
 bool    MScore::noteInputOctaveTendencyIsTopNote;
 bool    MScore::noteInputOctaveUpwardFifth;

--- a/libmscore/mscore.h
+++ b/libmscore/mscore.h
@@ -375,6 +375,7 @@ class MScore {
       static bool   highlightRests;
       static bool   highlightMore;
       static bool   highlightLyrics;
+      static bool   honorEnPassantVisibility;
 
       static bool noteInputOctaveTendencyIsTopNote;
       static bool noteInputOctaveUpwardFifth;

--- a/libmscore/property.cpp
+++ b/libmscore/property.cpp
@@ -125,6 +125,8 @@ static constexpr PropertyMetaData propertyList[] = {
       { Pid::LOCK_ASPECT_RATIO,       false, "lockAspectRatio",       P_TYPE::BOOL,                DUMMY_QT_TRANSLATE_NOOP("propertyName", "aspect ratio locked") },
       { Pid::IMAGE_FRAME_WIDTH,       false, "imageFrameWidth",       P_TYPE::SP_REAL,             DUMMY_QT_TRANSLATE_NOOP("propertyName", "image frame size") },
       { Pid::IMAGE_FRAME_COLOR,       false, "imageFrameColor",       P_TYPE::COLOR,               DUMMY_QT_TRANSLATE_NOOP("propertyName", "image frame color")},
+      { Pid::EN_PASSANT_MANIFEST,     false, "enPassantManifest",     P_TYPE::BOOL,                DUMMY_QT_TRANSLATE_NOOP("propertyName", "temporarily make visible during playback")},
+
       { Pid::SIZE_IS_SPATIUM,         false, "sizeIsSpatium",         P_TYPE::BOOL,                DUMMY_QT_TRANSLATE_NOOP("propertyName", "size is spatium")  },
       { Pid::TEXT,                    true,  "text",                  P_TYPE::STRING,              DUMMY_QT_TRANSLATE_NOOP("propertyName", "text")             },
       { Pid::HTML_TEXT,               false, 0,                       P_TYPE::STRING,              ""                                                    },

--- a/libmscore/property.h
+++ b/libmscore/property.h
@@ -131,6 +131,7 @@ enum class Pid {
       LOCK_ASPECT_RATIO,
       IMAGE_FRAME_WIDTH,
       IMAGE_FRAME_COLOR,
+      EN_PASSANT_MANIFEST,
       SIZE_IS_SPATIUM,
       TEXT,
       HTML_TEXT,

--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -1890,6 +1890,7 @@ void Score::scanElementsInRange(void* data, void (*func)(void*, Element*), bool 
 void Score::setSelection(const Selection& s)
       {
       deselectAll();
+      setUpdateAll();
       _selection = s;
 
       for (Element* e : _selection.elements())
@@ -3422,8 +3423,9 @@ void Score::select(Element* e, SelectType type, int staffIdx)
 
 void Score::selectSingle(Element* e, int staffIdx)
       {
-      SelState selState;
-      deselectAll();
+      SelState selState = _selection.state();
+      if (selState != SelState::NONE)
+            deselectAll();
       if (e == 0) {
             selState = SelState::NONE;
             setUpdateAll();

--- a/libmscore/select.cpp
+++ b/libmscore/select.cpp
@@ -51,6 +51,7 @@
 #include "sticking.h"
 #include "system.h"
 #include "tempotext.h"
+#include "textline.h"
 #include "tie.h"
 #include "tremolo.h"
 #include "tuplet.h"
@@ -302,8 +303,21 @@ Measure* Selection::findMeasure() const
 
 void Selection::deselectAll()
       {
-      if (_state == SelState::RANGE)
-            _score->setUpdateAll();
+      if (_score) {
+            if (_state == SelState::RANGE)
+                  _score->setUpdateAll();
+
+            for (auto i : _score->spannerMap().findContained(0, _score->endTick().ticks())) {
+                  auto s = i.value;
+                  if (s->isTextLine()) {
+                        auto tl = toTextLine(s);
+                        for (auto ss : tl->spannerSegments()) {
+                              ss->setSelected(false);
+                              }
+                        }
+                  }
+            }
+
       clear();
       updateState();
       }

--- a/libmscore/textline.cpp
+++ b/libmscore/textline.cpp
@@ -296,6 +296,8 @@ QVariant TextLine::propertyDefault(Pid propertyId) const
             case Pid::BEGIN_HOOK_HEIGHT:
             case Pid::END_HOOK_HEIGHT:
                   return Spatium(1.5);
+            case Pid::EN_PASSANT_MANIFEST:
+                  return false;
             default:
                   return TextLineBase::propertyDefault(propertyId);
             }

--- a/libmscore/textlinebase.cpp
+++ b/libmscore/textlinebase.cpp
@@ -959,8 +959,10 @@ void TextLineBase::spatiumChanged(qreal /*ov*/, qreal /*nv*/)
 void TextLineBase::writeProperties(XmlWriter& xml) const
       {
       for (Pid pid : pids) {
-            if (!isStyled(pid)) 
-                  writeProperty(xml, pid);
+            if (!isStyled(pid)) {
+                  if ((pid == Pid::EN_PASSANT_MANIFEST) && MScore::testMode) {/*Skip during testing*/}
+                  else writeProperty(xml, pid);
+                  }
             }
       SLine::writeProperties(xml);
       }

--- a/libmscore/textlinebase.cpp
+++ b/libmscore/textlinebase.cpp
@@ -858,7 +858,7 @@ void TextLineBaseSegment::spatiumChanged(qreal ov, qreal nv)
       _endText->spatiumChanged(ov, nv);
       }
 
-static constexpr std::array<Pid, 26> pids = { {
+static constexpr std::array<Pid, 27> pids = { {
       Pid::LINE_VISIBLE,
       Pid::BEGIN_HOOK_TYPE,
       Pid::BEGIN_HOOK_HEIGHT,
@@ -885,6 +885,7 @@ static constexpr std::array<Pid, 26> pids = { {
       Pid::END_FONT_SIZE,
       Pid::END_FONT_STYLE,
       Pid::END_TEXT_OFFSET,
+      Pid::EN_PASSANT_MANIFEST,
       } };
 
 //---------------------------------------------------------
@@ -909,6 +910,7 @@ TextLineBase::TextLineBase(Score* s, ElementFlags f)
       {
       setBeginHookHeight(Spatium(1.9));
       setEndHookHeight(Spatium(1.9));
+      setEnPassantManifest(false);
       }
 
 //---------------------------------------------------------
@@ -1051,6 +1053,8 @@ QVariant TextLineBase::getProperty(Pid id) const
                   return _endTextOffset;
             case Pid::LINE_VISIBLE:
                   return lineVisible();
+            case Pid::EN_PASSANT_MANIFEST:
+                  return enPassantManifest();
             default:
                   return SLine::getProperty(id);
             }
@@ -1142,6 +1146,9 @@ bool TextLineBase::setProperty(Pid id, const QVariant& v)
                   break;
             case Pid::END_FONT_STYLE:
                   setEndFontStyle(FontStyle(v.toInt()));
+                  break;
+            case Pid::EN_PASSANT_MANIFEST:
+                  setEnPassantManifest(v.toBool());
                   break;
             default:
                   return SLine::setProperty(id, v);

--- a/libmscore/textlinebase.h
+++ b/libmscore/textlinebase.h
@@ -106,6 +106,7 @@ class TextLineBase : public SLine {
       M_PROPERTY(qreal,     endFontSize,           setEndFontSize)
       M_PROPERTY(FontStyle, endFontStyle,          setEndFontStyle)
       M_PROPERTY(QPointF,   endTextOffset,         setEndTextOffset)
+      M_PROPERTY(bool,      enPassantManifest,     setEnPassantManifest)
 
    protected:
       friend class TextLineBaseSegment;

--- a/mscore/inspector/inspectorTextLine.cpp
+++ b/mscore/inspector/inspectorTextLine.cpp
@@ -27,6 +27,7 @@ InspectorTextLine::InspectorTextLine(QWidget* parent)
       const std::vector<InspectorItem> il = {
             { Pid::PLACEMENT,   0, ttl.placement,      ttl.resetPlacement        },
             { Pid::SYSTEM_FLAG, 0, ttl.systemTextLine, 0                         },
+            { Pid::EN_PASSANT_MANIFEST, 0, ttl.enPassantManifest, 0              },
             };
       const std::vector<InspectorPanel> ppList = {
             { ttl.title, ttl.panel },

--- a/mscore/inspector/inspector_textline.ui
+++ b/mscore/inspector/inspector_textline.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>183</width>
-    <height>59</height>
+    <height>97</height>
    </rect>
   </property>
   <property name="accessibleName">
@@ -49,7 +49,6 @@
      </property>
      <property name="font">
       <font>
-       <weight>75</weight>
        <bold>true</bold>
       </font>
      </property>
@@ -76,6 +75,22 @@
       <property name="spacing">
        <number>3</number>
       </property>
+      <item row="1" column="0" colspan="2">
+       <widget class="QCheckBox" name="systemTextLine">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="focusPolicy">
+         <enum>Qt::TabFocus</enum>
+        </property>
+        <property name="text">
+         <string>System Text Line</string>
+        </property>
+       </widget>
+      </item>
       <item row="0" column="1">
        <widget class="QComboBox" name="placement">
         <property name="sizePolicy">
@@ -125,19 +140,10 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="0" colspan="2">
-       <widget class="QCheckBox" name="systemTextLine">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="focusPolicy">
-         <enum>Qt::TabFocus</enum>
-        </property>
+      <item row="2" column="0" colspan="2">
+       <widget class="QCheckBox" name="enPassantManifest">
         <property name="text">
-         <string>System Text Line</string>
+         <string>Show En Passant</string>
         </property>
        </widget>
       </item>

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -568,6 +568,7 @@ void updateExternalValuesFromPreferences() {
       MScore::highlightRests  = preferences.getBool(PREF_SCORE_PLAYBACK_HIGHLIGHT_RESTS);
       MScore::highlightMore   = preferences.getBool(PREF_SCORE_PLAYBACK_HIGHLIGHT_MORE);  
       MScore::highlightLyrics = preferences.getBool(PREF_SCORE_PLAYBACK_HIGHLIGHT_LYRICS);
+      MScore::honorEnPassantVisibility = preferences.getBool(PREF_SCORE_PLAYBACK_HONOR_EN_PASSANT_VISIBLE);
 
       MScore::slurShoulderExtraMax = preferences.getDouble(PREF_UI_SCORE_SLURS_MAX_SHOULDER_EXTRA);
       MScore::slurShoulderExtraMin = preferences.getDouble(PREF_UI_SCORE_SLURS_MIN_SHOULDER_EXTRA);

--- a/mscore/preferences.cpp
+++ b/mscore/preferences.cpp
@@ -248,6 +248,7 @@ void Preferences::init(bool storeInMemoryOnly)
             {PREF_SCORE_PLAYBACK_HIGHLIGHT_RESTS,                  new BoolPreference(true)},
             {PREF_SCORE_PLAYBACK_HIGHLIGHT_MORE,                   new BoolPreference(false)},
             {PREF_SCORE_PLAYBACK_HIGHLIGHT_LYRICS,                 new BoolPreference(false)},
+            {PREF_SCORE_PLAYBACK_HONOR_EN_PASSANT_VISIBLE,         new BoolPreference(true)},
 
             {PREF_UI_SCORE_NOTEHEADS_BEHIND_STAFF_LINES,           new BoolPreference(false)},
             {PREF_UI_SCORE_NOTEHEADS_BEHIND_LEDGER_LINES,          new BoolPreference(false)},

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -1578,8 +1578,11 @@ void ScoreView::drawElements(QPainter& painter, QList<Element*>& el, Element* ed
                   continue;
             if (MScore::noteheadsBehindStaff && (e->isNote() || e->isStem()))
                   continue;
-            if (!e->visible() && (score()->printing() || !score()->showInvisible()))
-                  continue;
+            if (!e->visible() && (score()->printing() || !score()->showInvisible())) {
+                  bool tempShow = (e->isTextLineBase() && e->isTemporarilyShowing()); 
+                  if (!tempShow)
+                        continue;
+                  }
             if (e->isRest() && toRest(e)->isGap())
                   continue;
             QPointF pos(e->pagePos());
@@ -2902,9 +2905,27 @@ void ScoreView::cmd(const char* s)
             {{"play"}, [&](ScoreView* cv, const QByteArray&) {
                   if (seq && seq->canStart()) {
                         auto _score = cv->score();
-                        auto _selection = _score->selection();
+                        auto& _selection = _score->selection();
                         if (cv->state == ViewState::NORMAL || cv->state == ViewState::NOTE_ENTRY) {
                               // Start:
+                              auto resetTempSpannerVisibility = [](Score* score) {
+                                    int beginTick = 0;
+                                    int endTick   = score->endTick().ticks();
+                                    auto overlappingSpanners = score->spannerMap().findOverlapping(beginTick, endTick);
+                                    for (auto i : overlappingSpanners) {
+                                          auto s = i.value;
+                                          if (s->isTextLineBase()) {
+                                                auto tlb = toTextLineBase(s);
+                                                if (tlb->isTemporarilyShowing()) {
+                                                      tlb->setTemporarilyShowing(false);
+                                                      tlb->setVisible(false);
+                                                      }
+                                                }
+                                          }
+                                    };
+
+                              resetTempSpannerVisibility(_score);
+
                               if (!_selection.isNone()) {
                                     _score->deselectAll();
                                     // Clear on-screen keyboard:
@@ -2918,13 +2939,18 @@ void ScoreView::cmd(const char* s)
                               // Stop:
                               cv->changeState(ViewState::NORMAL);
 
-                              if (!cv->score()->selection().isNone())
-                                    cv->score()->deselectAll();
+                              if (!_selection.isNone())
+                                    _score->deselectAll();
 
                               bool validOriginalSelection = (originalSelection.score() == _score);
+
+                              // Deselect any text line segments (en passant)
+                              if (!_selection.isNone())
+                                    cv->deselectAll();
+
                               if (MScore::selectionFollowsCursor) {
                                     auto el = cv->chordRestFromCursor();
-                                    cv->score()->select(el);
+                                    _score->select(el);
                                     }
                               else if (validOriginalSelection) {
                                     if (/*TODO*/ true) {


### PR DESCRIPTION
**During playback**:  when enabled, **if visible**: _highlight_/**if invisible**: _show as regular_ during the range-span of the textline 

Another <ins>gimmick</ins> for fun:

[enPassant.webm](https://github.com/user-attachments/assets/e35695a8-937e-4b0f-9b78-227ed641a080)
