### PR TITLE
Efficiency Change: slow-down from applying accidental [more...]

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -4920,7 +4920,6 @@ void Score::cmdAddPitch(const EditData& ed, int note, bool addFlag, bool insert,
 
       int step = octave * TPC_DELTA_SEMITONE + note;
       cmdAddPitch(step,  addFlag, insert);
-      ed.view->adjustCanvasPosition(is.cr(), false);
       }
 
 void Score::cmdAddPitch(int step, bool addFlag, bool insert)

--- a/libmscore/element.cpp
+++ b/libmscore/element.cpp
@@ -2234,7 +2234,7 @@ bool Element::isUserModified() const
 void Element::triggerLayout() const
       {
       if (parent())
-            score()->setLayout(tick(), staffIdx(), this);
+            score()->setLayout(parent()->tick(), staffIdx(), this);
       }
 
 //----------------------------------------------------------------------

--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -5474,8 +5474,16 @@ void MasterScore::setLayoutAll(int staff, const Element* e)
 
 void MasterScore::setLayout(const Fraction& t, int staff, const Element* e)
       {
-      if (t >= Fraction(0,1))
+      auto zero = Fraction(0,1);
+      if (t == zero) {
+            if (e) {
+                  if (e->findAncestor(ElementType::SYSTEM))
+                        _cmdState.setTick(t);
+                  }
+            }
+      else if (t > zero) {
             _cmdState.setTick(t);
+            }
 
       if (e && e->score() == this) {
             // TODO: map staff number properly
@@ -5486,9 +5494,18 @@ void MasterScore::setLayout(const Fraction& t, int staff, const Element* e)
 
 void MasterScore::setLayout(const Fraction& tick1, const Fraction& tick2, int staff1, int staff2, const Element* e)
       {
-      if (tick1 >= Fraction(0,1))
+      auto zero = Fraction(0,1);
+
+      // Debug testing:
+      if (tick1 == tick2) {
+            if ((tick1 == zero) && e) {
+                  qDebug() << "<%s>" << e->name() << "with both ticks @ [0/1]";
+                  }
+            }
+
+      if (tick1 >= zero)
             _cmdState.setTick(tick1);
-      if (tick2 >= Fraction(0,1))
+      if (tick2 >= zero && (tick2 > tick1))
             _cmdState.setTick(tick2);
 
       if (e && e->score() == this) {


### PR DESCRIPTION
+ As score-size increases, accidental placement when more than one in a measure (or naturals) have slow-down, along with tie-into another measure. Why? There was a re-layout from beginning of score occurring because of invalid ticks starting at 0/1 fractions ....

+ Reset slur was triggering a full layout when terminal points were altered

Seems like the slow-downs I experienced were mainly happening in debug builds and not so much or as heavily in release builds, so this might be superfluous (save for local building)