### PR TITLE
Fix: Unmarking rests & En Passant Visibility

### DIFF
--- a/libmscore/element.cpp
+++ b/libmscore/element.cpp
@@ -663,39 +663,49 @@ QColor Element::curColor(bool isVisible, QColor normalColor) const
                         }
                   }
             else if (isSpannerSegment()) {
+                  // Mark the line itself
                   auto ss = toSpannerSegment(const_cast<Element*>(this));
                   auto sp = ss->spanner();
                   auto t1 = sp->tick();
                   auto t2 = sp->tick2();
-                  if (ss->isPedalSegment() || ss->isOttavaSegment()) {
-                        if (ss->isPedalSegment()) {
-                              // Potentially needs a recalibration of ticks...
-                              }
-                        t2 -= Fraction::fromTicks(1);
-                        }
+                  t2 -= Fraction::fromTicks(1);
                   if (auto playingElement = ss->score()->getLastCRSequenced()) {
                         auto pos = playingElement->tick();
                         marked = (pos >= t1 && pos < t2);
-                        ss->setSelected(marked);
+                        }
+                  }
+            else if (isTextBase()) {
+                  // Mark the text of line
+                  auto tb = toTextBase(this);
+                  if (auto playingElement = score()->getLastCRSequenced()) {
+                        if (auto p = tb->parent()) {
+                              if (p->isSpannerSegment()) {
+                                    auto ss = toSpannerSegment(p);
+                                    auto sp = ss->spanner();
+                                    Fraction pos = playingElement->tick();
+                                    Fraction t1 = sp->tick();
+                                    Fraction t2 = sp->tick2();
+                                    t2 -= Fraction::fromTicks(1);
+                                    marked = (pos >= t1 && pos < t2);
+                                    }
+                              }
                         }
                   }
             }
 
-      if (MScore::honorEnPassantVisibility && marked) {
-            Fraction fTick = this->tick();
-            int  iTick = fTick.ticks();
-            int  iTrack = this->track();
-            auto overlappingSpanners = score()->spannerMap().findOverlapping(0, iTick);
+      if (MScore::honorEnPassantVisibility && marked && (isNote() || isRest())) {
+            int iTrack = track();
+            Fraction fTick = tick();
+            auto overlappingSpanners = score()->spannerMap().findOverlapping(0, fTick.ticks());
             for (auto i : overlappingSpanners) {
                   auto s = i.value;
                   if (s->isTextLineBase() && s->track() == iTrack) {
                         auto tlb = toTextLineBase(s);
-                        bool enPassant = tlb->enPassantManifest();
-                        if (enPassant) {
-                              auto beginTick = tlb->tick();
-                              auto endTick = tlb->tick2();
-                              bool withinPlaybackPosition = (iTick >= beginTick.ticks() &&
-                                                             iTick < endTick.ticks());
+                        if (tlb->enPassantManifest()) {
+                              auto t1 = tlb->tick();
+                              auto t2 = tlb->tick2();
+                              t2 -= Fraction::fromTicks(1);
+                              bool withinPlaybackPosition = (fTick >= t1 && fTick < t2);
                               if (withinPlaybackPosition) {
                                     if (!tlb->visible()) {
                                           tlb->setVisible(true);
@@ -709,14 +719,7 @@ QColor Element::curColor(bool isVisible, QColor normalColor) const
                                           tlb->frontSegment()->setSelected(true);
                                           }
                                     }
-                              else if (tlb->isTemporarilyShowing()) {
-                                    tlb->setVisible(false);
-                                    score()->masterScore()->setUpdateAll();
-                                    }
-                              else {
-                                    tlb->frontSegment()->setSelected(false);
-                                    score()->masterScore()->setUpdateAll();
-                                    }
+                              else tlb->isTemporarilyShowing() ? tlb->setVisible(false) : tlb->frontSegment()->setSelected(false);
                               }
                         }
                   }

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -3062,6 +3062,7 @@ void ScoreView::cmd(const char* s)
                                           if (tlb->isTemporarilyShowing()) {
                                                 tlb->setTemporarilyShowing(false);
                                                 tlb->setVisible(false);
+                                                tlb->setSelected(false);
                                                 }
                                           }
                                     }

--- a/mscore/seq.cpp
+++ b/mscore/seq.cpp
@@ -1800,7 +1800,7 @@ void Seq::heartBeatTimeout()
       if (piano && piano->isVisible())
             piano->updateAllKeys();
 
-      MScore::highlightMore ? cv->update() : cv->update(cv->toPhysical(r));
+      cv->update();
       }
 
 //---------------------------------------------------------

--- a/mscore/seq.cpp
+++ b/mscore/seq.cpp
@@ -475,6 +475,7 @@ void Seq::unmarkNotes()
             }
 
       markedNotes.clear();
+      markedRests.clear();
 
       PianoTools* piano = mscore->pianoTools();
       if (piano && piano->isVisible())


### PR DESCRIPTION
Note-2-self: Another quick fix ( probably will squash this ) :

+ Better _En Passant Visibility_ selection/deselection during playback
+ Unmarking rests needed updating/potential crash when changing scores and playing again
+ Resorting to a full ScoreView updating during heartbeat