### PR TITLE
Option to omit asking to restore session when having quit unexpectedly

### DIFF
--- a/global/settings/types/preferencekeys.h
+++ b/global/settings/types/preferencekeys.h
@@ -213,6 +213,7 @@
 #define PREF_UI_APP_STARTUP_SHOWSPLASHSCREEN                "ui/application/startup/showSplashScreen"
 #define PREF_UI_APP_STARTUP_SHOWSTARTCENTER                 "ui/application/startup/showStartCenter"
 #define PREF_UI_APP_STARTUP_SHOWTOURS                       "ui/application/startup/showTours"
+#define PREF_UI_APP_STARTUP_RESTORE_SESSION                 "ui/application/startup/restoreSession"
 #define PREF_UI_APP_GLOBALSTYLE                             "ui/application/globalStyle"
 #define PREF_UI_APP_LANGUAGE                                "ui/application/language"
 #define PREF_UI_APP_RASTER_HORIZONTAL                       "ui/application/raster/horizontal"

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -5759,14 +5759,16 @@ bool MuseScore::restoreSession(bool always)
                               e.readNext();
                               }
                         else if (tag == "dirty") {
-                              QMessageBox::StandardButton b = QMessageBox::question(0,
-                                 tr("MuseScore"),
-                                 tr("The previous session quit unexpectedly.\n\nRestore session?"),
-                                 QMessageBox::Yes | QMessageBox::No,
-                                 QMessageBox::Yes
-                                 );
-                              if (b != QMessageBox::Yes)
-                                    return false;
+                              if (!preferences.getBool(PREF_UI_APP_STARTUP_RESTORE_SESSION)) {
+                                    QMessageBox::StandardButton b = QMessageBox::question(0,
+                                       tr("MuseScore"),
+                                       tr("The previous session quit unexpectedly.\n\nRestore session?"),
+                                       QMessageBox::Yes | QMessageBox::No,
+                                       QMessageBox::Yes
+                                       );
+                                    if (b != QMessageBox::Yes)
+                                          return false;
+                                    }
                               e.readNext();
                               }
                         else if (tag == "Score") {

--- a/mscore/preferences.cpp
+++ b/mscore/preferences.cpp
@@ -285,6 +285,7 @@ void Preferences::init(bool storeInMemoryOnly)
             {PREF_UI_APP_STARTUP_SHOWSPLASHSCREEN,                 new BoolPreference(true, false)},
             {PREF_UI_APP_STARTUP_SHOWSTARTCENTER,                  new BoolPreference(true, false)},
             {PREF_UI_APP_STARTUP_SHOWTOURS,                        new BoolPreference(true, false)},
+            {PREF_UI_APP_STARTUP_RESTORE_SESSION,                  new BoolPreference(true)},
             {PREF_UI_APP_GLOBALSTYLE,                              new EnumPreference(QVariant::fromValue(defaultAppGlobalStyle), false)},
             {PREF_UI_APP_LANGUAGE,                                 new StringPreference("system", false)},
             {PREF_UI_APP_RASTER_HORIZONTAL,                        new IntPreference(2)},


### PR DESCRIPTION
**Change of default behavior**: no longer ask - just do it. 

![image](https://github.com/user-attachments/assets/a6967cc6-5ce0-42f6-b5cb-6c3c42a68b1c)


Can be turned off via: 
```diff
+ui/application/startup/restoreSession
```

When set to true, this dialogue will no longer show and the previous session will reload automatically: