### PR TITLE
Note Entry: show status of toggle options at bottom-center of screen

### DIFF
--- a/global/settings/types/preferencekeys.h
+++ b/global/settings/types/preferencekeys.h
@@ -136,6 +136,8 @@
 #define PREF_SCORE_NOTE_INPUT_FORCE_VOICE2_BELOW            "ui/score/noteEntry/voice2/forceBeneathVoice1"
 #define PREF_SCORE_NOTE_INPUT_RETAIN_AUG_RHYTHM_MODE        "ui/score/noteEntry/rhythmMode/retainAugmentation"
 #define PREF_SCORE_NOTE_INPUT_ENTRY_STATUS_COLOR            "ui/score/noteEntry/toggleStatusColor"
+#define PREF_SCORE_NOTE_INPUT_ENTRY_STATUS_ENABLE           "ui/score/noteEntry/toggleStatus"
+
 #define PREF_SCORE_FINGERING_ALPHANUMERIC_AUTOFORWARD       "score/fingering/autoForwardWithAlphaNumerics"
 #define PREF_SCORE_STYLE_DEFAULTSTYLEFILE                   "score/style/defaultStyleFile"
 #define PREF_SCORE_STYLE_PARTSTYLEFILE                      "score/style/partStyleFile"

--- a/global/settings/types/preferencekeys.h
+++ b/global/settings/types/preferencekeys.h
@@ -135,6 +135,7 @@
 #define PREF_SCORE_NOTE_INPUT_RESET_PITCH_AT_SYSTEM         "ui/score/noteEntry/resetNoteEntryAtSystemOrCourtesy"
 #define PREF_SCORE_NOTE_INPUT_FORCE_VOICE2_BELOW            "ui/score/noteEntry/voice2/forceBeneathVoice1"
 #define PREF_SCORE_NOTE_INPUT_RETAIN_AUG_RHYTHM_MODE        "ui/score/noteEntry/rhythmMode/retainAugmentation"
+#define PREF_SCORE_NOTE_INPUT_ENTRY_STATUS_COLOR            "ui/score/noteEntry/toggleStatusColor"
 #define PREF_SCORE_FINGERING_ALPHANUMERIC_AUTOFORWARD       "score/fingering/autoForwardWithAlphaNumerics"
 #define PREF_SCORE_STYLE_DEFAULTSTYLEFILE                   "score/style/defaultStyleFile"
 #define PREF_SCORE_STYLE_PARTSTYLEFILE                      "score/style/partStyleFile"

--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -4733,6 +4733,14 @@ void Score::cmdAddPitch(const EditData& ed, int note, bool addFlag, bool insert,
             qDebug("cannot enter notes here (no chord rest at current position)");
             return;
             }
+
+      qreal previousPitch = -1;
+      if (auto e = selection().element()) {
+            if (e->isNote()) {
+                  previousPitch = toNote(e)->pitch();
+                  }
+            }
+
       is.setRest(false);
       const Drumset* ds = is.drumset();
       int octave = 4;
@@ -4794,6 +4802,7 @@ void Score::cmdAddPitch(const EditData& ed, int note, bool addFlag, bool insert,
                               // TPC below: basis is current note selection
 
                               Note* n = below ? toNote(e) : chord->upNote();
+                              previousPitch = n->pitch();
                               int tpc = n->tpc();
                               octave = (n->epitch() - int(tpc2alter(tpc))) / PITCH_DELTA_OCTAVE;
                               if (note <= tpc2step(tpc) && !below)
@@ -4855,6 +4864,7 @@ void Score::cmdAddPitch(const EditData& ed, int note, bool addFlag, bool insert,
                               if (resetOctave()) {
                                     auto currentClefType = staff->clef(inputTick);
                                     curPitch = line2pitch(4, currentClefType, Key::C);
+                                    previousPitch = -1;
                                     break;
                                     }
                               else if (seg->isChordRestType()) {
@@ -4882,6 +4892,7 @@ void Score::cmdAddPitch(const EditData& ed, int note, bool addFlag, bool insert,
                                           // check if it's an actual change or just a courtesy
                                           if (!isCourtesy || isBeginning || MScore::resetNoteEntryAtSystemOrCourtesy) {
                                                 curPitch = line2pitch(4, clef->clefType(), Key::C); // C 72 for treble clef
+                                                previousPitch = -1;
                                                 break;
                                                 }
                                           }
@@ -4921,6 +4932,17 @@ void Score::cmdAddPitch(const EditData& ed, int note, bool addFlag, bool insert,
 
       int step = octave * TPC_DELTA_SEMITONE + note;
       cmdAddPitch(step,  addFlag, insert);
+
+      auto currentPitch = is.getLastPitch();
+      Direction result = Direction::AUTO;
+      if (previousPitch == -1)
+            ;
+      else if (currentPitch > previousPitch)
+            result = Direction::UP;
+      else if (currentPitch < previousPitch)
+            result = Direction::DOWN;
+      int pitchDelta = currentPitch - previousPitch;
+      is.updateLastInputDirection(result, pitchDelta);
       }
 
 void Score::cmdAddPitch(int step, bool addFlag, bool insert)
@@ -4948,6 +4970,7 @@ void Score::cmdAddPitch(int step, bool addFlag, bool insert)
                         }
                   addNote(chord, nval, forceAccidental);
                   _is.setAccidentalType(AccidentalType::NONE);
+                  _is.updateLastPitch(nval.pitch);
                   }
                   return;
             }
@@ -5318,6 +5341,13 @@ void Score::cmdOverrideColor(const char* what)
             changedColor = QColorDialog::getColor(currentColor, nullptr, title, flags);
             MScore::selectColor[3] = changedColor.isValid() ? changedColor : currentColor;
             preferences.setPreference(PREF_UI_SCORE_VOICE1_COLOR, MScore::selectColor[0]);
+            }
+      else if (strcmp(what, "note-entry-status") == 0) {
+            title = "Select Note Entry Status Color";
+            currentColor = MScore::noteEntryInformationColor;
+            changedColor = QColorDialog::getColor(currentColor, nullptr, title, flags);
+            MScore::noteEntryInformationColor = changedColor.isValid() ? changedColor : currentColor;
+            preferences.setPreference(PREF_SCORE_NOTE_INPUT_ENTRY_STATUS_COLOR, MScore::noteEntryInformationColor);
             }
 
       else qDebug() << "Override color <%s> not implemented" << what;

--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -5418,6 +5418,10 @@ bool Score::cmdToggleOptions(const QString& cmd)
       else if (cmd.endsWith("mouse-hover")) {
             preferences.setPreference(PREF_SCORE_HOVER_COLOR_ENABLE, checked=toggle(MScore::hoverColorEnabled));
             }
+      else if (cmd.endsWith("note-entry-information")) {
+            preferences.setPreference(PREF_SCORE_NOTE_INPUT_ENTRY_STATUS_ENABLE, checked=toggle(MScore::noteEntryInformationEnabled));
+            updateScore = true;
+            }
       else if (cmd.endsWith("noteheads-behind-staff")) {
             preferences.setPreference(PREF_UI_SCORE_NOTEHEADS_BEHIND_STAFF_LINES, checked=toggle(MScore::noteheadsBehindStaff));
             updateScore = true;

--- a/libmscore/input.h
+++ b/libmscore/input.h
@@ -57,6 +57,9 @@ class InputState {
       Hairpin* _dynamicLine    { nullptr }; // allow for a continuous 'slur-input-style' hairpin
       Pedal* _pedalLine        { nullptr }; // same for pedal mark
       bool _insertMode         { false };
+      int _lastInputPitch      { -1 };
+      int _lastInputPitchDiff  { 0 };
+      Direction _lastInputDirection { Direction::AUTO };
 
       Segment* nextInputPos() const;
 
@@ -126,6 +129,14 @@ class InputState {
       void moveInputPos(Element* e);
       void moveToNextInputPos();
       bool endOfScore() const;
+
+      void updateLastPitch(int p)         { _lastInputPitch = p;    }
+      int  getLastPitch()                 { return _lastInputPitch; }
+      void updateLastInputDirection(Direction d, int diff)
+                                          { _lastInputDirection = d;
+                                            _lastInputPitchDiff = diff; }
+      Direction getLastInputDirection()   { return _lastInputDirection; }
+      int getPitchDelta()                 { return _lastInputPitchDiff; }
 
       // TODO: unify with Selection::cr()?
       static Note* note(Element*);

--- a/libmscore/mscore.cpp
+++ b/libmscore/mscore.cpp
@@ -132,6 +132,7 @@ bool    MScore::highlightMore;
 bool    MScore::highlightLyrics;
 bool    MScore::honorEnPassantVisibility;
 
+QColor  MScore::noteEntryInformationColor;
 bool    MScore::noteInputOctaveTendencyIsTopNote;
 bool    MScore::noteInputOctaveUpwardFifth;
 bool    MScore::resetNoteEntryAtSystemOrCourtesy;

--- a/libmscore/mscore.cpp
+++ b/libmscore/mscore.cpp
@@ -133,6 +133,7 @@ bool    MScore::highlightLyrics;
 bool    MScore::honorEnPassantVisibility;
 
 QColor  MScore::noteEntryInformationColor;
+bool    MScore::noteEntryInformationEnabled;
 bool    MScore::noteInputOctaveTendencyIsTopNote;
 bool    MScore::noteInputOctaveUpwardFifth;
 bool    MScore::resetNoteEntryAtSystemOrCourtesy;

--- a/libmscore/mscore.h
+++ b/libmscore/mscore.h
@@ -378,6 +378,7 @@ class MScore {
       static bool   honorEnPassantVisibility;
 
       static QColor noteEntryInformationColor;
+      static bool noteEntryInformationEnabled;
       static bool noteInputOctaveTendencyIsTopNote;
       static bool noteInputOctaveUpwardFifth;
       static bool resetNoteEntryAtSystemOrCourtesy;

--- a/libmscore/mscore.h
+++ b/libmscore/mscore.h
@@ -377,6 +377,7 @@ class MScore {
       static bool   highlightLyrics;
       static bool   honorEnPassantVisibility;
 
+      static QColor noteEntryInformationColor;
       static bool noteInputOctaveTendencyIsTopNote;
       static bool noteInputOctaveUpwardFifth;
       static bool resetNoteEntryAtSystemOrCourtesy;

--- a/libmscore/noteentry.cpp
+++ b/libmscore/noteentry.cpp
@@ -444,6 +444,7 @@ void Score::putNote(const Position& p, bool replace)
             }
       if (cr && !st->isTabStaff(cr->tick()))
             _is.moveToNextInputPos();
+      _is.updateLastPitch(nval.pitch);
       }
 
 //---------------------------------------------------------
@@ -580,6 +581,7 @@ void Score::repitchNote(const Position& p, bool replace)
             next = nextChordRest(next);
       if (next)
             _is.moveInputPos(next->segment());
+      _is.updateLastPitch(note->pitch());
       }
 
 //---------------------------------------------------------

--- a/mscore/events.cpp
+++ b/mscore/events.cpp
@@ -14,6 +14,7 @@
 #include "musescore.h"
 #include "scoreview.h"
 #include "seq.h"
+#include "textcursor.h"
 #include "texttools.h"
 #include "zoombox.h"
 
@@ -1366,6 +1367,10 @@ void ScoreView::changeState(ViewState s)
                   break;
             case ViewState::PLAY:
                   seq->start();
+                  if (_cursor) {
+                        _cursor->accidental = AccidentalType::NONE;
+                        _cursor->duration   = TDuration::DurationType::V_INVALID;
+                        }
                   break;
             case ViewState::ENTRY_PLAY:
                   break;

--- a/mscore/icons.cpp
+++ b/mscore/icons.cpp
@@ -206,6 +206,7 @@ static const char* iconNames[] = {
       "empty.svg",                  // Voice-2
       "empty.svg",                  // Voice-3
       "empty.svg",                  // Voice-4
+      "empty.svg",                  // Note Entry information
       };
 
 //---------------------------------------------------------
@@ -287,6 +288,7 @@ void genIcons()
             case Icons::overrideColorVoice2_ICON:           c = MScore::selectColor[1];               break;
             case Icons::overrideColorVoice3_ICON:           c = MScore::selectColor[2];               break;
             case Icons::overrideColorVoice4_ICON:           c = MScore::selectColor[3];               break;
+            case Icons::overrideColorNoteEntryStatus_ICON:  c = MScore::noteEntryInformationColor;    break;
 
             default:
                   c = MScore::defaultColor;

--- a/mscore/icons.h
+++ b/mscore/icons.h
@@ -99,6 +99,7 @@ enum class Icons : short { Invalid_ICON = -1,
       overrideColorVoice2_ICON,
       overrideColorVoice3_ICON,
       overrideColorVoice4_ICON,
+      overrideColorNoteEntryStatus_ICON,
 
       ICONS
       };

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -333,6 +333,7 @@ const std::list<const char*> MuseScore::_allToggleOptionsMenuEntries {
             "toggle-options-upward-fifth-entry",
             "toggle-options-retain-augmentation-rhythmMode",
             "toggle-options-reset-entry-NewSystemOrCourtesy",
+            "toggle-options-note-entry-information",
 
             "separator-Playback",
             "toggle-options-playback-highlight-notes",
@@ -878,6 +879,8 @@ void MuseScore::populateToggleOptionsMenu()
                         pref = MScore::cursorResetToStart;
                   else if (0==strcmp(option, "mouse-hover"))
                         pref = MScore::hoverColorEnabled;
+                  else if (0==strcmp(option, "note-entry-information"))
+                        pref = MScore::noteEntryInformationEnabled;
                   else if (0==strcmp(option, "noteheads-behind-staff"))
                         pref = MScore::noteheadsBehindStaff;
                   else if (0==strcmp(option, "noteheads-behind-ledger"))

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -537,6 +537,7 @@ void updateExternalValuesFromPreferences() {
       MScore::retainAugmentationInRhythmEntry = preferences.getBool(PREF_SCORE_NOTE_INPUT_RETAIN_AUG_RHYTHM_MODE);
       MScore::fingerTextAutoForwardAlphaNumeric = preferences.getBool(PREF_SCORE_FINGERING_ALPHANUMERIC_AUTOFORWARD);
       MScore::noteEntryInformationColor = preferences.getColor(PREF_SCORE_NOTE_INPUT_ENTRY_STATUS_COLOR);
+      MScore::noteEntryInformationEnabled = preferences.getBool(PREF_SCORE_NOTE_INPUT_ENTRY_STATUS_ENABLE);
 
       MScore::defaultPlayDuration = preferences.getInt(PREF_SCORE_NOTE_DEFAULTPLAYDURATION);
       MScore::panPlayback = preferences.getBool(PREF_APP_PLAYBACK_PANPLAYBACK);

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -321,6 +321,7 @@ const std::list<const char*> MuseScore::_allColorControlMenuEntries {
             "color-override-voice-4",
             "color-override-hover", // Max Alpha: Hover "behind everything", else over everything
             "color-override-cursor",
+            "color-override-note-entry-status",
             };
 
 const std::list<const char*> MuseScore::_allToggleOptionsMenuEntries {
@@ -535,6 +536,8 @@ void updateExternalValuesFromPreferences() {
       MScore::noteInputForceVoice2BeneathVoice1 = preferences.getBool(PREF_SCORE_NOTE_INPUT_FORCE_VOICE2_BELOW);
       MScore::retainAugmentationInRhythmEntry = preferences.getBool(PREF_SCORE_NOTE_INPUT_RETAIN_AUG_RHYTHM_MODE);
       MScore::fingerTextAutoForwardAlphaNumeric = preferences.getBool(PREF_SCORE_FINGERING_ALPHANUMERIC_AUTOFORWARD);
+      MScore::noteEntryInformationColor = preferences.getColor(PREF_SCORE_NOTE_INPUT_ENTRY_STATUS_COLOR);
+
       MScore::defaultPlayDuration = preferences.getInt(PREF_SCORE_NOTE_DEFAULTPLAYDURATION);
       MScore::panPlayback = preferences.getBool(PREF_APP_PLAYBACK_PANPLAYBACK);
       MScore::harmonyPlayDisableCompatibility = preferences.getBool(PREF_SCORE_HARMONY_PLAY_DISABLE_COMPATIBILITY);

--- a/mscore/preferences.cpp
+++ b/mscore/preferences.cpp
@@ -237,6 +237,7 @@ void Preferences::init(bool storeInMemoryOnly)
             {PREF_SCORE_NOTE_INPUT_RESET_PITCH_AT_SYSTEM,          new BoolPreference(false)},
             {PREF_SCORE_NOTE_INPUT_FORCE_VOICE2_BELOW,             new BoolPreference(true)},
             {PREF_SCORE_FINGERING_ALPHANUMERIC_AUTOFORWARD,        new BoolPreference(false)},
+            {PREF_SCORE_NOTE_INPUT_ENTRY_STATUS_COLOR,             new ColorPreference(QColor(255,0,0), true)},
             {PREF_UI_SCORE_DISABLE_NOTE_DRAG_VERTICAL,             new BoolPreference(false)},
             {PREF_UI_SCORE_LASSO_WITHOUT_SHIFT,                    new BoolPreference(true)},
             {PREF_SCORE_STYLE_DEFAULTSTYLEFILE,                    new StringPreference("", false)},

--- a/mscore/preferences.cpp
+++ b/mscore/preferences.cpp
@@ -238,6 +238,7 @@ void Preferences::init(bool storeInMemoryOnly)
             {PREF_SCORE_NOTE_INPUT_FORCE_VOICE2_BELOW,             new BoolPreference(true)},
             {PREF_SCORE_FINGERING_ALPHANUMERIC_AUTOFORWARD,        new BoolPreference(false)},
             {PREF_SCORE_NOTE_INPUT_ENTRY_STATUS_COLOR,             new ColorPreference(QColor(255,0,0), true)},
+            {PREF_SCORE_NOTE_INPUT_ENTRY_STATUS_ENABLE,            new BoolPreference(false)},
             {PREF_UI_SCORE_DISABLE_NOTE_DRAG_VERTICAL,             new BoolPreference(false)},
             {PREF_UI_SCORE_LASSO_WITHOUT_SHIFT,                    new BoolPreference(true)},
             {PREF_SCORE_STYLE_DEFAULTSTYLEFILE,                    new StringPreference("", false)},

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -875,7 +875,11 @@ void ScoreView::moveCursor()
       int staffIdx = track / VOICES;
 
       QColor c(MScore::selectColor[voice]);
-      c.setAlpha(100);
+      c.setAlpha(77);
+
+      _cursor->dots         = is.duration().dots();
+      _cursor->duration     = is.duration();
+      _cursor->accidental   = is.accidentalType();
       _cursor->setColor(c);
       _cursor->setTick(segment->tick());
 
@@ -1523,6 +1527,137 @@ void ScoreView::drawHoverHighlight(QPainter& p, const Element& el)
       }
 
 //---------------------------------------------------------
+//   drawNoteEntryInformation
+//   Indicator manifests toggle information, along with 
+//   last add-pitch direction/interval
+//---------------------------------------------------------
+
+void ScoreView::drawNoteEntryInformation(QPainter& p, const QPointF& pt, int fontSz, bool showIntervals)
+      {
+      QPen pen;
+      pen.setColor(MScore::noteEntryInformationColor);
+      p.setPen(pen);
+      p.setBrush(Qt::NoBrush);
+      QFont font;
+      font.setFamily(ScoreFont::fallbackTextFont());
+      font.setPointSize(fontSz);
+      QFontMetrics fm(font);
+      p.setFont(font);
+
+      qreal toggleX = pt.x();
+      qreal toggleY = pt.y();
+
+      auto is = score()->inputState();
+      auto accidental = is.accidentalType();
+      auto duration = is.duration();
+      auto dots = duration.dots();
+      QString s;
+      if (is.noteEntryMode()) {
+            if (duration.type() != TDuration::DurationType::V_INVALID) {
+                  QPointF pos;
+                  qreal xOff;
+                  qreal yOff;
+                  QString noteWhole  ("");
+                  QString noteHalf   ("");
+                  QString noteQuarter("");
+                  QString note8th    ("");
+                  QString note16th   ("");
+                  QString note32nd   ("");
+                  QString note64th   ("");
+
+                  // Duration (Notehead with flag)
+                  bool flagNote = false;
+                  bool wholeNote = false;
+                  if      (duration == TDuration::DurationType::V_HALF)      s=noteHalf;
+                  else if (duration == TDuration::DurationType::V_QUARTER)   s=noteQuarter;
+                  else if (duration == TDuration::DurationType::V_EIGHTH)  { s=note8th;     flagNote=true;  }
+                  else if (duration == TDuration::DurationType::V_16TH)    { s=note16th;    flagNote=true;  }
+                  else if (duration == TDuration::DurationType::V_32ND)    { s=note32nd;    flagNote=true;  }
+                  else if (duration == TDuration::DurationType::V_64TH)    { s=note64th;    flagNote=true;  }
+                  else if (duration == TDuration::DurationType::V_WHOLE)   { s=noteWhole;   wholeNote=true; }
+
+                  int noteWidth = fm.charWidth(note16th, 0);
+                  pos = QPointF(toggleX - (wholeNote ? noteWidth * 0.10 : 0.0), toggleY);
+                  p.drawText(pos, s);
+
+                  // Augmentation dots
+                  if (dots > 0) {
+                        QString aug = " ";
+                        qreal percent = !flagNote ? 0.90 : 1.10;
+                        xOff = noteWidth * percent;
+                        s.clear();
+                        for (int i = 0; i < dots; ++i)
+                              s += aug;
+
+                        pos = QPointF(toggleX + xOff, toggleY);
+                        p.drawText(pos, s);
+                        }
+
+                  // Accidental
+                  if (accidental != AccidentalType::NONE) {
+                        xOff = (accidental == AccidentalType::FLAT2) ? (-noteWidth * 0.90) : (-noteWidth * 0.55);
+                        yOff = (fm.height() * 0.20);
+                        if (accidental == AccidentalType::FLAT)     s = "";
+                        if (accidental == AccidentalType::FLAT2)    s = "";
+                        if (accidental == AccidentalType::SHARP)    s = "";
+                        if (accidental == AccidentalType::SHARP2)   s = "";
+                        if (accidental == AccidentalType::NATURAL)  s = "";
+
+                        pos = QPointF(toggleX + xOff, toggleY + yOff);
+                        p.drawText(pos, s);
+                        }
+
+                  // Indicate last input to be above or below previous "basis" note
+                  auto lid = is.getLastInputDirection();
+                  if (lid != Direction::AUTO) {
+                        QString upArrow   = "";
+                        QString downArrow = "";
+                        s = (lid == Direction::DOWN ? downArrow : upArrow);
+                        xOff = noteWidth * 1.1;
+                        yOff = -fm.height() * 0.20;
+
+                        pos = QPointF(toggleX + xOff, toggleY + yOff);
+                        p.drawText(pos, s);
+                        }
+
+                  // Indicate octave tendency as top/bottom note (tip is direction)
+                  s = MScore::noteInputOctaveTendencyIsTopNote ? "" : "";
+                  yOff = -fm.height() * 0.45;
+
+                  pos = QPointF(toggleX, toggleY + yOff);
+                  p.drawText(pos, s);
+
+                  if (showIntervals) {
+                        int diff = is.getPitchDelta();
+                        s.clear();
+                        switch (diff) {
+                              case  0:           s = " =";  break;/*"="*/
+                              case  1: case  -1: s = "2";  break;/*"m2"*/ /*"min 2nd"*/
+                              case  2: case  -2: s = " 2";  break;/*"M2"*/ /*"maj"*/
+                              case  3: case  -3: s = "3"; break;/*"m3"*/ /*"min 3rd"*/
+                              case  4: case  -4: s = " 3";  break;/*"M3"*/ /*"maj 3rd"*/
+                              case  5: case  -5: s = " 4";  break;/*"P4"*/ /*"per 4th"*/
+                              case  6: case  -6: s = "4"; break;/*"TT"*/ /*"aug 4th"*/
+                              case  7: case  -7: s = " 5";  break;/*"P5"*/ /*"per 5th"*/
+                              case  8: case  -8: s = "6"; break;/*"m6"*/ /*"min 6th"*/
+                              case  9: case  -9: s = " 6";  break;/*"M6"*/ /*"maj 6th"*/
+                              case 10: case -10: s = "7"; break;/*"m7"*/ /*"min 7th"*/
+                              case 11: case -11: s = " 7";  break;/*"M7"*/ /*"maj 7th"*/
+                              case 12: case -12: s = " 8";  break;/*"P8"*/ /*"per oct"*/
+                              default: s = ""; break;
+                              }
+                        xOff = noteWidth * 1.0;
+                        yOff = -fm.height() * 0.66;
+                        font.setPointSize(int(fontSz/3));
+                        p.setFont(font);
+                        pos = QPointF(toggleX + xOff, toggleY + yOff);
+                        p.drawText(pos, s);
+                        }
+                  }
+            }
+      }
+
+//---------------------------------------------------------
 //   drawElements
 //---------------------------------------------------------
 
@@ -1985,6 +2120,10 @@ void ScoreView::paint(const QRect& r, QPainter& p)
       p.setWorldMatrixEnabled(false);
 
       p.restore();
+
+      // Center-bottom of ScoreView
+      QPointF noteEntryInfoPos(r.width() * 0.5, r.bottom() - 10);
+      drawNoteEntryInformation(p, noteEntryInfoPos,  72, true);
 
       if (MScore::fadeFocus && !hasFocus()) {
             auto w = width();
@@ -4351,6 +4490,8 @@ void ScoreView::endNoteEntry()
       {
       InputState& is = _score->inputState();
       is.setNoteEntryMode(false);
+      is.updateLastInputDirection(Direction::AUTO, 0);
+      is.updateLastPitch(-1);
       if (is.slur()) {
             const std::vector<SpannerSegment*>& el = is.slur()->spannerSegments();
             if (!el.empty())

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -2121,9 +2121,11 @@ void ScoreView::paint(const QRect& r, QPainter& p)
 
       p.restore();
 
-      // Center-bottom of ScoreView
-      QPointF noteEntryInfoPos(r.width() * 0.5, r.bottom() - 10);
-      drawNoteEntryInformation(p, noteEntryInfoPos,  72, true);
+      if (MScore::noteEntryInformationEnabled) {
+            qreal yMargin = 10;
+            QPointF bottomCenterOfScoreView(r.width() * 0.5, r.bottom() - yMargin);
+            drawNoteEntryInformation(p, bottomCenterOfScoreView, 72, true);
+            }
 
       if (MScore::fadeFocus && !hasFocus()) {
             auto w = width();

--- a/mscore/scoreview.h
+++ b/mscore/scoreview.h
@@ -284,6 +284,7 @@ class ScoreView : public QWidget, public MuseScoreView {
 
       void setShadowNote(const QPointF&);
       void drawHoverHighlight(QPainter&, const Element&);
+      void drawNoteEntryInformation(QPainter& p, const QPointF& pt, int fontSz, bool showIntervals);
       void drawElements(QPainter& p,QList<Element*>& el, Element* editElement);
       bool dragTimeAnchorElement(const QPointF& pos);
       bool dragMeasureAnchorElement(const QPointF& pos);

--- a/mscore/shortcut.cpp
+++ b/mscore/shortcut.cpp
@@ -2834,6 +2834,17 @@ Shortcut Shortcut::_sc[] = {
       {
          MsWidget::MAIN_WINDOW,
          STATE_HIDDEN | STATE_NORMAL | STATE_NOTE_ENTRY,
+         "toggle-options-note-entry-information",
+         QT_TRANSLATE_NOOP("action","Show Note Entry information at bottom center of Score View"),
+         QT_TRANSLATE_NOOP("action","Show Note Entry information at bottom center of Score View"),
+         0,
+         Icons::checkmark_ICON,
+         Qt::ApplicationShortcut,
+         ShortcutFlags::A_CHECKABLE
+         },
+      {
+         MsWidget::MAIN_WINDOW,
+         STATE_HIDDEN | STATE_NORMAL | STATE_NOTE_ENTRY,
          "toggle-options-null",
          QT_TRANSLATE_NOOP("action","Options"),
          QT_TRANSLATE_NOOP("action","Options"),

--- a/mscore/shortcut.cpp
+++ b/mscore/shortcut.cpp
@@ -2537,6 +2537,17 @@ Shortcut Shortcut::_sc[] = {
       {
          MsWidget::MAIN_WINDOW,
          STATE_HIDDEN | STATE_NORMAL | STATE_NOTE_ENTRY,
+         "color-override-note-entry-status",
+         QT_TRANSLATE_NOOP("action","Override Color: Note Entry Status"),
+         QT_TRANSLATE_NOOP("action","Override Color: Note Entry Status"),
+         0,
+         Icons::overrideColorNoteEntryStatus_ICON,
+         Qt::WindowShortcut,
+         ShortcutFlags::A_CHECKABLE
+         },
+      {
+         MsWidget::MAIN_WINDOW,
+         STATE_HIDDEN | STATE_NORMAL | STATE_NOTE_ENTRY,
          "toggle-options-single-note-selection-color",
          QT_TRANSLATE_NOOP("action","Selection: One color for all (See Color Options)"),
          QT_TRANSLATE_NOOP("action","Selection: One color for all (See Color Options)"),

--- a/mscore/textcursor.cpp
+++ b/mscore/textcursor.cpp
@@ -24,6 +24,8 @@
 
 #include "scoreview.h"
 
+#include <QPainter>
+
 namespace Ms {
 
 //---------------------------------------------------------
@@ -55,8 +57,9 @@ void PositionCursor::paint(QPainter* p)
       {
       if (!visible())
             return;
+      Score* s = _sv->score();
       QPointF points[3];
-      qreal h = _sv->score()->spatium() * 2;
+      qreal h = s->spatium() * 2;
 
       qreal x = _rect.left();
       qreal y = _rect.top();
@@ -85,15 +88,16 @@ void PositionCursor::paint(QPainter* p)
                   break;
             default:                            // fill the rectangle and add TAB string marks, if required
                   p->fillRect(_rect, color());
-                  if (_sv->score()->noteEntryMode()) {
-                        int         track       = _sv->score()->inputTrack();
+                  if (s->noteEntryMode()) {
+                        int track = s->inputTrack();
                         if (track >= 0) {
-                              Staff*      staff       = _sv->score()->staff(track2staff(track));
-                              const StaffType*  staffType   = staff->staffType(Fraction(0,1));
-                              if (staffType && staffType->group() == StaffGroup::TAB)
-                                    staffType->drawInputStringMarks(p, _sv->score()->inputState().string(),
-                                       track2voice(track), _rect);
+                              Staff* staff = s->staff(track2staff(track));
+                              const StaffType* staffType = staff->staffType(Fraction(0,1));
+                              if (staffType && staffType->group() == StaffGroup::TAB) {
+                                    int voice = track2voice(track);
+                                    staffType->drawInputStringMarks(p, s->inputState().string(), voice, _rect);
                                     }
+                              }
                         }
                   break;
             }

--- a/mscore/textcursor.h
+++ b/mscore/textcursor.h
@@ -14,6 +14,7 @@
 #define __TEXTCURSOR_H__
 
 #include "libmscore/fraction.h"
+#include "libmscore/durationtype.h"
 
 namespace Ms {
 
@@ -58,6 +59,10 @@ class PositionCursor {
       void move(const Fraction& tick);
       void paint(QPainter*);
       QRectF bbox() const;
+
+      int dots = 0;
+      TDuration duration;
+      AccidentalType accidental;
       };
 
 }


### PR DESCRIPTION
Another gimmick, but it can aid in a vertical split-screen when MuseScore is above and a PDF is below in that the status shows:
+ **Accidental state**
+ **Duration state**
+ **Augmentation state**
+ **Octave tendency indicator**:
  **Top-most** note of previous chord is used for octave tendency :
  ![image](https://github.com/user-attachments/assets/493c9309-5d71-400a-9cfd-8f1dc2de61bc)
        **Bottom-most** note of previous chord is used for octave tendency :
        ![image](https://github.com/user-attachments/assets/07f3233e-a235-4f9a-ac8b-6faf43179aa0)


+ Whether the most recent entry entered a note above or below the previous pitch (arrow to right)
+ For the hell of it, shows the interval as 1-7 with flat sign to signify minor (above the arrow to right) 

Theoretically lets the eye not need to move much between source and destination when needing to verify current status or what direction the last entry was

[noteEntryIndicator.webm](https://github.com/user-attachments/assets/91ba4a94-a9bd-480f-84f3-86be77b084c3)


The pitch indicator is not very advanced, so it doesn't work if e.g. the user inserts a note, moves around beyond another set of notes and inserts a note again — it's designed to be "streamlined" during note-entry rather than considering navigational activity.