### PR TITLE
Measure Property: Centering of Single ChordRests (besides FullMeasureRest)

### DIFF
--- a/libmscore/chordrest.cpp
+++ b/libmscore/chordrest.cpp
@@ -1340,6 +1340,17 @@ Shape ChordRest::shape() const
       }
 
 //---------------------------------------------------------
+//   isCentered
+//---------------------------------------------------------
+
+bool ChordRest::isCentered() const
+      {
+      bool entireMeasure = (ticks() == measure()->ticks());
+      bool haveCenteredSingleCR = entireMeasure && measure()->centerSingleChord();
+      return haveCenteredSingleCR && !isFullMeasureRest();
+      }
+
+//---------------------------------------------------------
 //   lyrics
 //---------------------------------------------------------
 

--- a/libmscore/chordrest.h
+++ b/libmscore/chordrest.h
@@ -186,6 +186,8 @@ class ChordRest : public DurationElement {
       virtual void computeUp()   { _up = true; }
 
       bool isFullMeasureRest() const { return _durationType == TDuration::DurationType::V_MEASURE; }
+      bool isCentered() const;
+
       virtual void removeMarkings(bool keepTremolo = false);
 
       bool isBefore(const ChordRest*) const;

--- a/libmscore/excerpt.cpp
+++ b/libmscore/excerpt.cpp
@@ -495,6 +495,7 @@ void Excerpt::cloneStaves(Score* oscore, Score* score, const QList<int>& map, QM
                   nm->setNo(m->no());
                   nm->setNoOffset(m->noOffset());
                   nm->setBreakMultiMeasureRest(m->breakMultiMeasureRest());
+                  nm->setCenterSingleChord(m->centerSingleChord());
 
                   for (int dstStaffIdx = 0; dstStaffIdx < map.size(); ++dstStaffIdx) {
                         nm->setStaffStemless(dstStaffIdx, m->stemless(map[dstStaffIdx]));

--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -220,6 +220,7 @@ Measure::Measure(Score* s)
       _noMode                   = MeasureNumberMode::AUTO;
       _userStretch              = 1.0;
       _breakMultiMeasureRest    = false;
+      _centerSingleChord        = false;
       _mmRest                   = 0;
       _mmRestCount              = 0;
       setFlag(ElementFlag::MOVABLE, true);
@@ -244,6 +245,7 @@ Measure::Measure(const Measure& m)
             _mstaves.push_back(new MStaff(*ms));
 
       _breakMultiMeasureRest = m._breakMultiMeasureRest;
+      _centerSingleChord     = m._centerSingleChord;
       _mmRest                = m._mmRest;
       _mmRestCount           = m._mmRestCount;
       _playbackCount         = m._playbackCount;
@@ -1969,6 +1971,7 @@ void Measure::write(XmlWriter& xml, int staff, bool writeSystemElements, bool fo
                   xml.tag("endRepeat", _repeatCount);
             writeProperty(xml, Pid::IRREGULAR);
             writeProperty(xml, Pid::BREAK_MMR);
+            writeProperty(xml, Pid::CENTER_SINGLE_CHORD);
             writeProperty(xml, Pid::USER_STRETCH);
             writeProperty(xml, Pid::NO_OFFSET);
             writeProperty(xml, Pid::MEASURE_NUMBER_MODE);
@@ -2077,6 +2080,8 @@ void Measure::read(XmlReader& e, int staffIdx)
                   setIrregular(e.readBool());
             else if (tag == "breakMultiMeasureRest")
                   _breakMultiMeasureRest = e.readBool();
+            else if (tag == "centerSingleChord")
+                  _centerSingleChord = e.readBool();
             else if (tag == "startRepeat") {
                   setRepeatStart(true);
                   e.readNext();
@@ -3125,6 +3130,7 @@ Measure* Measure::cloneMeasure(Score* sc, const Fraction& tick, TieMap* tieMap)
       m->setIrregular(irregular());
       m->_userStretch           = _userStretch;
       m->_breakMultiMeasureRest = _breakMultiMeasureRest;
+      m->_centerSingleChord     = _centerSingleChord;
       m->_playbackCount         = _playbackCount;
 
       m->setTick(tick);
@@ -3235,6 +3241,7 @@ Measure* Measure::cloneMeasureLimited(Score* scoreDest, const Fraction& tick, Ti
       m->setIrregular(irregular());
       m->_userStretch           = _userStretch;
       m->_breakMultiMeasureRest = _breakMultiMeasureRest;
+      m->_centerSingleChord     = _centerSingleChord;
       m->_playbackCount         = _playbackCount;
 
       m->setRepeatStart (repeatStart());
@@ -3446,6 +3453,8 @@ QVariant Measure::getProperty(Pid propertyId) const
                   return int(measureNumberMode());
             case Pid::BREAK_MMR:
                   return breakMultiMeasureRest();
+            case Pid::CENTER_SINGLE_CHORD:
+                  return centerSingleChord();
             case Pid::REPEAT_COUNT:
                   return repeatCount();
             case Pid::USER_STRETCH:
@@ -3474,6 +3483,9 @@ bool Measure::setProperty(Pid propertyId, const QVariant& value)
             case Pid::BREAK_MMR:
                   setBreakMultiMeasureRest(value.toBool());
                   break;
+            case Pid::CENTER_SINGLE_CHORD:
+                  setCenterSingleChord(value.toBool());
+                  break;
             case Pid::REPEAT_COUNT:
                   setRepeatCount(value.toInt());
                   break;
@@ -3500,6 +3512,8 @@ QVariant Measure::propertyDefault(Pid propertyId) const
             case Pid::MEASURE_NUMBER_MODE:
                   return int(MeasureNumberMode::AUTO);
             case Pid::BREAK_MMR:
+                  return false;
+            case Pid::CENTER_SINGLE_CHORD:
                   return false;
             case Pid::REPEAT_COUNT:
                   return 2;
@@ -3763,7 +3777,11 @@ void Measure::stretchMeasure(qreal targetWidth)
                         continue;
                   ElementType t = e->type();
                   int staffIdx    = e->staffIdx();
-                  if (t == ElementType::REPEAT_MEASURE || (t == ElementType::REST && (isMMRest() || toRest(e)->isFullMeasureRest()))) {
+
+                  ChordRest* cr = e->isChordRest() ? toChordRest(e) : nullptr;
+                  if ((t == ElementType::REPEAT_MEASURE) ||
+                      (t == ElementType::REST && (isMMRest() || toRest(e)->isFullMeasureRest())) ||
+                      (cr && cr->isCentered())) {
                         //
                         // element has to be centered in free space
                         //    x1 - left measure position of free space
@@ -3797,11 +3815,21 @@ void Measure::stretchMeasure(qreal targetWidth)
                               e->setPos(x1 - s.x() + d, e->staff()->height() * .5);   // center vertically in measure
                               s.createShape(staffIdx);
                               }
-                        else { // if (rest->isFullMeasureRest()) {
+                        else {
+                              //
+                              // center singular chordrest filling the measure with centering property
+                              //
+                              if (cr) {
+                                    qreal deltaWidth = cr->isChord() ? (toChord(cr)->upNote()->width() * 0.5)
+                                                                : (e->width() * 0.5);
+
+                                    e->rxpos() = ((x2 - x1) * 0.5) + x1 - s.x() - e->bbox().x() - deltaWidth;
+                                    }
                               //
                               // center full measure rest
                               //
-                              e->rxpos() = (x2 - x1 - e->width()) * .5 + x1 - s.x() - e->bbox().x();
+                              else e->rxpos() = (x2 - x1 - e->width()) * .5 + x1 - s.x() - e->bbox().x();
+
                               s.createShape(staffIdx);  // DEBUG
                               }
                         }
@@ -4649,7 +4677,7 @@ void Measure::setStretchedWidth(qreal w)
 //   hasAccidental
 //---------------------------------------------------------
 
-static bool hasAccidental(Segment* s)
+bool Measure::hasAccidental(Segment* s)
       {
       Score* score = s->score();
       for (int track = 0; track < s->score()->ntracks(); ++track) {

--- a/libmscore/measure.h
+++ b/libmscore/measure.h
@@ -84,6 +84,8 @@ class Measure final : public MeasureBase {
       MeasureNumberMode _noMode;
       bool _breakMultiMeasureRest;
 
+      bool _centerSingleChord;
+
       void push_back(Segment* e);
       void push_front(Segment* e);
 
@@ -239,6 +241,9 @@ class Measure final : public MeasureBase {
       bool breakMultiMeasureRest() const        { return _breakMultiMeasureRest; }
       void setBreakMultiMeasureRest(bool val)   { _breakMultiMeasureRest = val;  }
 
+      bool centerSingleChord() const            { return _centerSingleChord;     }
+      void setCenterSingleChord(bool val)       { _centerSingleChord = val;      }
+
       bool empty() const;
       bool isOnlyRests(int track) const;
       bool isOnlyDeletedRests(int track) const;
@@ -286,6 +291,8 @@ class Measure final : public MeasureBase {
       void checkTrailer();
       void setStretchedWidth(qreal);
       void layoutStaffLines();
+
+      static bool hasAccidental(Segment* s);
 
       qreal computeFirstSegmentXPosition(Segment* segment);
 

--- a/libmscore/property.cpp
+++ b/libmscore/property.cpp
@@ -213,6 +213,8 @@ static constexpr PropertyMetaData propertyList[] = {
       { Pid::SPANNER_TRACK2,          false, "track2",                P_TYPE::INT,                 DUMMY_QT_TRANSLATE_NOOP("propertyName", "track2")           },
       { Pid::OFFSET2,                 false, "userOff2",              P_TYPE::POINT_SP,            DUMMY_QT_TRANSLATE_NOOP("propertyName", "offset2")         },
       { Pid::BREAK_MMR,               false, "breakMultiMeasureRest", P_TYPE::BOOL,                DUMMY_QT_TRANSLATE_NOOP("propertyName", "breaking multimeasure rest")},
+      { Pid::CENTER_SINGLE_CHORD,     false, "centerSingleChord",     P_TYPE::BOOL,                DUMMY_QT_TRANSLATE_NOOP("propertyName", "single chord is centered in measure")},
+
       { Pid::MMREST_NUMBER_POS,       false, "mmRestNumberPos",       P_TYPE::SPATIUM,             DUMMY_QT_TRANSLATE_NOOP("propertyName", "vertical position of multimeasure rest number")},
       { Pid::REPEAT_COUNT,            true,  "endRepeat",             P_TYPE::INT,                 DUMMY_QT_TRANSLATE_NOOP("propertyName", "end repeat")       },
 

--- a/libmscore/property.h
+++ b/libmscore/property.h
@@ -218,6 +218,7 @@ enum class Pid {
       SPANNER_TRACK2,
       OFFSET2,
       BREAK_MMR,
+      CENTER_SINGLE_CHORD,
       MMREST_NUMBER_POS,
       REPEAT_COUNT,
 

--- a/mscore/debugger/debugger.cpp
+++ b/mscore/debugger/debugger.cpp
@@ -807,6 +807,7 @@ void MeasureView::setElement(Element* e)
       mb.irregular->setChecked(m->irregular());
       mb.repeatCount->setValue(m->repeatCount());
       mb.breakMultiMeasureRest->setChecked(m->breakMultiMeasureRest());
+      mb.centerSingleChord->setChecked(m->centerSingleChord());
       mb.mmRestCount->setValue(m->mmRestCount());
       mb.timesig->setText(m->timesig().print());
       mb.len->setText(m->ticks().print());

--- a/mscore/debugger/measure.ui
+++ b/mscore/debugger/measure.ui
@@ -427,6 +427,13 @@
           </property>
          </widget>
         </item>
+        <item row="1" column="4">
+         <widget class="QCheckBox" name="centerSingleChord">
+          <property name="text">
+           <string>centerSingle</string>
+          </property>
+         </widget>
+        </item>
        </layout>
       </item>
       <item>

--- a/mscore/measureproperties.cpp
+++ b/mscore/measureproperties.cpp
@@ -139,6 +139,7 @@ void MeasureProperties::setMeasure(Measure* _m)
 
       irregular->setChecked(m->irregular());
       breakMultiMeasureRest->setChecked(m->breakMultiMeasureRest());
+      centerSingleChord->setChecked(m->centerSingleChord());
       int n  = m->repeatCount();
       count->setValue(n);
       bool enableCount = m->repeatEnd();
@@ -266,6 +267,7 @@ void MeasureProperties::apply()
       bool offsetChanged = (measureOffset != m->noOffset()) ? true : false;
       m->undoChangeProperty(Pid::REPEAT_COUNT, repeatCount());
       m->undoChangeProperty(Pid::BREAK_MMR, breakMultiMeasureRest->isChecked());
+      m->undoChangeProperty(Pid::CENTER_SINGLE_CHORD, centerSingleChord->isChecked());
       m->undoChangeProperty(Pid::USER_STRETCH, layoutStretch->value());
       m->undoChangeProperty(Pid::MEASURE_NUMBER_MODE, measureNumberMode->currentIndex());
       m->undoChangeProperty(Pid::NO_OFFSET, measureOffset);

--- a/mscore/measureproperties.ui
+++ b/mscore/measureproperties.ui
@@ -9,8 +9,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>632</width>
-    <height>426</height>
+    <width>573</width>
+    <height>460</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -277,37 +277,7 @@
           <property name="horizontalSpacing">
            <number>6</number>
           </property>
-          <item row="0" column="0" colspan="2">
-           <widget class="QCheckBox" name="irregular">
-            <property name="toolTip">
-             <string>Do not count</string>
-            </property>
-            <property name="text">
-             <string>Exclude from measure count</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="3">
-           <widget class="QCheckBox" name="breakMultiMeasureRest">
-            <property name="text">
-             <string>Break multimeasure rest</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="3">
-           <widget class="QLabel" name="labelCount">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string>Play count:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="4">
+          <item row="6" column="4">
            <widget class="QSpinBox" name="count">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -323,20 +293,14 @@
             </property>
            </widget>
           </item>
-          <item row="1" column="2">
-           <spacer name="horizontalSpacer">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
+          <item row="5" column="0">
+           <widget class="QLabel" name="label_9">
+            <property name="text">
+             <string>Measure number mode:</string>
             </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>40</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
+           </widget>
           </item>
-          <item row="1" column="3">
+          <item row="5" column="3">
            <widget class="QLabel" name="label_8">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -352,26 +316,7 @@
             </property>
            </widget>
           </item>
-          <item row="1" column="4">
-           <widget class="QDoubleSpinBox" name="layoutStretch">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="minimum">
-             <double>0.000000000000000</double>
-            </property>
-            <property name="singleStep">
-             <double>0.100000000000000</double>
-            </property>
-            <property name="value">
-             <double>1.000000000000000</double>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="0">
+          <item row="6" column="0">
            <widget class="QLabel" name="label_7">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -384,30 +329,7 @@
             </property>
            </widget>
           </item>
-          <item row="2" column="1">
-           <widget class="QSpinBox" name="measureNumberOffset">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="minimum">
-             <number>-9999</number>
-            </property>
-            <property name="maximum">
-             <number>9999</number>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="label_9">
-            <property name="text">
-             <string>Measure number mode:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="1">
+          <item row="5" column="1">
            <widget class="QComboBox" name="measureNumberMode">
             <item>
              <property name="text">
@@ -426,7 +348,7 @@
             </item>
            </widget>
           </item>
-          <item row="1" column="5">
+          <item row="5" column="5">
            <spacer name="horizontalSpacer_2">
             <property name="orientation">
              <enum>Qt::Horizontal</enum>
@@ -438,6 +360,91 @@
              </size>
             </property>
            </spacer>
+          </item>
+          <item row="6" column="1">
+           <widget class="QSpinBox" name="measureNumberOffset">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimum">
+             <number>-9999</number>
+            </property>
+            <property name="maximum">
+             <number>9999</number>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0" colspan="2">
+           <widget class="QCheckBox" name="irregular">
+            <property name="toolTip">
+             <string>Do not count</string>
+            </property>
+            <property name="text">
+             <string>Exclude from measure count</string>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="2">
+           <spacer name="horizontalSpacer">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item row="5" column="4">
+           <widget class="QDoubleSpinBox" name="layoutStretch">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimum">
+             <double>0.000000000000000</double>
+            </property>
+            <property name="singleStep">
+             <double>0.100000000000000</double>
+            </property>
+            <property name="value">
+             <double>1.000000000000000</double>
+            </property>
+           </widget>
+          </item>
+          <item row="6" column="3">
+           <widget class="QLabel" name="labelCount">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>Play count:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0" colspan="2">
+           <widget class="QCheckBox" name="centerSingleChord">
+            <property name="text">
+             <string>Center full-measure ChordRests</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QCheckBox" name="breakMultiMeasureRest">
+            <property name="text">
+             <string>Break multimeasure rest</string>
+            </property>
+           </widget>
           </item>
          </layout>
         </widget>
@@ -513,7 +520,6 @@
   <tabstop>actualZ</tabstop>
   <tabstop>actualN</tabstop>
   <tabstop>irregular</tabstop>
-  <tabstop>breakMultiMeasureRest</tabstop>
   <tabstop>measureNumberMode</tabstop>
   <tabstop>layoutStretch</tabstop>
   <tabstop>measureNumberOffset</tabstop>

--- a/mscore/plugin/api/elements.h
+++ b/mscore/plugin/api/elements.h
@@ -286,6 +286,7 @@ class Element : public Ms::PluginAPI::ScoreElement {
       API_PROPERTY( spannerTicks,            SPANNER_TICKS             )
       API_PROPERTY( spannerTrack2,           SPANNER_TRACK2            )
       API_PROPERTY( userOff2,                OFFSET2                   )
+      API_PROPERTY( centerSingleChord,       CENTER_SINGLE_CHORD       )
       API_PROPERTY( breakMmr,                BREAK_MMR                 )
       API_PROPERTY( repeatCount,             REPEAT_COUNT              )
       API_PROPERTY( userStretch,             USER_STRETCH              )

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -1942,9 +1942,12 @@ void ScoreView::paint(const QRect& r, QPainter& p)
                                     if (!score()->staff(i)->show())
                                           continue;
                                     ChordRest* cr = static_cast<ChordRest*>(fs->element(i * VOICES));
-                                    if (cr && (cr->type() == ElementType::REPEAT_MEASURE || cr->durationType() == TDuration::DurationType::V_MEASURE)) {
-                                          x2 = s->measure()->abbox().right() - _spatium * 0.5;
-                                          break;
+                                    if (cr) {
+                                          bool haveSingleCenteredChord = (cr->ticks() == cr->measure()->ticks()) && cr->measure()->centerSingleChord();
+                                          if (cr->type() == ElementType::REPEAT_MEASURE || cr->isFullMeasureRest() || haveSingleCenteredChord) {
+                                                x2 = s->measure()->abbox().right() - _spatium * 0.5;
+                                                break;
+                                                }
                                           }
                                     }
                               }


### PR DESCRIPTION
Centered chords were often found in my experience within theory manuals/exercises, where you'd see a whole chord centered inside a measure, or sometimes in scores at the end of a system finishing with a whole-rest

+ Current flaw: does not calculate extra layout for any grace notes, so they can go outside of bounds if a measure doesn't have the appropriate size
 
+ Would've preferred to have a more generic "centering" of an entire measure's contents, but that's more complicated and wanted something quick.

It's a time saver — instead of manually adjusting leading space, chord offsets, and then maybe perform measure stretching, just enable this option in **Measure Properties**:


![image](https://github.com/user-attachments/assets/f6f309c6-1f74-4a29-94d5-d946adedad0b)



![image](https://github.com/user-attachments/assets/a125de85-47c3-4cea-9ae7-055824fc1549)

![image](https://github.com/user-attachments/assets/4a109946-6011-4a40-b06d-e6ce70135db4)

![image](https://github.com/user-attachments/assets/e3dbd3fc-2e69-4c32-bae9-9245c9a9dfbb)

This will continue to work despite the presence of subsidiary voices, though I'd advi**z**e against that. Then again, I have seen some **_olde weird textbooks_** do something like this:

![image](https://github.com/user-attachments/assets/121a8316-7367-4d08-9b92-d2b0647ea8b1)


