### PR TITLE
Articulations - New Parameters: Velocity/OnTime/Gate + [Tremolo/Arpeggio] + Grace Articulation

### DIFF
--- a/libmscore/arpeggio.h
+++ b/libmscore/arpeggio.h
@@ -99,6 +99,9 @@ class Arpeggio final : public Element {
       qreal Stretch() const             { return _stretch; }
       void setStretch(qreal val)        { _stretch = val;  }
 
+      bool up() const
+            { return (_arpeggioType != ArpeggioType::DOWN && _arpeggioType != ArpeggioType::DOWN_STRAIGHT); }
+
       QVariant getProperty(Pid propertyId) const override;
       bool setProperty(Pid propertyId, const QVariant&) override;
       QVariant propertyDefault(Pid propertyId) const override;

--- a/libmscore/articulation.cpp
+++ b/libmscore/articulation.cpp
@@ -50,6 +50,7 @@ Articulation::Articulation(Score* s)
       _onTime         = 0;
       _veloOffset     = 0;
       _veloUserOffset = 0;
+      _veloStaff      = 0;
       _ornamentStyle  = MScore::OrnamentStyle::DEFAULT;
       setPlayArticulation(true);
       initElementStyle(&articulationStyle);
@@ -63,6 +64,7 @@ Articulation::Articulation(SymId id, Score* s)
       _onTime         = 0;
       _veloOffset     = 0;
       _veloUserOffset = 0;
+      _veloStaff      = 0;
       }
 
 //---------------------------------------------------------

--- a/libmscore/articulation.cpp
+++ b/libmscore/articulation.cpp
@@ -19,8 +19,10 @@
 #include "stafftype.h"
 #include "undo.h"
 #include "page.h"
+#include "part.h"
 #include "barline.h"
 #include "sym.h"
+#include "instrument.h"
 #include "xml.h"
 
 namespace Ms {
@@ -199,9 +201,23 @@ void Articulation::write(XmlWriter& xml) const
       writeProperty(xml, Pid::DIRECTION);
       xml.tag("subtype", Sym::id2name(_symId));
       writeProperty(xml, Pid::PLAY);
-      writeProperty(xml, Pid::GATE_TIME);
+
+      // don't write gate or velocity of articulation if its value is default respecting the instrument definition:
+      if (ChordRest* cr = chordRest()) {
+            if (Part* p = cr->part()) {
+                  if (Instrument* i = p->instrument(cr->tick())) {
+                        for (const MidiArticulation& a : qAsConst(i->articulation())) {
+                              if (this->name() == a.name) {
+                                    if (this->getGateTime() != a.gateTime)
+                                          writeProperty(xml, Pid::GATE_TIME);
+                                    else if (this->getVelocityOffset() != a.velocity)
+                                          writeProperty(xml, Pid::VELOCITY_OFFSET);
+                                    }
+                              }
+                        }
+                  }
+            }
       writeProperty(xml, Pid::ON_TIME);
-      writeProperty(xml, Pid::VELOCITY_OFFSET);
       writeProperty(xml, Pid::ORNAMENT_STYLE);
       for (const StyledProperty& spp : *styledProperties())
             writeProperty(xml, spp.pid);

--- a/libmscore/articulation.cpp
+++ b/libmscore/articulation.cpp
@@ -42,11 +42,15 @@ static const ElementStyle articulationStyle {
 Articulation::Articulation(Score* s)
    : Element(s, ElementFlag::MOVABLE)
       {
-      _symId         = SymId::noSym;
-      _anchor        = ArticulationAnchor::TOP_STAFF;
-      _direction     = Direction::AUTO;
-      _up            = true;
-      _ornamentStyle = MScore::OrnamentStyle::DEFAULT;
+      _symId          = SymId::noSym;
+      _anchor         = ArticulationAnchor::TOP_STAFF;
+      _direction      = Direction::AUTO;
+      _up             = true;
+      _gateTime       = 0;
+      _onTime         = 0;
+      _veloOffset     = 0;
+      _veloUserOffset = 0;
+      _ornamentStyle  = MScore::OrnamentStyle::DEFAULT;
       setPlayArticulation(true);
       initElementStyle(&articulationStyle);
       }
@@ -55,6 +59,10 @@ Articulation::Articulation(SymId id, Score* s)
    : Articulation(s)
       {
       setSymId(id);
+      _gateTime       = 0;
+      _onTime         = 0;
+      _veloOffset     = 0;
+      _veloUserOffset = 0;
       }
 
 //---------------------------------------------------------
@@ -152,6 +160,12 @@ bool Articulation::readProperties(XmlReader& e)
             ;
       else if (tag == "direction")
             readProperty(e, Pid::DIRECTION);
+      else if (tag == "gateTime")
+            readProperty(e, Pid::GATE_TIME);
+      else if (tag == "onTime")
+            readProperty(e, Pid::ON_TIME);
+      else if (tag == "velocityOffset")
+            readProperty(e, Pid::VELOCITY_OFFSET);
       else if ( tag == "ornamentStyle")
             readProperty(e, Pid::ORNAMENT_STYLE);
       else if ( tag == "play")
@@ -183,6 +197,9 @@ void Articulation::write(XmlWriter& xml) const
       writeProperty(xml, Pid::DIRECTION);
       xml.tag("subtype", Sym::id2name(_symId));
       writeProperty(xml, Pid::PLAY);
+      writeProperty(xml, Pid::GATE_TIME);
+      writeProperty(xml, Pid::ON_TIME);
+      writeProperty(xml, Pid::VELOCITY_OFFSET);
       writeProperty(xml, Pid::ORNAMENT_STYLE);
       for (const StyledProperty& spp : *styledProperties())
             writeProperty(xml, spp.pid);
@@ -312,8 +329,12 @@ QVariant Articulation::getProperty(Pid propertyId) const
             case Pid::SYMBOL:              return QVariant::fromValue(_symId);
             case Pid::DIRECTION:           return QVariant::fromValue<Direction>(direction());
             case Pid::ARTICULATION_ANCHOR: return int(anchor());
+            case Pid::GATE_TIME:           return int(getGateTime());
+            case Pid::ON_TIME:             return int(getOnTime());
+            case Pid::VELOCITY_OFFSET:     return int(getVelocityOffset());
             case Pid::ORNAMENT_STYLE:      return int(ornamentStyle());
             case Pid::PLAY:                return bool(playArticulation());
+
             default:
                   return Element::getProperty(propertyId);
             }
@@ -338,6 +359,15 @@ bool Articulation::setProperty(Pid propertyId, const QVariant& v)
             case Pid::PLAY:
                   setPlayArticulation(v.toBool());
                   break;
+            case Pid::GATE_TIME:
+                  setGateTime(v.toInt());
+                  break;
+            case Pid::ON_TIME:
+                  setOnTime(v.toInt());
+                  break;
+            case Pid::VELOCITY_OFFSET:
+                  setVelocityOffset(v.toInt());
+                  break;
             case Pid::ORNAMENT_STYLE:
                   setOrnamentStyle(MScore::OrnamentStyle(v.toInt()));
                   break;
@@ -357,7 +387,12 @@ QVariant Articulation::propertyDefault(Pid propertyId) const
       switch (propertyId) {
             case Pid::DIRECTION:
                   return QVariant::fromValue<Direction>(Direction::AUTO);
-
+            case Pid::ON_TIME:
+                  return 0;
+            case Pid::GATE_TIME:
+                  return 0;
+            case Pid::VELOCITY_OFFSET:
+                  return 0;
             case Pid::ORNAMENT_STYLE:
                   //return int(score()->style()->ornamentStyle(_ornamentStyle));
                   return int(MScore::OrnamentStyle::DEFAULT);
@@ -569,6 +604,9 @@ void Articulation::resetProperty(Pid id)
       {
       switch (id) {
             case Pid::DIRECTION:
+            case Pid::GATE_TIME:
+            case Pid::ON_TIME:
+            case Pid::VELOCITY_OFFSET:
             case Pid::ORNAMENT_STYLE:
                   setProperty(id, propertyDefault(id));
                   return;

--- a/libmscore/articulation.h
+++ b/libmscore/articulation.h
@@ -65,6 +65,11 @@ class Articulation final : public Element {
       MScore::OrnamentStyle _ornamentStyle;     // for use in ornaments such as trill
       bool _playArticulation;
 
+      int _gateTime, _onTime;
+      int _veloOffset,
+          _veloUserOffset,
+          _veloStaff;
+
       void draw(QPainter*) const;
 
       enum class AnchorGroup {
@@ -113,6 +118,32 @@ class Articulation final : public Element {
       void setUp(bool val);
       void setDirection(Direction d)        { _direction = d;    }
       Direction direction() const           { return _direction; }
+
+      void setGateTime(int val)
+            { _gateTime = val; }
+      int getGateTime() const
+            { return _gateTime; }
+      
+      void setOnTime(int val)
+            { _onTime = val; }
+      int getOnTime() const
+            { return _onTime; }
+
+      void setVelocityOffset(int val) 
+            { _veloOffset = val; }
+      int getVelocityOffset() const 
+            { return _veloOffset; }
+      
+      void setVelocityUserOffset(int val)
+            { _veloUserOffset = val; }
+      int getVelocityUserOffset() const
+            { return _veloUserOffset; }
+      
+      void setStaffDynamic(int val)
+            { _veloStaff = val; }
+      int getStaffDynamic() const
+            { return _veloStaff; }
+
 
       ChordRest* chordRest() const;
       Segment* segment() const;

--- a/libmscore/noteevent.h
+++ b/libmscore/noteevent.h
@@ -26,12 +26,18 @@ class NoteEvent {
       int _pitch;   // relative pitch to note pitch
       int _ontime;  // one unit is 1/1000 of nominal note len
       int _len;     // one unit is 1/1000 of nominal note len
+      int _vOffset; // an attempt to allow variation within tremolos
 
    public:
       constexpr static int NOTE_LENGTH = 1000;
 
-      NoteEvent() : _pitch(0), _ontime(0), _len(NOTE_LENGTH) {}
-      NoteEvent(int a, int b, int c) : _pitch(a), _ontime(b), _len(c) {}
+      NoteEvent() : _pitch(0), _ontime(0), _len(NOTE_LENGTH), _vOffset(0) {}
+      NoteEvent(int pitch, int onTime, int length)
+            : _pitch(pitch), _ontime(onTime), _len(length), _vOffset(0)
+            {}
+      NoteEvent(int pitch, int onTime, int length, int velocityOffset)
+            : _pitch(pitch), _ontime(onTime), _len(length), _vOffset(velocityOffset)
+            {}
 
       void read(XmlReader&);
       void write(XmlWriter&) const;
@@ -40,9 +46,11 @@ class NoteEvent {
       int ontime() const     { return _ontime; }
       int offtime() const    { return _ontime + _len; }
       int len() const        { return _len; }
+      int veloOff() const    { return _vOffset; }
       void setPitch(int v)   { _pitch = v; }
       void setOntime(int v)  { _ontime = v; }
       void setLen(int v)     { _len = v;    }
+      void setVeloOff(int v) { _vOffset = v;}
       bool operator==(const NoteEvent&) const;
       };
 

--- a/libmscore/property.cpp
+++ b/libmscore/property.cpp
@@ -203,6 +203,10 @@ static constexpr PropertyMetaData propertyList[] = {
       { Pid::LASSO_SIZE,              false, 0,                       P_TYPE::SIZE_MM,             DUMMY_QT_TRANSLATE_NOOP("propertyName", "lasso size")       },
       { Pid::TIME_STRETCH,            true,  "timeStretch",           P_TYPE::REAL,                DUMMY_QT_TRANSLATE_NOOP("propertyName", "time stretch")     },
       { Pid::ORNAMENT_STYLE,          true,  "ornamentStyle",         P_TYPE::ORNAMENT_STYLE,      DUMMY_QT_TRANSLATE_NOOP("propertyName", "ornament style")   },
+      { Pid::GATE_TIME,               true,  "gateTime",              P_TYPE::GATE_TIME,           DUMMY_QT_TRANSLATE_NOOP("propertyName", "gate time")        },
+      { Pid::ON_TIME,                 true,  "onTime",                P_TYPE::ON_TIME,             DUMMY_QT_TRANSLATE_NOOP("propertyName", "on time")          },
+      { Pid::VELOCITY_OFFSET,         true,  "velocityOffset",        P_TYPE::VELOCITY_OFFSET,     DUMMY_QT_TRANSLATE_NOOP("propertyName", "velocity offset")  },
+
 
       { Pid::TIMESIG,                 false, "timesig",               P_TYPE::FRACTION,            DUMMY_QT_TRANSLATE_NOOP("propertyName", "time signature")   },
       { Pid::TIMESIG_GLOBAL,          false, 0,                       P_TYPE::FRACTION,            DUMMY_QT_TRANSLATE_NOOP("propertyName", "global time signature") },
@@ -441,6 +445,9 @@ QVariant propertyFromString(Pid id, QString value)
                   return QVariant(bool(value.toInt()));
             case P_TYPE::ZERO_INT:
             case P_TYPE::INT:
+            case P_TYPE::GATE_TIME:
+            case P_TYPE::ON_TIME:
+            case P_TYPE::VELOCITY_OFFSET:
                   return QVariant(value.toInt());
             case P_TYPE::REAL:
             case P_TYPE::SPATIUM:
@@ -637,6 +644,9 @@ QVariant readProperty(Pid id, XmlReader& e)
             case P_TYPE::BOOL:
                   return QVariant(bool(e.readInt()));
             case P_TYPE::ZERO_INT:
+            case P_TYPE::GATE_TIME:
+            case P_TYPE::ON_TIME:
+            case P_TYPE::VELOCITY_OFFSET:
             case P_TYPE::INT:
                   return QVariant(e.readInt());
             case P_TYPE::REAL:
@@ -729,6 +739,9 @@ QString propertyToString(Pid id, QVariant value, bool mscx)
             case P_TYPE::BOOL:
             case P_TYPE::INT:
             case P_TYPE::ZERO_INT:
+            case P_TYPE::GATE_TIME:
+            case P_TYPE::ON_TIME:
+            case P_TYPE::VELOCITY_OFFSET:
                   return QString::number(value.toInt());
             case P_TYPE::REAL:
                   return QString::number(value.value<double>());

--- a/libmscore/property.h
+++ b/libmscore/property.h
@@ -208,6 +208,9 @@ enum class Pid {
       LASSO_SIZE,
       TIME_STRETCH,
       ORNAMENT_STYLE,
+      GATE_TIME,
+      ON_TIME,
+      VELOCITY_OFFSET,
 
       TIMESIG,
       TIMESIG_GLOBAL,
@@ -393,6 +396,9 @@ enum class P_TYPE : char {
       DIRECTION,      // enum class Direction
       DIRECTION_H,    // enum class MScore::DirectionH
       ORNAMENT_STYLE, // enum class MScore::OrnamentStyle
+      GATE_TIME,
+      ON_TIME,
+      VELOCITY_OFFSET,
       TDURATION,
       LAYOUT_BREAK,
       VALUE_TYPE,

--- a/libmscore/rendermidi.cpp
+++ b/libmscore/rendermidi.cpp
@@ -1310,7 +1310,11 @@ const Drumset* getDrumset(const Chord* chord)
 //   renderTremolo
 //---------------------------------------------------------
 
-void renderTremolo(Chord* chord, QList<NoteEventList>& ell, int arpeggioDelta, int arpeggio2Delta, int gateTime1, int gateTime2, int vOff1, int vOff2)
+void renderTremolo(Chord* chord, QList<NoteEventList>& ell,
+                   int arpeggioDelta, int arpeggio2Delta,
+                   int onTime1, int onTime2,
+                   int gateTime1, int gateTime2,
+                   int vOff1, int vOff2)
       {
       size_t firstChordNoteCount = chord->notes().size();
       Tremolo* tremolo = chord->tremolo();
@@ -1348,8 +1352,18 @@ void renderTremolo(Chord* chord, QList<NoteEventList>& ell, int arpeggioDelta, i
 
                   int totalTicks = 2 * chord->ticks().ticks();
                   int n  = (totalTicks / t);
+                  int div = n;
                       n /= 2;
                   int l  = (2000 * t) / totalTicks;
+
+                  // Second onTime didn't get accumulations through createPlayEvents since it's
+                  // synthetically applied through the first chord
+                  onTime2 *= 10;
+                  onTime1 /= n;
+                  onTime2 /= n;
+
+                  arpeggioDelta  /= (onTime1 != 0) ? div : 1;
+                  arpeggio2Delta /= (onTime2 != 0) ? div : 1;
 
                   int firstChordIdx   = chord1ArpDown ? firstChordNoteCount  - 1 : 0;
                   int secondChordIdx  = chord2ArpDown ? secondChordNoteCount - 1 : 0;
@@ -1373,9 +1387,10 @@ void renderTremolo(Chord* chord, QList<NoteEventList>& ell, int arpeggioDelta, i
                               }
 
                         int firstArpDelta
-                              = arpeggioDelta  * startFirstChord  + (firstChordStep * arpeggioDelta * k);
+                              = onTime1 + (arpeggioDelta  * startFirstChord)  + (firstChordStep * arpeggioDelta * k);
                         int secondArpDelta
-                              = arpeggio2Delta * startSecondChord + (secondChordStep * arpeggio2Delta * k);
+                              = onTime2 + (arpeggio2Delta * startSecondChord) + (secondChordStep * arpeggio2Delta * k);
+
                         if (k < firstChordNoteCount && k < secondChordNoteCount) {
                               // both chords have note
                               int p1 = chord->notes()[k]->pitch();
@@ -2078,13 +2093,14 @@ bool graceNotesMerged(Chord* chord)
 //   renderChordArticulation
 //---------------------------------------------------------
 
-void renderChordArticulation(Chord* chord, QList<NoteEventList>& ell, int& gateTime, int& velocityOffset)
+void renderChordArticulation(Chord* chord, QList<NoteEventList>& ell, int& onTime, int& gateTime, int& velocityOffset)
       {
       Segment* seg = chord->segment();
       Instrument* instr = chord->part()->instrument(seg->tick());
       int channel  = 0;  // note->subchannel();
       std::vector<Articulation*> articulationsRendered;
       signed int gateSum = 0;
+      signed int onSum = 0;
       for (unsigned k = 0; k < chord->notes().size(); ++k) {
             NoteEventList* events = &ell[k];
             Note *note = chord->notes()[k];
@@ -2117,6 +2133,7 @@ void renderChordArticulation(Chord* chord, QList<NoteEventList>& ell, int& gateT
                               Fraction noteTick       = chord->tick();
                               qreal velocityMultiplier = instr->getVelocityMultiplier(a->articulationName());
 
+                              int storedOnTime                 = a->getOnTime();
                               int storedGateTime               = a->getGateTime();
                               int storedArticulationDelta      = a->getVelocityOffset();
                               int storedUserVelocityDelta      = a->getVelocityUserOffset();
@@ -2138,6 +2155,7 @@ void renderChordArticulation(Chord* chord, QList<NoteEventList>& ell, int& gateT
                                     }
 
                               gateSum += (-100 + gateTime);
+                              onSum += storedOnTime;
 
                               //  _  _  ____  __    _____  ___  ____  ____  _  _
                               // ( \/ )( ___)(  )  (  _  )/ __)(_  _)(_  _)( \/ )
@@ -2182,6 +2200,8 @@ void renderChordArticulation(Chord* chord, QList<NoteEventList>& ell, int& gateT
                         }
                   }
             }
+      // Accumulate ontime
+      onTime += onSum;
       }
 
 //---------------------------------------------------------
@@ -2231,15 +2251,18 @@ static QList<NoteEventList> renderChord(Chord* chord, int gateTime, int ontime, 
       int velocityOffset2 = 0;
       bool hasArticulations = !chord->articulations().isEmpty();
 
-      renderChordArticulation(chord, ell, gateTime, velocityOffset1);
+      int articulationOnTime1 = ontime;
+      int articulationOnTime2 = 0;
+
+      renderChordArticulation(chord, ell, articulationOnTime1, gateTime, velocityOffset1);
+      Tremolo* tremolo = chord->tremolo();
+      bool twoChordTremolo = tremolo && (chord->tremoloChordType() != TremoloChordType::TremoloSingle);
+      bool firstOfTremolo = (chord->tremoloChordType() == TremoloChordType::TremoloFirstNote);
 
       if (arpeggio) {
             arpeggioDelta = renderArpeggio(chord, ell, ontime);
             }
 
-      Tremolo* tremolo = chord->tremolo();
-      bool twoChordTremolo = tremolo && (chord->tremoloChordType() != TremoloChordType::TremoloSingle);
-      bool firstOfTremolo = (chord->tremoloChordType() == TremoloChordType::TremoloFirstNote);
       if (tremolo) {
             if (firstOfTremolo) {
                   if (Chord* secondChord = tremolo->chord2()) {
@@ -2249,11 +2272,11 @@ static QList<NoteEventList> renderChord(Chord* chord, int gateTime, int ontime, 
                                     ell2.append(NoteEventList());
                                     }
                               // Obtain gate/velocity from articulation
-                              renderChordArticulation(secondChord, ell2, gateTime2, velocityOffset2);
+                              renderChordArticulation(secondChord, ell2, articulationOnTime2, gateTime2, velocityOffset2);
 
                               if (secondChord->arpeggio() && secondChord->arpeggio()->playArpeggio()) {
                                     // Obtain arpeggio delta
-                                    arpeggio2Delta = renderArpeggio(secondChord, ell2, ontime);
+                                    arpeggio2Delta = renderArpeggio(secondChord, ell2, articulationOnTime2);
                                     }
                               }
                         }
@@ -2261,6 +2284,7 @@ static QList<NoteEventList> renderChord(Chord* chord, int gateTime, int ontime, 
 
             renderTremolo(chord, ell,
                           arpeggioDelta, arpeggio2Delta,
+                          articulationOnTime1, articulationOnTime2,
                           gateTime, gateTime2,
                           velocityOffset1, velocityOffset2);
             }

--- a/libmscore/rendermidi.cpp
+++ b/libmscore/rendermidi.cpp
@@ -313,6 +313,7 @@ static void collectNote(EventMap* events, int channel, const Note* note, qreal v
             return;
 
       Chord* chord = note->chord();
+      bool isGrace = false;
 
       int staffIdx = staff->idx();
       int ticks;
@@ -320,6 +321,7 @@ static void collectNote(EventMap* events, int channel, const Note* note, qreal v
       if (chord->isGrace()) {
             Q_ASSERT( !graceNotesMerged(chord)); // this function should not be called on a grace note if grace notes are merged
             chord = toChord(chord->parent());
+            isGrace = true;
             }
 
       ticks = chord->actualTicks().ticks(); // ticks of the actual note
@@ -378,8 +380,9 @@ static void collectNote(EventMap* events, int channel, const Note* note, qreal v
 
             // Get the velocity used for this note from the staff
             // This allows correct playback of tremolos even without SND enabled.
-            int velo = 0;
             Fraction nonUnwoundTick = Fraction::fromTicks(on - tickOffset);
+            const int staffVelocity = staff->velocities().val(nonUnwoundTick);
+            int velo = 0;
             int articulationVelocity = 0;
             if (config.useSND) {
                   switch (config.method) {
@@ -388,12 +391,12 @@ static void collectNote(EventMap* events, int channel, const Note* note, qreal v
                               break;
                         case DynamicsRenderMethod::SEG_START:
                         default:
-                              velo = staff->velocities().val(nonUnwoundTick);
+                              velo = staffVelocity;
                               break;
                         }
                   }
             else {
-                  velo = staff->velocities().val(nonUnwoundTick);
+                  velo = staffVelocity;
                   for (Articulation* a : chord->articulations()) {
                         bool rendered
                               = std::find(articulationsRendered.begin(),
@@ -415,6 +418,12 @@ static void collectNote(EventMap* events, int channel, const Note* note, qreal v
             int veloDelta = !doubleChordTrem ? articulationVelocity : e.veloOff();
             velo += veloDelta;
             velo += note->veloOffset();
+
+            if (isGrace) {
+                  // Use grace note's velocity from [Score::createGraceNotesPlayEvents] rather than
+                  // the above calculation of parent chord
+                  velo = staffVelocity + e.veloOff();
+                  }
 
             // Velocity offset per-note is applied within playNote:
             playNote(events, note, channel, p, qBound(1, velo, 127), on, off, staffIdx);
@@ -2362,9 +2371,13 @@ void Score::createGraceNotesPlayEvents(const Fraction& tick, Chord* chord, int& 
             QList<NoteEventList> el;
             Chord* gc = gnb.at(i);
             size_t nn = gc->notes().size();
+            int velocityOffset = 0;
+            for (Articulation* a : gc->articulations()) {
+                  velocityOffset += a->getVelocityOffset();
+                  }
             for (unsigned ii = 0; ii < nn; ++ii) {
                   NoteEventList nel;
-                  nel.append(NoteEvent(0, on, graceDuration));
+                  nel.append(NoteEvent(0, on, graceDuration, velocityOffset));
                   el.append(nel);
                   }
 

--- a/libmscore/rendermidi.cpp
+++ b/libmscore/rendermidi.cpp
@@ -311,6 +311,7 @@ static void collectNote(EventMap* events, int channel, const Note* note, qreal v
       {
       if (!note->play() || note->hidden())      // do not play overlapping notes
             return;
+
       Chord* chord = note->chord();
 
       int staffIdx = staff->idx();
@@ -370,6 +371,7 @@ static void collectNote(EventMap* events, int channel, const Note* note, qreal v
                   p = 127;
             int on  = tick1 + (ticks * e.ontime())/1000;
             int off = on + (ticks * e.len())/1000 - 1;
+
             if (tieFor && i == nels - 1)
                   off += tieLen;
 
@@ -377,6 +379,7 @@ static void collectNote(EventMap* events, int channel, const Note* note, qreal v
             // This allows correct playback of tremolos even without SND enabled.
             int velo;
             Fraction nonUnwoundTick = Fraction::fromTicks(on - tickOffset);
+            int articulationVelocity = 0;
             if (config.useSND) {
                   switch (config.method) {
                         case DynamicsRenderMethod::FIXED_MAX:
@@ -390,9 +393,21 @@ static void collectNote(EventMap* events, int channel, const Note* note, qreal v
                   }
             else {
                   velo = staff->velocities().val(nonUnwoundTick);
+                  for (Articulation* a : chord->articulations()) {
+                        // TODO: Can't accumulate multi articulations easily here
+                        articulationVelocity = a->getVelocityOffset();
+                        }
                   }
 
-            velo *= velocityMultiplier;
+            velo *= velocityMultiplier; // e.g. * 1.5
+
+            Tremolo* tremolo = (note->chord() ? note->chord()->tremolo() : nullptr);
+            bool doubleChordTrem = tremolo && (chord->tremoloChordType() != TremoloChordType::TremoloSingle);
+
+            int veloDelta = !doubleChordTrem ? articulationVelocity : e.veloOff();
+            velo += veloDelta;
+            velo += note->veloOffset();
+
             playNote(events, note, channel, p, qBound(1, velo, 127), on, off, staffIdx);
             }
 
@@ -1277,15 +1292,13 @@ const Drumset* getDrumset(const Chord* chord)
 //   renderTremolo
 //---------------------------------------------------------
 
-void renderTremolo(Chord* chord, QList<NoteEventList>& ell)
+void renderTremolo(Chord* chord, QList<NoteEventList>& ell, int arpeggioDelta, int arpeggio2Delta, int gateTime1, int gateTime2, int vOff1, int vOff2)
       {
-      Segment* seg = chord->segment();
+      size_t firstChordNoteCount = chord->notes().size();
       Tremolo* tremolo = chord->tremolo();
-      int notes = int(chord->notes().size());
 
       // check if tremolo was rendered before for drum staff
-      const Drumset* ds = getDrumset(chord);
-      if (ds) {
+      if (const Drumset* ds = getDrumset(chord)) {
             for (Note* n : chord->notes()) {
                   DrumInstrumentVariant div = ds->findVariant(n->pitch(), chord->articulations(), chord->tremolo());
                   if (div.pitch != INVALID_PITCH && div.tremolo == tremolo->tremoloType())
@@ -1302,34 +1315,36 @@ void renderTremolo(Chord* chord, QList<NoteEventList>& ell)
             int t = MScore::division / (1 << (tremolo->lines() + chord->durationType().hooks()));
             if (t == 0) // avoid crash on very short tremolo
                   t = 1;
-            SegmentType st = SegmentType::ChordRest;
-            Segment* seg2 = seg->next(st);
-            int track = chord->track();
-            while (seg2 && !seg2->element(track))
-                  seg2 = seg2->next(st);
+            if (Chord* chord2 = tremolo->chord2()) {
 
-            if (!seg2)
-                  return;
+                  Arpeggio* chord1Arp     = chord->arpeggio();
+                  bool chord1ArpDown = chord1Arp && !chord1Arp->up();
+                  Arpeggio* chord2Arp     = chord2->arpeggio();
+                  bool chord2ArpDown = chord2Arp && !chord2Arp->up();
 
-            Element* s2El = seg2->element(track);
-            if (s2El) {
-                  if (!s2El->isChord())
-                        return;
-                  }
-            else
-                  return;
+                  size_t secondChordNoteCount
+                        = chord2->notes().size();
 
-            Chord* c2 = toChord(s2El);
-            if (c2->type() == ElementType::CHORD) {
-                  int notes2 = int(c2->notes().size());
-                  int tnotes = qMax(notes, notes2);
-                  int tticks = chord->ticks().ticks() * 2; // use twice the size
-                  int n = tticks / t;
-                  n /= 2;
-                  int l = 2000 * t / tticks;
-                  for (int k = 0; k < tnotes; ++k) {
+                  size_t maxNoteCount
+                        = std::max(firstChordNoteCount, secondChordNoteCount);
+
+                  int totalTicks = 2 * chord->ticks().ticks();
+                  int n  = (totalTicks / t);
+                      n /= 2;
+                  int l  = (2000 * t) / totalTicks;
+
+                  int firstChordIdx   = chord1ArpDown ? firstChordNoteCount  - 1 : 0;
+                  int secondChordIdx  = chord2ArpDown ? secondChordNoteCount - 1 : 0;
+                  int firstChordStep  = chord1ArpDown ? -1 : +1;
+                  int secondChordStep = chord2ArpDown ? -1 : +1;
+
+                  int startFirstChord  = chord1ArpDown ? firstChordNoteCount  - 1 : 0;
+                  int startSecondChord = chord2ArpDown ? secondChordNoteCount - 1 : 0;
+
+                  for (size_t k = 0; k < maxNoteCount; ++k) {
                         NoteEventList* events;
-                        if (k < notes) {
+
+                        if (k < firstChordNoteCount) {
                               // first chord has note
                               events = &ell[k];
                               events->clear();
@@ -1338,29 +1353,68 @@ void renderTremolo(Chord* chord, QList<NoteEventList>& ell)
                               // otherwise reuse note 0
                               events = &ell[0];
                               }
-                        if (k < notes && k < notes2) {
+
+                        int firstArpDelta
+                              = arpeggioDelta  * startFirstChord  + (firstChordStep * arpeggioDelta * k);
+                        int secondArpDelta
+                              = arpeggio2Delta * startSecondChord + (secondChordStep * arpeggio2Delta * k);
+                        if (k < firstChordNoteCount && k < secondChordNoteCount) {
                               // both chords have note
                               int p1 = chord->notes()[k]->pitch();
-                              int p2 = c2->notes()[k]->pitch();
-                              int dpitch = p2 - p1;
+                              int p2 = chord2->notes()[k]->pitch();
+                              int pitchDelta = p2 - p1;
                               for (int i = 0; i < n; ++i) {
-                                    events->append(NoteEvent(0, l * i * 2, l));
-                                    events->append(NoteEvent(dpitch, l * i * 2 + l, l));
+                                    int firstChordOnTime  = l * i * 2;
+                                    int secondChordOnTime = firstChordOnTime + l;
+
+                                    firstChordOnTime  += firstArpDelta;
+                                    secondChordOnTime += secondArpDelta;
+
+                                    int lenFirst  = l - firstArpDelta;
+                                    int lenSecond = l - secondArpDelta;
+
+                                    events->append(NoteEvent(0, firstChordOnTime, lenFirst, vOff1));
+                                          auto& e = events->back();
+                                          e.setLen( (e.len() * gateTime1) / 100);
+
+                                    events->append(NoteEvent(pitchDelta, secondChordOnTime, lenSecond, vOff2));
+                                          auto& e2 = events->back();
+                                          e2.setLen(e2.len() * gateTime2 / 100);
                                     }
+                              firstChordIdx  += firstChordStep;
+                              secondChordIdx += secondChordStep;
                               }
-                        else if (k < notes) {
+                        else if (k < firstChordNoteCount) {
                               // only first chord has note
-                              for (int i = 0; i < n; ++i)
-                                    events->append(NoteEvent(0, l * i * 2, l));
+                              for (int i = 0; i < n; ++i) {
+                                    int onTime = l * i * 2;
+                                    int delta = firstArpDelta;
+                                    onTime += delta;
+                                    int lenFirst = l - delta;
+
+                                    events->append(NoteEvent(0, onTime, lenFirst, vOff1));
+                                    auto& e = events->back();
+                                          e.setLen( (e.len() * gateTime1) / 100);
+                                    }
+                              firstChordIdx++;
                               }
                         else {
                               // only second chord has note
                               // reuse note 0 of first chord
                               int p1 = chord->notes()[0]->pitch();
-                              int p2 = c2->notes()[k]->pitch();
-                              int dpitch = p2-p1;
-                              for (int i = 0; i < n; ++i)
-                                    events->append(NoteEvent(dpitch, l * i * 2 + l, l));
+                              int p2 = chord2->notes()[k]->pitch();
+                              int pitchDelta = p2-p1;
+                              for (int i = 0; i < n; ++i) {
+                                    int onTime = l * i * 2 + l;
+                                    int delta = secondArpDelta;
+                                    onTime += delta;
+                                    int lenSecond = l - delta;
+
+                                    events->append(NoteEvent(pitchDelta, onTime, lenSecond, vOff2));
+                                    auto& e2 = events->back();
+                                          e2.setLen(e2.len() * gateTime2 / 100);
+                                    }
+                              secondChordIdx++;
                               }
                         }
                   }
@@ -1368,7 +1422,8 @@ void renderTremolo(Chord* chord, QList<NoteEventList>& ell)
                   qDebug("Chord::renderTremolo: cannot find 2. chord");
             }
       else if (chord->tremoloChordType() == TremoloChordType::TremoloSecondNote) {
-            for (int k = 0; k < notes; ++k) {
+            // All note events for tremolo were generated during first chord rendering
+            for (size_t k = 0; k < firstChordNoteCount; ++k) {
                   NoteEventList* events = &(ell)[k];
                   events->clear();
                   }
@@ -1379,7 +1434,7 @@ void renderTremolo(Chord* chord, QList<NoteEventList>& ell)
                   t = 1;
             int n = chord->ticks().ticks() / t;
             int l = 1000 / n;
-            for (int k = 0; k < notes; ++k) {
+            for (size_t k = 0; k < firstChordNoteCount; ++k) {
                   NoteEventList* events = &(ell)[k];
                   events->clear();
                   for (int i = 0; i < n; ++i)
@@ -1392,36 +1447,46 @@ void renderTremolo(Chord* chord, QList<NoteEventList>& ell)
 //   renderArpeggio
 //---------------------------------------------------------
 
-void renderArpeggio(Chord *chord, QList<NoteEventList> & ell)
+// "Refactored"
+
+int renderArpeggio(Chord *chord, QList<NoteEventList> & ell)
       {
-      int notes = int(chord->notes().size());
-      int l = 64;
-      while (l && (l * notes > chord->upNote()->playTicks()))
-            l = 2*l / 3;
-      int start, end, step;
-      bool up = chord->arpeggio()->arpeggioType() != ArpeggioType::DOWN && chord->arpeggio()->arpeggioType() != ArpeggioType::DOWN_STRAIGHT;
-      if (up) {
-            start = 0;
-            end   = notes;
-            step  = 1;
-            }
-      else {
-            start = notes - 1;
-            end   = -1;
-            step  = -1;
-            }
-      int j = 0;
-      for (int i = start; i != end; i += step) {
-            NoteEventList* events = &(ell)[i];
+      Arpeggio* arp = chord->arpeggio();
+      bool isUp = arp->up();
+      size_t noteCount = chord->notes().size();
+      size_t playTicks = chord->upNote()->playTicks();
+      int chordTick = chord->tick().ticks();
+      int fullLength = 1000;
+      int lengthFactor = 64;
+
+      while (lengthFactor && (lengthFactor * noteCount > playTicks))
+            lengthFactor *= 2/3;
+
+      qreal chordTempo = chord->score()->tempomap()->tempo(chordTick);
+      double tempoRatio = chordTempo / Score::defaultTempo();
+      int start = isUp ? 0         : noteCount - 1;
+      int end   = isUp ? noteCount : -1;
+      int step  = isUp ? +1        : -1;
+      int iteration = 0;
+      int delta     = 0;
+      qreal stretch = arp->Stretch();
+
+      for (int noteIndex = start; noteIndex != end; noteIndex += step) {
+            NoteEventList* events = &(ell)[noteIndex];
             events->clear();
 
-            auto tempoRatio = chord->score()->tempomap()->tempo(chord->tick().ticks()) / Score::defaultTempo();
-            int ot = (l * j * 1000) / chord->upNote()->playTicks() *
-               tempoRatio * chord->arpeggio()->Stretch();
+            int onTime  = (iteration * lengthFactor * fullLength) / playTicks;
+                onTime *= (tempoRatio * stretch);
 
-            events->append(NoteEvent(0, ot, 1000 - ot));
-            j++;
+            if (noteIndex == (start + step))
+                  delta = onTime;
+
+            int pitch = 0;
+            int noteLength = fullLength - onTime;
+            events->append(NoteEvent(pitch, onTime, noteLength));
+            iteration++;
             }
+      return delta;
       }
 
 //---------------------------------------------------------
@@ -1996,7 +2061,7 @@ bool graceNotesMerged(Chord* chord)
 //   renderChordArticulation
 //---------------------------------------------------------
 
-void renderChordArticulation(Chord* chord, QList<NoteEventList> & ell, int & gateTime)
+void renderChordArticulation(Chord* chord, QList<NoteEventList> & ell, int & gateTime, int& velocityOffset)
       {
       Segment* seg = chord->segment();
       Instrument* instr = chord->part()->instrument(seg->tick());
@@ -2016,8 +2081,75 @@ void renderChordArticulation(Chord* chord, QList<NoteEventList> & ell, int & gat
                   for (Articulation*& a : chord->articulations()) {
                         if (!a->playArticulation())
                               continue;
-                        if (!renderNoteArticulation(events, note, false, a->symId(), a->ornamentStyle()))
+                        if (!renderNoteArticulation(events, note, false, a->symId(), a->ornamentStyle())) {
+                              // NOTE: Instrument definition to Articulation Definition occurs here: (e.g. 95 to 50)
                               instr->updateGateTime(&gateTime, channel, a->articulationName());
+
+                              // NOTE: PRE alterations can and will override gate/onTime changes made here
+                              Fraction noteTick       = chord->tick();
+                              qreal velocityMultiplier = instr->getVelocityMultiplier(a->articulationName());
+
+                              int storedGateTime               = a->getGateTime();
+                              int storedArticulationDelta      = a->getVelocityOffset();
+                              int storedUserVelocityDelta      = a->getVelocityUserOffset();
+                              int storedStaffDynamic           = a->getStaffDynamic();
+
+                              int currentStaffVelocity         = chord->staff()->velocities().val(noteTick);
+                              int finalDefaultVelocity         = currentStaffVelocity * velocityMultiplier;
+                              int calculatedArticulationDelta  = std::abs(finalDefaultVelocity - currentStaffVelocity);
+
+                              bool initializeGateInspectorValue
+                                    = (storedGateTime == 0);
+
+                              if (initializeGateInspectorValue) {
+                                    a->setGateTime(gateTime);
+                                    }
+
+                              else { // Conform to Inspector value
+                                    gateTime = storedGateTime;
+                                    }
+
+                              //  _  _  ____  __    _____  ___  ____  ____  _  _
+                              // ( \/ )( ___)(  )  (  _  )/ __)(_  _)(_  _)( \/ )
+                              //  \  /  )__)  )(__  )(_)(( (__  _)(_   )(   \  /
+                              //   \/  (____)(____)(_____)\___)(____) (__)  (__)
+                              //
+
+                              int calculatedUserVelocityDelta
+                                    = (storedArticulationDelta - calculatedArticulationDelta);
+                              bool uninitializedArticulationVelocity
+                                    = (storedArticulationDelta == 0);
+                              bool velocityDeltaHasChanged
+                                    = (storedArticulationDelta != calculatedArticulationDelta);
+
+                              if (uninitializedArticulationVelocity) {
+                                    calculatedUserVelocityDelta = 0;
+                                    }
+
+                              else if (velocityDeltaHasChanged) {
+                                    bool staffDynamicsHaveChanged
+                                          = (storedStaffDynamic != currentStaffVelocity);
+                                    if (staffDynamicsHaveChanged) {
+                                          calculatedUserVelocityDelta = storedUserVelocityDelta;
+                                          }
+                                    }
+
+                              int finalVelocity = (storedStaffDynamic == 0)
+                                          ? storedArticulationDelta // Loading score instead of user-change
+                                          : calculatedArticulationDelta + calculatedUserVelocityDelta;
+
+                              a->setVelocityOffset
+                                    (finalVelocity);
+                              a->setVelocityUserOffset
+                                    (calculatedUserVelocityDelta);
+                              a->setStaffDynamic
+                                    (currentStaffVelocity);
+
+                              // TODO: add multiple articulations. For now, this gives errors because cycling through
+                              // notes so there are extra cycles for no reason... Just use the topMost one then for now
+                              //
+                              velocityOffset = finalVelocity;
+                              }
                         }
                   }
             }
@@ -2057,39 +2189,82 @@ static QList<NoteEventList> renderChord(Chord* chord, int gateTime, int ontime, 
       if (chord->notes().empty())
             return ell;
 
-      size_t notes = chord->notes().size();
-      for (size_t i = 0; i < notes; ++i)
+      size_t notesCount = chord->notes().size();
+      for (size_t i = 0; i < notesCount; ++i)
             ell.append(NoteEventList());
 
-      bool arpeggio = false;
-      if (chord->tremolo()) {
-            renderTremolo(chord, ell);
+      bool arpeggio      = (chord->arpeggio() && chord->arpeggio()->playArpeggio());
+      int arpeggioDelta  = 0;
+      int arpeggio2Delta = 0;
+
+      int gateTime2 = gateTime;
+      int velocityOffset1 = 0;
+      int velocityOffset2 = 0;
+      bool hasArticulations = !chord->articulations().isEmpty();
+
+      renderChordArticulation(chord, ell, gateTime, velocityOffset1);
+
+      if (arpeggio) {
+            arpeggioDelta = renderArpeggio(chord, ell);
             }
-      else if (chord->arpeggio() && chord->arpeggio()->playArpeggio()) {
-            renderArpeggio(chord, ell);
-            arpeggio = true;
+
+      Tremolo* tremolo = chord->tremolo();
+      bool twoChordTremolo = tremolo && (chord->tremoloChordType() != TremoloChordType::TremoloSingle);
+      bool firstOfTremolo = (chord->tremoloChordType() == TremoloChordType::TremoloFirstNote);
+      if (tremolo) {
+            if (firstOfTremolo) {
+                  if (Chord* secondChord = tremolo->chord2()) {
+                        QList<NoteEventList> ell2;
+                        if (!secondChord->notes().empty()) {
+                              for (size_t i = 0; i < secondChord->notes().size(); ++i) {
+                                    ell2.append(NoteEventList());
+                                    }
+                              // Obtain gate/velocity from articulation
+                              renderChordArticulation(secondChord, ell2, gateTime2, velocityOffset2);
+
+                              if (secondChord->arpeggio() && secondChord->arpeggio()->playArpeggio()) {
+                                    // Obtain arpeggio delta
+                                    arpeggio2Delta = renderArpeggio(secondChord, ell2);
+                                    }
+                              }
+                        }
+                  }
+
+            renderTremolo(chord, ell,
+                          arpeggioDelta, arpeggio2Delta,
+                          gateTime, gateTime2,
+                          velocityOffset1, velocityOffset2);
             }
-      else
-            renderChordArticulation(chord, ell, gateTime);
+
+      bool notSecondOfTremolo  = (chord->tremoloChordType() != TremoloChordType::TremoloSecondNote);
+      bool graceNotesAfter = (trailtime != 0);
 
       // Check each note and apply gateTime
-      for (unsigned i = 0; i < notes; ++i) {
+      // Arpeggios allow for staccato gating
+      for (size_t i = 0; i < notesCount; ++i) {
             NoteEventList* el = &ell[i];
             if (!shouldRenderNote(chord->notes()[i])) {
                   el->clear();
                   continue;
                   }
-            if (arpeggio)
-                  continue; // don't add extra events and apply gateTime to arpeggio
+
+            // Let arpeggios with no articulations be not affected by gateTime change
+            if (arpeggio && !hasArticulations)
+                  continue;
 
             // If we are here then we still need to render the note.
             // Render its body if necessary and apply gateTime.
-            if (el->size() == 0 && chord->tremoloChordType() != TremoloChordType::TremoloSecondNote) {
+            if (el->empty() && notSecondOfTremolo) {
                   el->append(NoteEvent(0, ontime, 1000 - ontime - trailtime));
                   }
-            if (trailtime == 0) // if trailtime is non-zero that means we have graceNotesAfter, so we don't need additional gate time.
-                  for (NoteEvent& e : ell[i])
-                        e.setLen(e.len() * gateTime / 100);
+
+            if (!graceNotesAfter && !twoChordTremolo) {
+                  // Two-chord tremolos already had length calculated
+                  for (NoteEvent& e : ell[i]) {
+                        int updatedLen = (e.len() * gateTime) / 100;
+                        e.setLen(updatedLen);
+                        }
+                  }
             }
       return ell;
       }
@@ -2238,6 +2413,11 @@ void Score::createPlayEvents(Chord* chord)
       // Check if swing needs to be applied
       if (unit && !chord->tuplet()) {
             swingAdjustParams(chord, gateTime, ontime, unit, ratio);
+            }
+      for (Articulation* articulation : chord->articulations()) {
+            int iOnTime = articulation->getOnTime();
+            int onTimeDelta = (iOnTime * 10);
+            ontime += onTimeDelta;
             }
       //
       //    render normal (and articulated) chords

--- a/libmscore/rendermidi.cpp
+++ b/libmscore/rendermidi.cpp
@@ -355,6 +355,7 @@ static void collectNote(EventMap* events, int channel, const Note* note, qreal v
 
       NoteEventList nel = note->playEvents();
       int nels = nel.size();
+      std::vector<Articulation*> articulationsRendered;
       for (int i = 0, pitch = note->ppitch(); i < nels; ++i) {
             const NoteEvent& e = nel[i]; // we make an explicit const ref, not a const copy.  no need to copy as we won't change the original object.
 
@@ -377,7 +378,7 @@ static void collectNote(EventMap* events, int channel, const Note* note, qreal v
 
             // Get the velocity used for this note from the staff
             // This allows correct playback of tremolos even without SND enabled.
-            int velo;
+            int velo = 0;
             Fraction nonUnwoundTick = Fraction::fromTicks(on - tickOffset);
             int articulationVelocity = 0;
             if (config.useSND) {
@@ -394,8 +395,15 @@ static void collectNote(EventMap* events, int channel, const Note* note, qreal v
             else {
                   velo = staff->velocities().val(nonUnwoundTick);
                   for (Articulation* a : chord->articulations()) {
-                        // TODO: Can't accumulate multi articulations easily here
-                        articulationVelocity = a->getVelocityOffset();
+                        bool rendered
+                              = std::find(articulationsRendered.begin(),
+                                          articulationsRendered.end(),
+                                          a)
+                              == std::end(articulationsRendered) ? false : true;
+                        if (rendered) break;
+
+                        articulationsRendered.emplace_back(a);
+                        articulationVelocity += a->getVelocityOffset();
                         }
                   }
 
@@ -408,6 +416,7 @@ static void collectNote(EventMap* events, int channel, const Note* note, qreal v
             velo += veloDelta;
             velo += note->veloOffset();
 
+            // Velocity offset per-note is applied within playNote:
             playNote(events, note, channel, p, qBound(1, velo, 127), on, off, staffIdx);
             }
 
@@ -1447,10 +1456,9 @@ void renderTremolo(Chord* chord, QList<NoteEventList>& ell, int arpeggioDelta, i
 //   renderArpeggio
 //---------------------------------------------------------
 
-// "Refactored"
-
-int renderArpeggio(Chord *chord, QList<NoteEventList> & ell)
+int renderArpeggio(Chord *chord, QList<NoteEventList> & ell, int prevOnTime)
       {
+      (void) prevOnTime;
       Arpeggio* arp = chord->arpeggio();
       bool isUp = arp->up();
       size_t noteCount = chord->notes().size();
@@ -2061,12 +2069,13 @@ bool graceNotesMerged(Chord* chord)
 //   renderChordArticulation
 //---------------------------------------------------------
 
-void renderChordArticulation(Chord* chord, QList<NoteEventList> & ell, int & gateTime, int& velocityOffset)
+void renderChordArticulation(Chord* chord, QList<NoteEventList>& ell, int& gateTime, int& velocityOffset)
       {
       Segment* seg = chord->segment();
       Instrument* instr = chord->part()->instrument(seg->tick());
       int channel  = 0;  // note->subchannel();
-
+      std::vector<Articulation*> articulationsRendered;
+      signed int gateSum = 0;
       for (unsigned k = 0; k < chord->notes().size(); ++k) {
             NoteEventList* events = &ell[k];
             Note *note = chord->notes()[k];
@@ -2082,6 +2091,16 @@ void renderChordArticulation(Chord* chord, QList<NoteEventList> & ell, int & gat
                         if (!a->playArticulation())
                               continue;
                         if (!renderNoteArticulation(events, note, false, a->symId(), a->ornamentStyle())) {
+                              bool rendered
+                                    = std::find(articulationsRendered.begin(),
+                                                articulationsRendered.end(),
+                                                a)
+                                    == std::end(articulationsRendered)
+                                          ? false
+                                          : true;
+
+                              if (rendered) break;
+
                               // NOTE: Instrument definition to Articulation Definition occurs here: (e.g. 95 to 50)
                               instr->updateGateTime(&gateTime, channel, a->articulationName());
 
@@ -2109,6 +2128,8 @@ void renderChordArticulation(Chord* chord, QList<NoteEventList> & ell, int & gat
                                     gateTime = storedGateTime;
                                     }
 
+                              gateSum += (-100 + gateTime);
+
                               //  _  _  ____  __    _____  ___  ____  ____  _  _
                               // ( \/ )( ___)(  )  (  _  )/ __)(_  _)(_  _)( \/ )
                               //  \  /  )__)  )(__  )(_)(( (__  _)(_   )(   \  /
@@ -2134,8 +2155,8 @@ void renderChordArticulation(Chord* chord, QList<NoteEventList> & ell, int & gat
                                           }
                                     }
 
-                              int finalVelocity = (storedStaffDynamic == 0)
-                                          ? storedArticulationDelta // Loading score instead of user-change
+                              int finalVelocity = (storedStaffDynamic == 0) // 0 = score-loading phase
+                                          ? storedArticulationDelta
                                           : calculatedArticulationDelta + calculatedUserVelocityDelta;
 
                               a->setVelocityOffset
@@ -2145,10 +2166,9 @@ void renderChordArticulation(Chord* chord, QList<NoteEventList> & ell, int & gat
                               a->setStaffDynamic
                                     (currentStaffVelocity);
 
-                              // TODO: add multiple articulations. For now, this gives errors because cycling through
-                              // notes so there are extra cycles for no reason... Just use the topMost one then for now
-                              //
-                              velocityOffset = finalVelocity;
+                              // Accumulate velocity
+                              velocityOffset += finalVelocity;
+                              articulationsRendered.emplace_back(a);
                               }
                         }
                   }
@@ -2205,7 +2225,7 @@ static QList<NoteEventList> renderChord(Chord* chord, int gateTime, int ontime, 
       renderChordArticulation(chord, ell, gateTime, velocityOffset1);
 
       if (arpeggio) {
-            arpeggioDelta = renderArpeggio(chord, ell);
+            arpeggioDelta = renderArpeggio(chord, ell, ontime);
             }
 
       Tremolo* tremolo = chord->tremolo();
@@ -2224,7 +2244,7 @@ static QList<NoteEventList> renderChord(Chord* chord, int gateTime, int ontime, 
 
                               if (secondChord->arpeggio() && secondChord->arpeggio()->playArpeggio()) {
                                     // Obtain arpeggio delta
-                                    arpeggio2Delta = renderArpeggio(secondChord, ell2);
+                                    arpeggio2Delta = renderArpeggio(secondChord, ell2, ontime);
                                     }
                               }
                         }
@@ -2261,8 +2281,9 @@ static QList<NoteEventList> renderChord(Chord* chord, int gateTime, int ontime, 
             if (!graceNotesAfter && !twoChordTremolo) {
                   // Two-chord tremolos already had length calculated
                   for (NoteEvent& e : ell[i]) {
-                        int updatedLen = (e.len() * gateTime) / 100;
-                        e.setLen(updatedLen);
+                        int updatedLength = (arpeggio && hasArticulations) ? (gateTime * 10) - e.ontime()
+                                                                           : (e.len() * gateTime) / 100;
+                        e.setLen(updatedLength);
                         }
                   }
             }
@@ -2414,9 +2435,11 @@ void Score::createPlayEvents(Chord* chord)
       if (unit && !chord->tuplet()) {
             swingAdjustParams(chord, gateTime, ontime, unit, ratio);
             }
-      for (Articulation* articulation : chord->articulations()) {
-            int iOnTime = articulation->getOnTime();
-            int onTimeDelta = (iOnTime * 10);
+
+      int onTimeDelta = 0;
+      for (Articulation* a : chord->articulations()) {
+            int storedOnTime = a->getOnTime();
+            onTimeDelta = (storedOnTime * 10);
             ontime += onTimeDelta;
             }
       //

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -569,7 +569,6 @@ class Score : public QObject, public ScoreElement {
       LayoutMode _layoutMode { LayoutMode::PAGE };
       SynthesizerState _synthesizerState;
 
-      void createPlayEvents(Chord*);
       void createGraceNotesPlayEvents(const Fraction& tick, Chord* chord, int& ontime, int& trailtime);
       void cmdPitchUp();
       void cmdPitchDown();
@@ -973,6 +972,7 @@ class Score : public QObject, public ScoreElement {
 
       void updateSwing();
       void createPlayEvents(Measure const * start = nullptr, Measure const * const end = nullptr);
+      void createPlayEvents(Chord*);
 
       void updateCapo();
       void updateVelo();

--- a/mscore/inspector/inspector.cpp
+++ b/mscore/inspector/inspector.cpp
@@ -654,6 +654,9 @@ InspectorArticulation::InspectorArticulation(QWidget* parent)
             { Pid::ARTICULATION_ANCHOR, 0, ar.anchor,           ar.resetAnchor           },
             { Pid::DIRECTION,           0, ar.direction,        ar.resetDirection        },
             { Pid::TIME_STRETCH,        0, ar.timeStretch,      ar.resetTimeStretch      },
+            { Pid::GATE_TIME,           0, ar.gateTime,         ar.resetGateTime         },
+            { Pid::ON_TIME,             0, ar.onTime,           ar.resetOnTime           },
+            { Pid::VELOCITY_OFFSET,     0, ar.velocityOffset,   ar.resetVelocityOffset   },
             { Pid::ORNAMENT_STYLE,      0, ar.ornamentStyle,    ar.resetOrnamentStyle    },
             { Pid::PLAY,                0, ar.playArticulation, ar.resetPlayArticulation }
             };
@@ -685,6 +688,30 @@ void InspectorArticulation::setElement()
       InspectorElementBase::setElement();
       if (!ar.playArticulation->isChecked())
             ar.gridWidget->setEnabled(false);
+      }
+
+//---------------------------------------------------------
+//   valueChanged
+//---------------------------------------------------------
+
+void InspectorArticulation::valueChanged(int idx)
+      {
+      InspectorElementBase::valueChanged(idx);
+      // Update play-events now instead of requiring playback (P.R.E. will reflect property change)
+      if (Articulation* a = toArticulation(inspector->element())) {
+            Score* score = a->score();
+            if (Element* p = a->parent()) {
+                  if (p->isChord()) {
+                        Chord* c = toChord(p);
+                        if (Tremolo* t = c->tremolo()) {
+                              if (c->tremoloChordType() != TremoloChordType::TremoloSingle) {
+                                    c = t->chord();
+                                    }
+                              }
+                        score->createPlayEvents(c);
+                        }
+                  }
+            }
       }
 
 //---------------------------------------------------------

--- a/mscore/inspector/inspector.h
+++ b/mscore/inspector/inspector.h
@@ -153,6 +153,7 @@ class InspectorArticulation : public InspectorElementBase {
    public:
       InspectorArticulation(QWidget* parent);
       virtual void setElement() override;
+      virtual void valueChanged(int idx) override;
       };
 
 //---------------------------------------------------------

--- a/mscore/inspector/inspectorArpeggio.cpp
+++ b/mscore/inspector/inspectorArpeggio.cpp
@@ -12,6 +12,9 @@
 
 #include "inspectorArpeggio.h"
 #include "libmscore/arpeggio.h"
+#include "libmscore/chord.h"
+#include "libmscore/score.h"
+#include "libmscore/tremolo.h"
 
 namespace Ms {
 
@@ -34,5 +37,29 @@ InspectorArpeggio::InspectorArpeggio(QWidget* parent)
 
       mapSignals(iiList, ppList);
       }
+
+//---------------------------------------------------------
+//   InspectorArpeggio
+//---------------------------------------------------------
+
+void InspectorArpeggio::valueChanged(int idx)
+      {
+      // Update Score/PRE Events
+      InspectorElementBase::valueChanged(idx);
+
+      if (Arpeggio* arpeggio = toArpeggio(inspector->element())) {
+            Score* score = arpeggio->score();
+            if (Element* parent = arpeggio->parent()) {
+                  if (parent->isChord()) {
+                        Chord* chord = toChord(parent);
+                        if (chord->tremolo() && chord->tremoloChordType() == TremoloChordType::TremoloSecondNote) {
+                              chord = chord->tremolo()->chord1();
+                              }
+                        score->createPlayEvents(chord);
+                        }
+                  }
+            }
+      }
+
 }
 

--- a/mscore/inspector/inspectorArpeggio.h
+++ b/mscore/inspector/inspectorArpeggio.h
@@ -30,6 +30,7 @@ class InspectorArpeggio : public InspectorElementBase {
 
    public:
       InspectorArpeggio(QWidget* parent);
+      virtual void valueChanged(int idx) override;
       };
 
 

--- a/mscore/inspector/inspector_articulation.ui
+++ b/mscore/inspector/inspector_articulation.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>363</width>
-    <height>244</height>
+    <height>303</height>
    </rect>
   </property>
   <property name="accessibleName">
@@ -49,7 +49,6 @@
      </property>
      <property name="font">
       <font>
-       <weight>75</weight>
        <bold>true</bold>
       </font>
      </property>
@@ -76,6 +75,13 @@
       <property name="spacing">
        <number>3</number>
       </property>
+      <item row="2" column="0" colspan="2">
+       <widget class="QCheckBox" name="playArticulation">
+        <property name="text">
+         <string>Play</string>
+        </property>
+       </widget>
+      </item>
       <item row="0" column="0">
        <widget class="QLabel" name="label">
         <property name="text">
@@ -86,6 +92,65 @@
         </property>
         <property name="buddy">
          <cstring>direction</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="2">
+       <widget class="Ms::ResetButton" name="resetPlayArticulation" native="true">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="accessibleName">
+         <string>Reset 'Play' value</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="2">
+       <widget class="Ms::ResetButton" name="resetDirection" native="true">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="accessibleName">
+         <string>Reset 'Direction' value</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_4">
+        <property name="text">
+         <string>Anchor:</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+        </property>
+        <property name="buddy">
+         <cstring>anchor</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="2">
+       <widget class="Ms::ResetButton" name="resetAnchor" native="true">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="accessibleName">
+         <string>Reset 'Anchor' value</string>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="0" colspan="3">
+       <widget class="QPushButton" name="properties">
+        <property name="text">
+         <string>Properties</string>
         </property>
        </widget>
       </item>
@@ -117,29 +182,10 @@
         </item>
        </widget>
       </item>
-      <item row="0" column="2">
-       <widget class="Ms::ResetButton" name="resetDirection" native="true">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="accessibleName">
-         <string>Reset 'Direction' value</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="label_4">
-        <property name="text">
-         <string>Anchor:</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-        </property>
-        <property name="buddy">
-         <cstring>anchor</cstring>
+      <item row="3" column="0" colspan="2">
+       <widget class="Line" name="line">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
         </property>
        </widget>
       </item>
@@ -181,33 +227,7 @@
         </item>
        </widget>
       </item>
-      <item row="1" column="2">
-       <widget class="Ms::ResetButton" name="resetAnchor" native="true">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="accessibleName">
-         <string>Reset 'Anchor' value</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="2">
-       <widget class="Ms::ResetButton" name="resetPlayArticulation" native="true">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="accessibleName">
-         <string>Reset 'Play' value</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="0" colspan="3">
+      <item row="4" column="0" colspan="3">
        <widget class="QWidget" name="gridWidget" native="true">
         <layout class="QGridLayout" name="gridLayout_2">
          <property name="leftMargin">
@@ -225,6 +245,117 @@
          <property name="spacing">
           <number>3</number>
          </property>
+         <item row="3" column="2">
+          <widget class="QSpinBox" name="velocityOffset">
+           <property name="minimum">
+            <number>-1000</number>
+           </property>
+           <property name="maximum">
+            <number>1000</number>
+           </property>
+           <property name="singleStep">
+            <number>5</number>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="2">
+          <widget class="QSpinBox" name="gateTime">
+           <property name="suffix">
+            <string comment="%" extracomment="%"/>
+           </property>
+           <property name="prefix">
+            <string/>
+           </property>
+           <property name="minimum">
+            <number>-1000</number>
+           </property>
+           <property name="maximum">
+            <number>1000</number>
+           </property>
+           <property name="singleStep">
+            <number>10</number>
+           </property>
+          </widget>
+         </item>
+         <item row="5" column="2">
+          <widget class="QComboBox" name="ornamentStyle">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="accessibleName">
+            <string>Ornament style</string>
+           </property>
+           <item>
+            <property name="text">
+             <string>Default</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>Baroque</string>
+            </property>
+           </item>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <widget class="QLabel" name="label_6">
+           <property name="toolTip">
+            <string extracomment="OnTime signifies how much gap to leave before note renders"/>
+           </property>
+           <property name="text">
+            <string>OnTime Offset:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="2">
+          <widget class="QDoubleSpinBox" name="timeStretch">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="accessibleName">
+            <string>Time stretch</string>
+           </property>
+           <property name="minimum">
+            <double>0.100000000000000</double>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="QLabel" name="label_5">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="text">
+            <string>Length:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="5" column="1">
+          <widget class="QLabel" name="label_3">
+           <property name="text">
+            <string>Ornament style:</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="1">
+          <widget class="QLabel" name="label_7">
+           <property name="toolTip">
+            <string extracomment="TrailTime signifies how much gap to leave after the note to allow for graceNotesAfter to be rendered"/>
+           </property>
+           <property name="text">
+            <string>Velocity +/-:</string>
+           </property>
+          </widget>
+         </item>
          <item row="0" column="3">
           <widget class="Ms::ResetButton" name="resetTimeStretch" native="true">
            <property name="sizePolicy">
@@ -248,56 +379,23 @@
            </property>
           </widget>
          </item>
-         <item row="0" column="2">
-          <widget class="QDoubleSpinBox" name="timeStretch">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="accessibleName">
-            <string>Time stretch</string>
+         <item row="2" column="2">
+          <widget class="QSpinBox" name="onTime">
+           <property name="suffix">
+            <string comment="%" extracomment="%"/>
            </property>
            <property name="minimum">
-            <double>0.100000000000000</double>
+            <number>-1000</number>
+           </property>
+           <property name="maximum">
+            <number>1000</number>
+           </property>
+           <property name="singleStep">
+            <number>10</number>
            </property>
           </widget>
          </item>
-         <item row="1" column="1">
-          <widget class="QLabel" name="label_3">
-           <property name="text">
-            <string>Ornament style:</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="2">
-          <widget class="QComboBox" name="ornamentStyle">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="accessibleName">
-            <string>Ornament style</string>
-           </property>
-           <item>
-            <property name="text">
-             <string>Default</string>
-            </property>
-           </item>
-           <item>
-            <property name="text">
-             <string>Baroque</string>
-            </property>
-           </item>
-          </widget>
-         </item>
-         <item row="1" column="3">
+         <item row="5" column="3">
           <widget class="Ms::ResetButton" name="resetOrnamentStyle" native="true">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
@@ -310,21 +408,23 @@
            </property>
           </widget>
          </item>
+         <item row="4" column="1" colspan="2">
+          <widget class="Line" name="line_2">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="3">
+          <widget class="Ms::ResetButton" name="resetVelocityOffset" native="true"/>
+         </item>
+         <item row="2" column="3">
+          <widget class="Ms::ResetButton" name="resetOnTime" native="true"/>
+         </item>
+         <item row="1" column="3">
+          <widget class="Ms::ResetButton" name="resetGateTime" native="true"/>
+         </item>
         </layout>
-       </widget>
-      </item>
-      <item row="4" column="0" colspan="3">
-       <widget class="QPushButton" name="properties">
-        <property name="text">
-         <string>Properties</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0" colspan="2">
-       <widget class="QCheckBox" name="playArticulation">
-        <property name="text">
-         <string>Play</string>
-        </property>
        </widget>
       </item>
      </layout>


### PR DESCRIPTION
**Inspector (Articulation)**: **Velocity offset**, **OnTime value,** **Gate** 
+ Enable User to be able to shorten/lengthen a staccato instead of being stuck at 50% without resorting to Piano Roll Editor or having to edit instrument definitions inside of an XML file which gives no per-instance control.

+ E.g., a stress mark can be +/- from instrument definition score-wide by **select-all-similar** and altering this attribute

**Tremolos:**
+ Arpeggios will render on two-chord tremolos properly
+ Allow for articulations (staccato etc), which in turn should consider the articulation's velocity/ontime/gate information
+ Each chord of a two-chord tremolo should consider its own articulation/arpeggio information

**GraceNotes**
+ Allow articulations (esp. stress marks in mind)

Inspector: Arpeggios will update note-events when changing stretch property (results will show in Piano Roll Editor [PRE] immediately)

***Demonstrations:*** Notice on the right-hand side, the PRE manifests the staccatos which are set to 
1) **None** 
2) **Default** (**50**) 
3) **20** 
4) **10**
(This was previously impossible)

![image](https://github.com/user-attachments/assets/0be1f14a-6f6c-465f-862c-95e3c345529f)

**Regular two-chord tremolo**:
![image](https://github.com/user-attachments/assets/4ddc135e-d30c-49b2-bbb4-2a88628bc60f)

**Tremolo with staccato on second chord set to 20 instead of default 50**
![image](https://github.com/user-attachments/assets/fc32cfc5-437d-4764-abfc-b6b02cae70b9)

**Tremolo with upward and downward arpeggios on the chords**
![image](https://github.com/user-attachments/assets/6586e1e9-1425-421b-9681-fd346f3ce6fd)


Arpeggios update PRE immediately when changing stretch (and they also work with tremolos):
Staccatos can also apply to arpeggio and change gating

At the moment, ontime values of an articulation won't affect notes associated with an arpeggio

[stretch.webm](https://github.com/user-attachments/assets/d3999f8d-3d30-4d50-a014-a38bdc6f8489)



P.S: These changes attempt not to write these values for articulations if they are in accord with the default values based on the instrument definitions (gateTime and velocity) so that MTESTS have no problem by default.