### PR TITLE
Efficiency: changeVoice no longer layouts the entire score

### DIFF
--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -5181,7 +5181,6 @@ void Score::changeVoice(int voice)
             selection().clear();
       for (Element* e : el)
             select(e, SelectType::ADD, -1);
-      setLayoutAll();
       endCmd();
       }
 


### PR DESCRIPTION
Note: `endCmd()` already performs a range-based layout through `Score::update(bool resetCmdState);`