### PR TITLE
New Command: Toggle All En Passant Visible/Invisible

### DIFF
--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -6827,6 +6827,24 @@ void MuseScore::cmd(QAction* a, const QString& cmd)
                   cs->setShowInvisible(false);
                   }
             }
+      else if (cmd == "toggle-visible-en-passant") {
+            int begin = 0;
+            int end = cs->endTick().ticks();
+            auto spanners = cs->spannerMap().findOverlapping(begin, end);
+            for (auto i : spanners) {
+                  auto s = i.value;
+                  if (s->isTextLineBase()) {
+                        auto tlb = toTextLineBase(s);
+                        bool enPassant = tlb->enPassantManifest();
+                        if (enPassant) {
+                              bool toggle = !tlb->visible();
+                              tlb->setVisible(toggle);
+                              }
+                        }
+                  }
+            cs->setLayoutAll();
+            cs->update();
+            }
       else if (cmd == "show-unprintable") {
             cs->setShowUnprintable(a->isChecked());
             cs->update();

--- a/mscore/shortcut.cpp
+++ b/mscore/shortcut.cpp
@@ -3281,6 +3281,16 @@ Shortcut Shortcut::_sc[] = {
       {
          MsWidget::MAIN_WINDOW,
          STATE_NORMAL | STATE_NOTE_ENTRY,
+         "toggle-visible-en-passant",
+         QT_TRANSLATE_NOOP("action","Toggle Visibility Attribute of all En Passant Text Lines"),
+         QT_TRANSLATE_NOOP("action","Toggle Visibility Attribute of all En Passant Text Lines"),
+         0,
+         Icons::Invalid_ICON,
+         Qt::WindowShortcut,
+         },
+      {
+         MsWidget::MAIN_WINDOW,
+         STATE_NORMAL | STATE_NOTE_ENTRY,
          "show-unprintable",
          QT_TRANSLATE_NOOP("action","Show Unprintable"),
          QT_TRANSLATE_NOOP("action","Show unprintable"),


### PR DESCRIPTION
Helper function to easily flip visibility of textlines with the _en passant visibility_ attribute enabled.