### PR TITLE
Draw a highlighted/framed rectangle & arrowed line

### DIFF
--- a/global/settings/types/preferencekeys.h
+++ b/global/settings/types/preferencekeys.h
@@ -129,6 +129,7 @@
 #define PREF_SCORE_NOTE_INPUT_DISABLE_MOUSE_INPUT           "ui/score/noteEntry/disableMouseEntry"
 #define PREF_UI_SCORE_DISABLE_NOTE_DRAG_VERTICAL            "ui/score/mouse/behavior/disableNoteDragVertical"
 #define PREF_UI_SCORE_LASSO_WITHOUT_SHIFT                   "ui/score/mouse/behavior/enableLassoWithoutShift"
+#define PREF_UI_SCORE_LASSO_ANNOTATIONS                     "ui/score/mouse/behavior/lasso/annotations"
 #define PREF_UI_SCORE_FADE_FOCUS                            "ui/score/fadeFocusUsesInvisibleColor"
 #define PREF_UI_SCORE_CURRENT_SYS_ON_TOP                    "ui/score/currentSystemAlwaysOnTop"
 #define PREF_UI_SCORE_OMIT_ADDING_LINKED_LINES              "ui/score/lines/linked/omit"

--- a/libmscore/beam.h
+++ b/libmscore/beam.h
@@ -107,6 +107,7 @@ class Beam final : public Element {
       void layout();
 
       const QVector<ChordRest*>& elements() { return _elements;  }
+      const QVector<ChordRest*>& elements() const { return _elements;  }
       void clear()                        { _elements.clear(); }
       bool empty() const                { return _elements.empty(); }
       bool contains(const ChordRest* cr) const { return std::find(_elements.begin(), _elements.end(), cr) != _elements.end(); }

--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -5395,6 +5395,9 @@ bool Score::cmdToggleOptions(const QString& cmd)
       else if (cmd.endsWith("lasso-border")) {
             preferences.setPreference(PREF_UI_SCORE_LASSO_BORDER_ENABLED, checked=toggle(MScore::lassoBorderEnabled));
             }
+      else if (cmd.endsWith("lasso-annotations")) {
+            preferences.setPreference(PREF_UI_SCORE_LASSO_ANNOTATIONS, checked=toggle(MScore::lassoAnnotations));
+            }
       else if (cmd.endsWith("move-cursor-by-beat")) {
             preferences.setPreference(PREF_SCORE_PLAYBACK_CURSOR_MOVE_BY_BEAT, checked=toggle(MScore::cursorMoveByBeat));
             }

--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -457,8 +457,6 @@ void Score::cmdAddSpanner(Spanner* spanner, int staffIdx, Segment* startSegment,
       Fraction tick2;
       if (!endSegment)
             tick2 = lastSegment()->tick();
-      else if (endSegment == startSegment)
-            tick2 = startSegment->measure()->last()->tick();
       else
             tick2 = endSegment->tick();
       spanner->setTick2(tick2);

--- a/libmscore/image.cpp
+++ b/libmscore/image.cpp
@@ -17,6 +17,8 @@
 #include "undo.h"
 #include "xml.h"
 
+#include <QPainter>
+
 namespace Ms {
 
 //---------------------------------------------------------
@@ -187,7 +189,15 @@ void Image::draw(QPainter* painter) const
             br.setStyle(Qt::SolidPattern);
             painter->setBrush(br);
             painter->setPen(Qt::NoPen);
-            painter->drawRect(bbox());
+
+            // TODO: Option for ellipse versus rectangle
+            bool ellipse = false;
+            if (ellipse) {
+                  qreal ellX = bbox().width() * 0.5;
+                  qreal ellY = bbox().height() * 0.5;
+                  painter->drawEllipse(bbox().center(), ellX, ellY);
+                  }
+            else painter->drawRect(bbox());
             }
       if (_frameWidth != 0.0) {
             QPen pen(Qt::NoBrush, _frameWidth * 0.10, Qt::SolidLine, Qt::SquareCap, Qt::BevelJoin);

--- a/libmscore/image.h
+++ b/libmscore/image.h
@@ -32,9 +32,6 @@ class Image final : public BSymbol {
             };
       ImageType imageType;
 
-      QSizeF pixel2size(const QSizeF& s) const;
-      QSizeF size2pixel(const QSizeF& s) const;
-
    protected:
       ImageStoreItem* _storeItem;
       QString _storePath;           // the path of the img in the ImageStore
@@ -91,6 +88,8 @@ class Image final : public BSymbol {
       QVariant propertyDefault(Pid id) const override;
 
       QSizeF imageSize() const;
+      QSizeF pixel2size(const QSizeF& s) const;
+      QSizeF size2pixel(const QSizeF& s) const;
 
       void setImageType(ImageType);
       ImageType getImageType() const { return imageType; }

--- a/libmscore/lasso.cpp
+++ b/libmscore/lasso.cpp
@@ -15,6 +15,8 @@
 #include "mscoreview.h"
 #include "score.h"
 
+#include <QPainter>
+
 namespace Ms {
 
 //---------------------------------------------------------
@@ -33,14 +35,19 @@ Lasso::Lasso(Score* s)
 
 void Lasso::draw(QPainter* painter) const
       {
-      auto color = MScore::lassoColor;
-      painter->setBrush(QBrush(color));
+      QColor color = MScore::lassoColor;
+      QColor selectionColor = MScore::selectColor[0];
+            (void) selectionColor;
+
+      painter->setBrush(Qt::NoBrush);
       if (MScore::lassoBorderEnabled) {
-            // 2 pixels width, regardless of view
-            qreal w = 2.0 / painter->transform().m11();
-            painter->setPen(QPen(MScore::selectColor[0], w));
+            qreal w = 5.0;
+            painter->setPen(QPen(color, w));
             }
-      else painter->setPen(Qt::NoPen);
+      else {
+            painter->setPen(Qt::NoPen);
+            painter->setBrush(QBrush(color));
+            }
 
       painter->drawRect(bbox());
       }

--- a/libmscore/lasso.h
+++ b/libmscore/lasso.h
@@ -14,6 +14,7 @@
 #define __LASSO_H__
 
 #include "element.h"
+#include <QPointF>
 
 namespace Ms {
 
@@ -38,6 +39,8 @@ class Lasso : public Element {
       Grip initialEditModeGrip() const override { return Grip(7); }
       Grip defaultGrip() const override { return Grip(7); }
       std::vector<QPointF> gripsPositions(const EditData&) const override;
+
+      QPointF startPoint, endPoint;
       };
 
 

--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -4787,20 +4787,26 @@ void Score::layoutSystemElements(System* system, LayoutContext& lc)
             if (!sp->visible() && ((startMeas && startMeas->isMMRest()) || (endMeas && endMeas->isMMRest()))
                 && score()->styleB(Sid::createMultiMeasureRests))
                   continue;
-            if (sp->tick() < etick && sp->tick2() > stick) {
-                  if (sp->isOttava()) {
-                        if (sp->staff()->staffType(sp->tick())->isTabStaff())
-                              continue;
-                        ottavas.push_back(sp);
+            if (sp->tick() < etick) {
+                  if (sp->tick2() > stick) {
+                        if (sp->isOttava()) {
+                              if (sp->staff()->staffType(sp->tick())->isTabStaff())
+                                    continue;
+                              ottavas.push_back(sp);
+                              }
+                        else if (sp->isPedal())
+                              pedal.push_back(sp);
+                        else if (sp->isVolta())
+                              voltas.push_back(sp);
+                        else if (sp->isHairpin())
+                              hairpins.push_back(sp);
+                        else if (!sp->isSlur() && !sp->isVolta() && !sp->isTrill())    // slurs are already
+                              spanner.push_back(sp);
                         }
-                  else if (sp->isPedal())
-                        pedal.push_back(sp);
-                  else if (sp->isVolta())
-                        voltas.push_back(sp);
-                  else if (sp->isHairpin())
-                        hairpins.push_back(sp);
-                  else if (!sp->isSlur() && !sp->isVolta() && !sp->isTrill())    // slurs are already
-                        spanner.push_back(sp);
+                  else if (sp->tick2() == stick && sp->tick() == stick) {
+                        if (sp->isTextLine())
+                              spanner.push_back(sp);
+                        }
                   }
             }
       processLines(system, hairpins);

--- a/libmscore/line.cpp
+++ b/libmscore/line.cpp
@@ -543,6 +543,10 @@ void LineSegment::rebaseAnchors(EditData& ed, Grip grip)
       {
       if (line()->anchor() != Spanner::Anchor::SEGMENT)
             return;
+
+      if (!line()->autoplace())
+            return;
+
       // don't change anchors on keyboard adjustment or if Ctrl is pressed
       // (Ctrl+Left/Right is handled elsewhere!)
       if (ed.key == Qt::Key_Left  || (ed.key == Qt::Key_J && MScore::nudgeUsesIJKL) ||
@@ -895,6 +899,7 @@ QPointF SLine::linePos(Grip grip, System** sys) const
                                     qreal x2 = cr->x() /* TODO + cr->space().rw() */;
                                     Segment* currentSeg = toSegment(endElement()->parent());
                                     Segment* seg = score()->tick2segmentMM(tick2(), false, SegmentType::ChordRest);
+                                    bool sameSegTextLine = (isTextLine() && tick() == tick2());
                                     if (!seg) {
                                           // no end segment found, use measure width
                                           x2 = endElement()->parent()->parent()->width() - sp;
@@ -921,7 +926,8 @@ QPointF SLine::linePos(Grip grip, System** sys) const
                                     else {
                                           // next chordrest is in next measure
                                           // lay out to end (barline) of current measure instead
-                                          seg = currentSeg->next(SegmentType::EndBarLine);
+                                          if (!sameSegTextLine)
+                                                seg = currentSeg->next(SegmentType::EndBarLine);
                                           if (!seg)
                                                 seg = currentSeg->measure()->last();
                                           // allow lyrics hyphen to extend to barline
@@ -931,6 +937,13 @@ QPointF SLine::linePos(Grip grip, System** sys) const
                                           x2 = qMax(x2, x3 - gap);
                                           }
                                     x = x2 - endElement()->parent()->x();
+                                    if (sameSegTextLine) {
+                                          if (auto scr = toChordRest(startElement())) {
+                                                cr = scr;
+                                                x = 0;
+                                                }
+                                          }
+
                                     }
                               }
                         }

--- a/libmscore/mscore.cpp
+++ b/libmscore/mscore.cpp
@@ -128,6 +128,7 @@ bool    MScore::fingerTextAutoForwardAlphaNumeric;
 
 bool    MScore::disableVerticalMouseDragOfNotes;
 bool    MScore::lassoWithoutShift;
+bool    MScore::lassoAnnotations;
 
 bool    MScore::palettesHideWhenApplied;
 

--- a/libmscore/mscore.h
+++ b/libmscore/mscore.h
@@ -337,6 +337,7 @@ class MScore {
       static QColor cursorColor;
       static QColor lassoColor;
       static bool   lassoBorderEnabled;
+      static bool   lassoAnnotations;
       static QColor defaultColor;
       static QColor invisibleElementsColor;
       static QColor singleNoteSelectionColor;

--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -313,8 +313,16 @@ Score::~Score()
       // deselectAll();
       qDeleteAll(_systems); // systems are layout-only objects so we delete
                             // them prior to measures.
+
       for (MeasureBase* m = _measures.first(); m;) {
             MeasureBase* nm = m->next();
+            // Remove spanners from measure bases first before deleting them afterwards (safe-side)
+            for (auto el : m->el()) {
+                  if (el->isSpanner()) {
+                        auto sp = toSpanner(el);
+                        m->el().remove(sp);
+                        }
+                  }
             if (m->isMeasure() && toMeasure(m)->mmRest())
                   delete toMeasure(m)->mmRest();
             delete m;
@@ -5508,7 +5516,7 @@ void MasterScore::setLayout(const Fraction& tick1, const Fraction& tick2, int st
 
       if (tick1 >= zero)
             _cmdState.setTick(tick1);
-      if (tick2 >= zero && (tick2 > tick1))
+      if (tick2 >= zero && (tick2 >= tick1))
             _cmdState.setTick(tick2);
 
       if (e && e->score() == this) {

--- a/libmscore/spanner.cpp
+++ b/libmscore/spanner.cpp
@@ -628,10 +628,16 @@ void Spanner::computeEndElement()
 
       switch (_anchor) {
             case Anchor::SEGMENT: {
+                  bool zeroTicks = ticks().isZero();
                   if (track2() == -1 || isHairpin())
                         setTrack2(track());
-                  if (ticks().isZero() && isTextLine() && parent())   // special case palette
-                        setTicks(score()->lastSegment()->tick() - _tick);
+                  if (zeroTicks && isTextLine() && parent()) {
+                        // Lasso-created lines need to have zero-tick ability, yet this
+                        // "special case palette" seems to have a parent... will bypass for now
+
+                        // special case palette
+                        // setTicks(score()->lastSegment()->tick() - _tick);
+                        }
 
                   if (isLyricsLine() && toLyricsLine(this)->isEndMelisma()) {
                         // lyrics endTick should already indicate the segment we want
@@ -658,7 +664,10 @@ void Spanner::computeEndElement()
                               if (isHairpin()) {
                                     // cr = (cr->track() != track()) ? cr->segment()->nextChordRest(track(), true) : cr;
                                     }
-                              _endElement = cr;
+                              if (zeroTicks && isTextLine() && parent()) {
+                                    _endElement = _startElement;
+                                    }
+                              else _endElement = cr;
                               }
                         }
                   if (!_endElement) {
@@ -670,8 +679,13 @@ void Spanner::computeEndElement()
                         ChordRest* cr = endCR();
                         Fraction nticks = cr->tick() + cr->actualTicks() - _tick;
                         if ((_ticks - nticks).isNotZero()) {
-                              qDebug("%s ticks changed, %d -> %d", name(), _ticks.ticks(), nticks.ticks());
-                              setTicks(nticks);
+                              if (isTextLine() && zeroTicks) {
+                                    // Leave ticks alone (used for same-segment anchored lines (to maintain angles)
+                                    }
+                              else {
+                                    qDebug("%s ticks changed, %d -> %d", name(), _ticks.ticks(), nticks.ticks());
+                                    setTicks(nticks);
+                                    }
                               if (isOttava())
                                     staff()->updateOttava();
                               }

--- a/mscore/events.cpp
+++ b/mscore/events.cpp
@@ -32,6 +32,8 @@
 #include "libmscore/staff.h"
 #include "libmscore/stafflines.h"
 #include "libmscore/text.h"
+#include "libmscore/textedit.h"
+#include "libmscore/stafftext.h"
 #include "libmscore/timesig.h"
 #include "libmscore/utils.h"
 
@@ -851,6 +853,7 @@ void ScoreView::mouseDoubleClickEvent(QMouseEvent* mouseEvent)
       {
       QTimer::singleShot(QApplication::doubleClickInterval(), this, SLOT(tripleClickTimeOut()));
       tripleClickPending = true;
+      QPointF mousePosition = toLogical(mouseEvent->pos());
 
       if (textEditMode()) {
             // double click on a textBase element that is being edited - select word
@@ -865,24 +868,57 @@ void ScoreView::mouseDoubleClickEvent(QMouseEvent* mouseEvent)
       if (state != ViewState::NORMAL)
             return;
 
-      Element* clickedElement = elementNear(toLogical(mouseEvent->pos()));
+      Element* clickedElement = elementNear(mousePosition);
+      if (clickedElement) {
+            if (!clickedElement->isEditable()) {
+                  if (clickedElement->isInstrumentName()) // double-click an instrument name to open the edit staff/part properties menu
+                        elementPropertyAction("staff-props", clickedElement);
+                  else if (clickedElement->isText() && (toText(clickedElement)->tid() == Tid::HEADER || toText(clickedElement)->tid() == Tid::FOOTER)) // double-click a header/footer to open the Header/Footer page in the Style dialog
+                        elementPropertyAction("style", clickedElement);
+                  return;
+                  }
 
-      if (!clickedElement)
-            return;
+            startEditMode(clickedElement);
 
-      if (!clickedElement->isEditable()) {
-            if (clickedElement->isInstrumentName()) // double-click an instrument name to open the edit staff/part properties menu
-                  elementPropertyAction("staff-props", clickedElement);
-            else if (clickedElement->isText() && (toText(clickedElement)->tid() == Tid::HEADER || toText(clickedElement)->tid() == Tid::FOOTER)) // double-click a header/footer to open the Header/Footer page in the Style dialog
-                  elementPropertyAction("style", clickedElement);
-            return;
+            if (clickedElement->isTextBase()) {
+                  setCursor(QCursor(Qt::IBeamCursor));
+                  toTextBase(clickedElement)->setPrimed(false);
+                  }
             }
+      else if (MScore::lassoAnnotations) {
+            if (Element* el = nearestElement(mousePosition, mousePosition)) {
+                  if (const Measure* m = nearestMeasure(el)) {
+                        if (ChordRest* cr = m->first()->nextChordRest(0)) {
+                              // Attempt adding [staff-text] to closest measure, offset to mouse position
+                              Element* e = cr;
+                              if (cr->isChord())
+                                    e = toChord(cr)->upNote();
+                              _score->select(e);
+                              cmdAddText(Tid::STAFF, Tid::DEFAULT, PropertyFlags::STYLED, Placement::ABOVE);
+                              e = _score->selection().element();
+                              if (e->isStaffText()) {
+                                    StaffText* text = toStaffText(e);
+                                    text->setAutoplace(false);
+                                    text->setPlainText("…");
+                                    text->layout();
 
-      startEditMode(clickedElement);
+                                    TextEditData* ted = static_cast<TextEditData*>(getEditData().getData(text));
+                                    TextCursor* _cursor = &ted->cursor;
+                                    text->selectAll(_cursor);
 
-      if (clickedElement->isTextBase()) {
-            setCursor(QCursor(Qt::IBeamCursor));
-            toTextBase(clickedElement)->setPrimed(false);
+                                    qreal tx = text->canvasBoundingRect().x();
+                                    qreal ty = text->canvasBoundingRect().y();
+                                    qreal mx = mousePosition.x();
+                                    qreal my = mousePosition.y();
+                                    qreal diffX = (mx > tx) ? (mx - tx) : -(tx - mx);
+                                    qreal diffY = (my > ty) ? (my - ty) : -(ty - my);
+
+                                    text->setOffset(diffX, diffY);
+                                    text->setPropertyFlags(Pid::OFFSET, PropertyFlags::UNSTYLED);
+                                    }
+                              }
+                        }
+                  }
             }
       }
 

--- a/mscore/events.cpp
+++ b/mscore/events.cpp
@@ -878,11 +878,16 @@ void ScoreView::mouseDoubleClickEvent(QMouseEvent* mouseEvent)
                   return;
                   }
 
-            startEditMode(clickedElement);
+            if (clickedElement->isNote() && MScore::lassoAnnotations) {
+                  cmdAddText(Tid::FINGERING);
+                  }
+            else {
+                  startEditMode(clickedElement);
 
-            if (clickedElement->isTextBase()) {
-                  setCursor(QCursor(Qt::IBeamCursor));
-                  toTextBase(clickedElement)->setPrimed(false);
+                  if (clickedElement->isTextBase()) {
+                        setCursor(QCursor(Qt::IBeamCursor));
+                        toTextBase(clickedElement)->setPrimed(false);
+                        }
                   }
             }
       else if (MScore::lassoAnnotations) {

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -574,6 +574,7 @@ void updateExternalValuesFromPreferences() {
 
       MScore::lassoColor = preferences.getColor(PREF_UI_SCORE_LASSO_COLOR);
       MScore::lassoBorderEnabled = preferences.getBool(PREF_UI_SCORE_LASSO_BORDER_ENABLED);
+      MScore::lassoAnnotations = preferences.getBool(PREF_UI_SCORE_LASSO_ANNOTATIONS);
       MScore::gripsColor = preferences.getColor(PREF_SCORE_GRIPS_COLOR);
 
       MScore::overrideAllColor = preferences.getColor(PREF_UI_SCORE_OVERRIDE_ALL_ELEMENTS_COLOR);

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -360,6 +360,7 @@ const std::list<const char*> MuseScore::_allToggleOptionsMenuEntries {
             "toggle-options-mouse-hover",
             "toggle-options-vertical-note-drag-allowed",
             "toggle-options-lasso-border",
+            "toggle-options-lasso-annotations",
             "toggle-options-fade-focus",
             "toggle-options-current-system-on-top",
             };
@@ -870,6 +871,8 @@ void MuseScore::populateToggleOptionsMenu()
                         pref = MScore::honorEnPassantVisibility;
                   else if (0==strcmp(option, "lasso-border"))
                         pref = MScore::lassoBorderEnabled;
+                  else if (0==strcmp(option, "lasso-annotations"))
+                        pref = MScore::lassoAnnotations;
                   else if (0==strcmp(option, "move-cursor-by-beat"))
                         pref = MScore::cursorMoveByBeat;
                   else if (0==strcmp(option, "move-cursor-by-measure"))

--- a/mscore/preferences.cpp
+++ b/mscore/preferences.cpp
@@ -243,6 +243,7 @@ void Preferences::init(bool storeInMemoryOnly)
             {PREF_SCORE_NOTE_INPUT_ENTRY_STATUS_ENABLE,            new BoolPreference(false)},
             {PREF_UI_SCORE_DISABLE_NOTE_DRAG_VERTICAL,             new BoolPreference(false)},
             {PREF_UI_SCORE_LASSO_WITHOUT_SHIFT,                    new BoolPreference(true)},
+            {PREF_UI_SCORE_LASSO_ANNOTATIONS,                      new BoolPreference(true)},
             {PREF_SCORE_STYLE_DEFAULTSTYLEFILE,                    new StringPreference("", false)},
             {PREF_SCORE_STYLE_PARTSTYLEFILE,                       new StringPreference("", false)},
             {PREF_SCORE_PLAYBACK_CURSOR_ENTIRE_MEASURE,            new BoolPreference(false, true)},

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -1668,8 +1668,11 @@ void ScoreView::drawElements(QPainter& painter, QList<Element*>& el, Element* ed
       bool hoverUnder = opaqueHoverColor;
       bool haveHover = MScore::hoverColorEnabled && dropTarget; 
       
-      if (haveHover && hoverUnder)
-            drawHoverHighlight(painter, *dropTarget);
+      if (haveHover && hoverUnder) {
+            if (state != ViewState::LASSO) {
+                  drawHoverHighlight(painter, *dropTarget);
+                  }
+            }
 
       // Option: Noteheads behind staff-lines
       // Requires stem to be drawn before noteheads, and a multi-pass approach
@@ -1745,8 +1748,12 @@ void ScoreView::drawElements(QPainter& painter, QList<Element*>& el, Element* ed
                   }
             }
 
-      if (haveHover && !hoverUnder)
-            drawHoverHighlight(painter, *dropTarget);
+      if (haveHover && !hoverUnder) {
+            if (state != ViewState::LASSO) {
+                  drawHoverHighlight(painter, *dropTarget);
+                  }
+            }
+
       }
 
 //---------------------------------------------------------
@@ -1875,7 +1882,7 @@ void ScoreView::paint(const QRect& r, QPainter& p)
                   if (!lasso->bbox().isEmpty()) {
                         lassoToDraw = lasso;
                         bool drawLassoBehindElements = (MScore::lassoColor.alpha() > 200);
-                        if (drawLassoBehindElements) {
+                        if (drawLassoBehindElements && !dropTarget) {
                               lassoToDraw->draw(&p);
                               lassoToDraw = nullptr;
                               }
@@ -2110,7 +2117,7 @@ void ScoreView::paint(const QRect& r, QPainter& p)
             editData.element->drawEditMode(&p, editData);
 
       // Lasso (Transparent overlay) / FOTO capture
-      else if (lassoToDraw) {
+      else if (lassoToDraw && !dropTarget) {
             if (state == ViewState::LASSO)
                   lassoToDraw->draw(&p);
             else
@@ -3149,10 +3156,10 @@ void ScoreView::cmd(const char* s)
                         cv->cmdAddPedal(HookType::HOOK_90, HookType::HOOK_90);
                   }},
             {{"add-noteline"}, [](ScoreView* cv, const QByteArray&) {
-                  cv->cmdAddNoteLine(false);
+                  cv->cmdAddLine(false);
                   }},
             {{"add-noteline-alt"}, [](ScoreView* cv, const QByteArray&) {
-                  cv->cmdAddNoteLine(true);
+                  cv->cmdAddLine(true);
                   }},
             {{"chord-text"}, [](ScoreView* cv, const QByteArray&) {
                   cv->changeState(ViewState::NORMAL);
@@ -4586,7 +4593,65 @@ void ScoreView::doDragLasso(QMouseEvent* ev)
       QRectF _lassoRect(lasso->bbox());
 
       if (dropTarget) {
-            ;
+            if (dropTarget->isLineSegment()) {
+                  // Update line positioning:
+                  QPointF startDest = lasso->startPoint;
+                  QPointF endDest = lasso->endPoint;
+                  LineSegment* tls = toLineSegment(const_cast<Element*>(dropTarget));
+                  Element* startElement = tls->line()->startElement();
+                  Measure* startM = startElement->findMeasure();
+
+                  Segment* startSegment = startM->findFirstR(SegmentType::ChordRest, startM->tick());
+                  Segment* endSegment = startSegment;
+
+                  qreal startX = startSegment->canvasBoundingRect().left();
+                  qreal endX = endSegment->canvasBoundingRect().left();
+
+                  qreal sx1 = startX;
+                  qreal sy1 = startSegment->canvasBoundingRect().y();
+                  qreal mx = startDest.x();
+                  qreal my = startDest.y();
+                  qreal diffX = (mx > sx1) ? (mx - sx1) : -(sx1 - mx);
+                  qreal diffY = (my > sy1) ? (my - sy1) : -(sy1 - my);
+
+                  // START: (OFFSET requires UNSTYLED property)
+                  tls->setOffset(diffX, diffY);
+
+                  // END:
+                  qreal sx2 = endX + diffX;
+                  qreal sy2 = endSegment->canvasBoundingRect().y() + diffY;
+                  qreal mx2 = endDest.x();
+                  qreal my2 = endDest.y();
+                  qreal diffX2 = (mx2 > sx2) ? (mx2 - sx2) : -(sx2 - mx2);
+                  qreal diffY2 = (my2 > sy2) ? (my2 - sy2) : -(sy2 - my2);
+
+                  qreal sdx = startDest.x();
+                  qreal edx = endDest.x();
+                  qreal sdy = startDest.y();
+                  qreal edy = endDest.y();
+
+                  qreal deltaX = sdx > edx ? (sdx - edx) : -(edx - sdx);
+                  qreal deltaY = sdy > edy ? (sdy - edy) : -(edy - sdy);
+                  int straightThreshold = 25;
+                  if (std::abs(deltaX) < straightThreshold) {
+                        diffX2 += deltaX;
+                        }
+                  if (std::abs(deltaY) < straightThreshold) {
+                        diffY2 += deltaY;
+                        }
+
+                  tls->setUserOff2(QPointF(diffX2, diffY2));
+                  tls->triggerLayout();
+                  }
+            }
+      else if (ctrl && MScore::lassoAnnotations) {
+            // Create line:
+            QPointF lassoTopLeft = lasso->canvasBoundingRect().topLeft();
+            QPointF lassoBottomRight = lasso->canvasBoundingRect().bottomRight();
+            Element* el = nearestElement(lassoTopLeft, lassoBottomRight);
+            if (const Measure* m = nearestMeasure(el)) {
+                  dropTarget = cmdAddLine(false, m, nullptr, lasso->startPoint, lasso->endPoint);
+                  }
             }
       else if (shift && !hasSwitchedBorderStyle) {
             MScore::lassoBorderEnabled = !MScore::lassoBorderEnabled;
@@ -4634,8 +4699,8 @@ void ScoreView::endLasso()
                                     qreal diffX = (lx > mx) ? (lx - mx) : -(mx - lx);
                                     qreal diffY = (ly > my) ? (ly - my) : -(my - ly);
                                     img->setOffset(diffX, diffY);
-                                    }
-                              } else err = "uncreated empty image";
+                                    } else err = "uncreated empty image";
+                              }
                         } else err = "no near measure found";
                   } else err = "no near element found";
             if (!err.isEmpty()) qDebug() << "Error:" << err;
@@ -6065,10 +6130,73 @@ void ScoreView::cmdAddPedal(HookType beginHook, HookType endHook)
 //     + a centered text letter "H"
 //---------------------------------------------------------
 
-void ScoreView::cmdAddNoteLine(bool hiddenLineWithText)
+LineSegment* ScoreView::cmdAddLine(const bool hiddenLineWithText, const Measure* startM, const Measure* endM, const QPointF startDest, const QPointF endDest)
       {
       Note* firstNote = 0;
       Note* lastNote  = 0;
+      qreal szEndFont = 24.0;
+
+      if (startM && !endM /* endM is currently superfluous */) {
+            Segment* startSegment = startM->findFirstR(SegmentType::ChordRest, startM->tick());
+            Segment* endSegment   = startSegment;
+            TextLine* tl = static_cast<TextLine*>(Element::create(ElementType::TEXTLINE, score()));
+               tl->setScore(_score);
+               tl->setAnchor(Spanner::Anchor::SEGMENT); // Alternatively: Anchor::MEASURE
+               tl->setVoice(0);
+               tl->setDiagonal(true);
+               tl->setPropertyFlags(Pid::OFFSET,         PropertyFlags::UNSTYLED);
+               tl->setPropertyFlags(Pid::END_FONT_SIZE,  PropertyFlags::UNSTYLED);
+               tl->setPropertyFlags(Pid::END_TEXT_ALIGN, PropertyFlags::UNSTYLED);
+               tl->layout(); // layout creates segment
+               tl->setAutoplace(false);
+               tl->setEndTextAlign(Align::HCENTER | Align::VCENTER);
+               tl->setEndText("<sym>arrowheadBlackRight</sym>");
+               tl->setEndFontSize(szEndFont);
+               tl->styleChanged();
+
+            LineSegment* tls = tl->frontSegment();
+            tls->setPropertyFlags(Pid::OFFSET, PropertyFlags::UNSTYLED); // necessary for offset programming
+            tls->styleChanged();
+
+            // START:
+            qreal startX = startSegment->canvasBoundingRect().left();
+            qreal endX = endSegment->canvasBoundingRect().left();
+            qreal sx1 = startX;
+            qreal sy1 = startSegment->canvasBoundingRect().y();
+            qreal mx = startDest.x();
+            qreal my = startDest.y();
+            qreal diffX = (mx > sx1) ? (mx - sx1) : -(sx1 - mx);
+            qreal diffY = (my > sy1) ? (my - sy1) : -(sy1 - my);
+
+            tls->setOffset(diffX, diffY);
+
+            // END:
+            qreal sx2 = endX + diffX;
+            qreal sy2 = endSegment->canvasBoundingRect().y() + diffY;
+            qreal mx2 = endDest.x();
+            qreal my2 = endDest.y();
+            qreal diffX2 = (mx2 > sx2) ? (mx2 - sx2) : -(sx2 - mx2);
+            qreal diffY2 = (my2 > sy2) ? (my2 - sy2) : -(sy2 - my2);
+            qreal deltaX = std::max(startDest.x(), endDest.x()) - std::min(startDest.x(), endDest.x());
+            qreal deltaY = std::max(startDest.y(), endDest.y()) - std::min(startDest.y(), endDest.y());
+
+            int straightThreshold = 25;
+            if (std::abs(deltaX) < straightThreshold) {
+                  diffX2 -= deltaX;
+                  }
+            if (std::abs(deltaY) < straightThreshold) {
+                  diffY2 -= deltaY;
+                  }
+
+            tls->setUserOff2(QPointF(diffX2, diffY2));
+
+            score()->startCmd();
+               score()->cmdAddSpanner(tl, 0 /*staffIdx*/, startSegment, endSegment);
+            score()->endCmd();
+
+            return tls;
+            }
+
       if (_score->selection().isRange()) {
             int startTrack = _score->selection().staffStart() * VOICES;
             int endTrack   = _score->selection().staffEnd() * VOICES;
@@ -6120,24 +6248,22 @@ void ScoreView::cmdAddNoteLine(bool hiddenLineWithText)
                                           tl->setLineWidth(0.0); // Hidden line
                                           tl->setLineColor(QColor(255, 255, 255, 0));
                                           tl->setBeginTextOffset(QPointF(0.0, -75.0));
-                                          // Lame, but it works for now since ->offset doesn't do shit for some reason
+                                          // TODO: it is now obvious that UNSTYLED property must be utilized to make use of OFFSET
                                           }
                                     _score->undoAddElement(tl);
                                     }
                               }
                         _score->endCmd();
 
-                        return;
+                        return nullptr;
                         }
                   }
-            else  {
-                  // qDebug() << "Invalid Selection to add Note-Anchored Line (rests, etc)";
-                  return;
-                  }
+            else return nullptr;
             }
+
       if (!firstNote || !lastNote) {
             qDebug("addNoteLine: no note %p %p", firstNote, lastNote);
-            return;
+            return nullptr;
             }
 
       TextLine* tl = new TextLine(_score);
@@ -6148,6 +6274,7 @@ void ScoreView::cmdAddNoteLine(bool hiddenLineWithText)
       tl->setTick(firstNote->chord()->tick());
       tl->setSystemFlag(false);
       tl->setEndElement(lastNote);
+      // TODO call layout then consider changing anchor position chord to be "normal" now knowing how to set offsets properly
 
       // --- Workaround for Hammer-on/Pull-off text (sloppy for now)
       if (hiddenLineWithText) {
@@ -6177,6 +6304,8 @@ void ScoreView::cmdAddNoteLine(bool hiddenLineWithText)
                   }
             }
 
+      LineSegment* tls = tl->frontSegment();
+      return tls;
       }
 
 //---------------------------------------------------------

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -3119,7 +3119,19 @@ void ScoreView::cmd(const char* s)
                         cv->changeState(ViewState::NORMAL);
                   }},
             {{"picture"}, [](ScoreView* cv, const QByteArray&) {
-                  cv->cmdAddEmptyImage(true, true);
+                  Element* e = nullptr;
+                  if (ChordRest* fcr = cv->score()->selection().firstChordRest()) {
+                        if (fcr->isChord())
+                              e = toChord(fcr)->upNote();
+                        else
+                              e = fcr;
+                        }
+
+                  if (!e) return;
+
+                  if (Measure* fm = e->findMeasure()) {
+                        cv->cmdAddEmptyImage(MScore::lassoBorderEnabled, true, QRectF(), *fm);
+                        }
                   }},
             {{"add-slur"}, [](ScoreView* cv, const QByteArray&) {
                   cv->cmdAddSlur();
@@ -4547,13 +4559,40 @@ void ScoreView::dragScoreView(QMouseEvent* ev)
 
 void ScoreView::doDragLasso(QMouseEvent* ev)
       {
+      // TODO: Allow no selection to occur when beginning drag (dragging is registerd after "normal click/select")
+
+      bool shift = ev->modifiers() & Qt::ShiftModifier;
+      bool ctrl  = ev->modifiers() & Qt::ControlModifier;
+            (void) ctrl;
+      bool alt   = ev->modifiers() & Qt::AltModifier;
+            (void) alt;
+
+      static bool hasSwitchedBorderStyle = false;
+      if (!shift && hasSwitchedBorderStyle)
+            hasSwitchedBorderStyle = false;
+
       TourHandler::startTour("select-tour");
       QPointF p = toLogical(ev->pos());
       _score->addRefresh(lasso->canvasBoundingRect());
       QRectF r;
+
+      lasso->startPoint = editData.startMove;
+      lasso->endPoint = QPointF(p.x(), p.y());
+
+      // qDebug() << "Lasso-drag start:" << editData.startMove << "current position:" << lasso->endPoint;
+
       r.setCoords(editData.startMove.x(), editData.startMove.y(), p.x(), p.y());
       lasso->setbbox(r.normalized());
       QRectF _lassoRect(lasso->bbox());
+
+      if (dropTarget) {
+            ;
+            }
+      else if (shift && !hasSwitchedBorderStyle) {
+            MScore::lassoBorderEnabled = !MScore::lassoBorderEnabled;
+            hasSwitchedBorderStyle = true;
+            }
+
       r = _matrix.mapRect(_lassoRect);
       QSize sz(r.size().toSize());
       mscore->statusBar()->showMessage(QString("%1 x %2").arg(sz.width()).arg(sz.height()), 3000);
@@ -4567,10 +4606,44 @@ void ScoreView::doDragLasso(QMouseEvent* ev)
 
 void ScoreView::endLasso()
       {
+      Qt::KeyboardModifiers currentModifiers = keyMods; 
+            (void) currentModifiers;
+
+      keyMods = Qt::NoModifier;
       _score->lassoSelect(lasso->bbox());
       _score->addRefresh(lasso->canvasBoundingRect());
+
+      if (MScore::lassoAnnotations) {
+            QString err;
+            QPointF lassoTopLeft = lasso->canvasBoundingRect().topLeft();
+            QPointF lassoBottomRight = lasso->canvasBoundingRect().bottomRight();
+            if (const Element* el = nearestElement(lassoTopLeft, lassoBottomRight)) {
+                  if (const Measure* m = nearestMeasure(el)) {
+                        if (!dropTarget) {
+                              bool framed = MScore::lassoBorderEnabled;
+                              bool transparent = MScore::lassoBorderEnabled;
+                              QRectF lassoRect(lassoTopLeft, QSizeF(lasso->width(), lasso->height()));
+                              if (Image* img = cmdAddEmptyImage(framed, transparent, lassoRect, *m)) {
+                                    Segment* fs = m->findFirstR(SegmentType::ChordRest, m->tick());
+                                    QPointF measureTopLeft = fs->canvasBoundingRect().topLeft();
+                                    qreal lx = lassoTopLeft.x();
+                                    qreal mx = measureTopLeft.x();
+                                    qreal ly = lassoTopLeft.y();
+                                    qreal my = measureTopLeft.y();
+
+                                    qreal diffX = (lx > mx) ? (lx - mx) : -(mx - lx);
+                                    qreal diffY = (ly > my) ? (ly - my) : -(my - ly);
+                                    img->setOffset(diffX, diffY);
+                                    }
+                              } else err = "uncreated empty image";
+                        } else err = "no near measure found";
+                  } else err = "no near element found";
+            if (!err.isEmpty()) qDebug() << "Error:" << err;
+            }
+
+      dropTarget = nullptr;
       lasso->setbbox(QRectF());
-      _score->lassoSelectEnd();
+      MScore::lassoAnnotations ? _score->selection().clear() : _score->lassoSelectEnd();
       _score->update();
       mscore->endCmd();
       }
@@ -5279,36 +5352,40 @@ void ScoreView::startUndoRedo(bool undo)
 //    to be invoked by the "picture" shortcut.
 //---------------------------------------------------------
 
-void ScoreView::cmdAddEmptyImage(bool framed, bool fullyTransparent)
+Image* ScoreView::cmdAddEmptyImage(bool framed, bool fullyTransparent, const QRectF& r, const Measure& m)
       {
-      Element* e = nullptr;
-      if (auto fcr = _score->selection().firstChordRest()) {
-            if (fcr->isChord())
-                  e = toChord(fcr)->upNote();
-            else
-                  e = fcr;
-            }
-      if (!e)
-            return;
-
       Image* s = new Image(_score);
       s->setImageType(ImageType::NONE);
       s->setAutoplace(false);
+      s->setZ(33);
+      s->setVoice(0);
 
-      int alpha = fullyTransparent ? 0 : 88;
-      s->setColor(QColor(0, 0, 0, alpha));
+      int alpha = fullyTransparent ? 0 : MScore::lassoColor.alpha();
+      if (framed && fullyTransparent)
+            s->setFrameColor(MScore::lassoColor);
 
-      qreal frameWidth = framed ? SPATIUM20 : 0.0;
+      s->setColor(QColor(MScore::lassoColor.red(), MScore::lassoColor.green(), MScore::lassoColor.blue(),  alpha));
+
+      qreal frameWidth = framed ? SPATIUM20 * 2.0 : 0.0;
       s->setFrameWidth(frameWidth);
+      s->setParent(m.findFirstR(SegmentType::ChordRest, m.tick()));
 
-      s->setParent(e);
-      s->setSize(QSizeF(10, 10));
+      qreal w = 10;
+      qreal h = 10;
+      if (!r.isEmpty()) {
+            QSizeF sz = s->pixel2size(QSizeF(r.width(), r.height()));
+            w = sz.width();
+            h = sz.height();
+            }
 
+      s->setSize(QSizeF(w, h));
       s->setLockAspectRatio(false);
 
       _score->startCmd();
          _score->undoAddElement(s);
       _score->endCmd();
+
+      return s;
       }
 
 //---------------------------------------------------------
@@ -7366,6 +7443,64 @@ Element* ScoreView::elementNear(QPointF p)
 #endif
       Element* e = ll.at(0);
       return e;
+      }
+
+//---------------------------------------------------------
+//   nearestElement
+//---------------------------------------------------------
+
+Element* ScoreView::nearestElement(const QPointF& point, const QPointF& point2)
+      {
+      const int testLimit = 50;
+      const int testStep  = 10;
+      Element* el = elementNear(point);
+      QPointF leftTest = point;
+      QPointF rightTest = point2;
+
+      // Attempt finding near-element: Vertical test
+      for (int i = 0; !el && i < testLimit; ++i) {
+            rightTest.ry() -= testStep;
+            leftTest.ry() += testStep;
+            el = elementNear(leftTest) ? elementNear(leftTest) : elementNear(rightTest);
+            }
+
+      if (!el) {
+            // TODO: contrary 45 degree testing
+            }
+
+      return el;
+      }
+
+//---------------------------------------------------------
+//   nearestMeasure
+//---------------------------------------------------------
+
+const Measure* ScoreView::nearestMeasure(const Element* el)
+      {
+      const Measure* m = nullptr;
+      if (el) {
+            if (const Measure* ms = el->findMeasure()) {
+                  m = ms;
+                  }
+            else if (el->isSpannerSegment()) {
+                  const SpannerSegment* sseg = toSpannerSegment(el);
+                  if (const Element* sEl = sseg->spanner()->startElement()) {
+                        m = sEl->findMeasure();
+                        }
+                  }
+            else if (el->isBeam()) {
+                  m = toBeam(el)->elements().first()->measure();
+                  }
+            else if (el->isMeasureBase()) {
+                  m = toMeasureBase(el)->nextMeasure();
+                  }
+            else if (const Element* p1 = el->parent()) {
+                  if (const Measure* m2 = p1->findMeasure()) {
+                        m = m2;
+                        }
+                  }
+            }
+      return m;
       }
 
 //---------------------------------------------------------

--- a/mscore/scoreview.h
+++ b/mscore/scoreview.h
@@ -446,7 +446,7 @@ class ScoreView : public QWidget, public MuseScoreView {
       void addSlur(ChordRest*, ChordRest*, const Slur*) override;
       virtual void cmdAddHairpin(HairpinType);
       virtual void cmdAddPedal(HookType, HookType);
-      void cmdAddNoteLine(bool);
+      LineSegment* cmdAddLine(const bool, const Measure* startM=nullptr, const Measure* endM=nullptr, const QPointF startDest=QPointF(), const QPointF endDest=QPointF());
       Image* cmdAddEmptyImage(const bool, const bool, const QRectF&, const Measure& m);
 
       void setEditElement(Element*);

--- a/mscore/scoreview.h
+++ b/mscore/scoreview.h
@@ -186,6 +186,8 @@ class ScoreView : public QWidget, public MuseScoreView {
 
       QFocusFrame* focusFrame;
 
+      Qt::KeyboardModifiers keyMods;
+
       EditData editData;
       std::vector<std::unique_ptr<ElementGroup>> dragGroups;
 
@@ -445,7 +447,7 @@ class ScoreView : public QWidget, public MuseScoreView {
       virtual void cmdAddHairpin(HairpinType);
       virtual void cmdAddPedal(HookType, HookType);
       void cmdAddNoteLine(bool);
-      void cmdAddEmptyImage(bool, bool);
+      Image* cmdAddEmptyImage(const bool, const bool, const QRectF&, const Measure& m);
 
       void setEditElement(Element*);
       void updateEditElement();
@@ -553,6 +555,9 @@ class ScoreView : public QWidget, public MuseScoreView {
       void selectInstrument(InstrumentChange*);
       EditData& getEditData()        { return editData; }
       void changeState(ViewState);
+
+      Element* nearestElement(const QPointF& point, const QPointF& point2);
+      const Measure* nearestMeasure(const Element* el);
 
       virtual const QRect geometry() const override { return QWidget::geometry(); }
 

--- a/mscore/shortcut.cpp
+++ b/mscore/shortcut.cpp
@@ -2746,6 +2746,17 @@ Shortcut Shortcut::_sc[] = {
       {
          MsWidget::MAIN_WINDOW,
          STATE_HIDDEN | STATE_NORMAL | STATE_NOTE_ENTRY,
+         "toggle-options-lasso-annotations",
+         QT_TRANSLATE_NOOP("action","Annotations (Lasso/Dbl-Click Text)"),
+         QT_TRANSLATE_NOOP("action","Annotations (Lasso/Dbl-Click Text)"),
+         0,
+         Icons::checkmark_ICON,
+         Qt::ApplicationShortcut,
+         ShortcutFlags::A_CHECKABLE
+         },
+      {
+         MsWidget::MAIN_WINDOW,
+         STATE_HIDDEN | STATE_NORMAL | STATE_NOTE_ENTRY,
          "toggle-options-fingering-tightening-layout",
          QT_TRANSLATE_NOOP("action","Fingering: Tightening (Multi-Voicing)"),
          QT_TRANSLATE_NOOP("action","Fingering: Tightening (Multi-Voicing)"),


### PR DESCRIPTION
**Advanced Preference** `ui/score/mouse/behavior/lasso/annotations`  enables the following behavior
(The option will be in the Toggle Option drop-down):

![image](https://github.com/user-attachments/assets/42558c5a-8f41-4ed4-b373-fca4fbfb29a7)



### Lasso Highlighting/Frame
Lasso will create a highlighted rectangle, or framed-rectangle with nothing inside of it (based on png/svg image code). The color is based on Lasso Color which is user-definable in this repository. Multiple colors can be preemptively used by changing lasso color quickly via the [Override color] drop-down menu instead of resorting to advanced preferences dialog.

As the user performs the lasso function, pressing shift will switch between framed+transparent or unframed+highlight. The switch only occurs *during* lasso-drag, i.e. while dragging the mouse.

### Draw a line with an arrow anywhere 
So long as a musical system can be found in proximity to the begin point of a lasso-drag, this will occur if the user presses CTRL to switch from highlight/frame to a line.
- Vertical/Horizontal state "clicks" within a small threshold for ease
- No color variation (not based on lasso color): just black


**Demonstration**

[HIGHLIGHT.webm](https://github.com/user-attachments/assets/43adb580-ee00-4a1e-aca9-097a3561cb94)


### Double-clicking anywhere will create a staff-text at that location
These next two features are kind of gimmicky, but possibly useful when having no easy access to an alpha-numeric keyboard (using a mouse with an on-screen keyboard or opening the special characters dialog with the Unicode symbols tab)

[TEXT.webm](https://github.com/user-attachments/assets/15c127cf-b791-4748-b67b-8bc7f613e58e)


### Double-clicking a notehead will create a finger-text on that note
- This is borderline superfluous, but mainly for a special personal purpose when not having access to a keyboard for updating fingering + using palettes/special characters for entry. Normally you can just apply a finger-text via the palette, without needing to create a fingering text first, but if using fingering text for "typing in something else" for directions or whatever via mouse using special character list, that's another story. Either way, it'll only work when the adv. preference is on.