### PR TITLE
Score Fonts: Repeat dots for some fonts need fixing (External fonts)

### DIFF
--- a/libmscore/barline.cpp
+++ b/libmscore/barline.cpp
@@ -525,8 +525,21 @@ void BarLine::drawDots(QPainter* painter, qreal x) const
       else {
             const StaffType* st = staffType();
 
+
             //workaround to make Emmentaler, Gonville and MuseJazz font work correctly with repeatDots
-            qreal offset = (score()->scoreFont()->name() == "Emmentaler" || score()->scoreFont()->name() == "Gonville" || score()->scoreFont()->name() == "MuseJazz") ? 0.5 * score()->spatium() * mag() : 0;
+            auto& sfn = score()->scoreFont()->name();
+
+            // Taking the "longer route" since external fonts often need the additional half-spatium application:
+            qreal offset = sfn == "Leland"          ||
+                           sfn == "Bravura"         ||
+                           sfn == "Petaluma"        ||
+                           sfn == "Finale Maestro"  ||
+                           sfn == "Finale Broadway" ||
+                           sfn == "Leipzig"         ||
+                           sfn == "Valerio"
+                              ? 0.0
+                              : 0.5 * score()->spatium() * mag();
+
             y1l          = st->doty1() * _spatium + offset;
             y2l          = st->doty2() * _spatium + offset;
             


### PR DESCRIPTION
Was getting:

![image](https://github.com/user-attachments/assets/60e1e5a2-243a-4965-a61e-c86fbe40622c)
![image](https://github.com/user-attachments/assets/3eec342a-0b93-4fdf-82da-b2438c5dbb5d)

Cause was due to 
**Fix GH#14787: Finale Maestro / Broadway: repeat dots appear too low**
saving on code space - the ternary check's nature was inverted sometime in 3.7-Evolution but it affected my local external fonts adversely 