### PR TITLE
Omitting some qDebug() logs

### DIFF
--- a/audio/drivers/alsa.cpp
+++ b/audio/drivers/alsa.cpp
@@ -537,7 +537,8 @@ void AlsaDriver::write(int n, float* l, float* r)
                   }
             int avail = snd_pcm_avail_update(_play_handle);
             if (avail < 0) {
-                  qDebug("AlsaDriver::write: snd_pcm_avail_update() (%s)", snd_strerror(avail));
+                  // Disabling debug messages here temporarily due to broken pipes manifesting during debugging:
+                  // qDebug("AlsaDriver::write: snd_pcm_avail_update() (%s)", snd_strerror(avail));
                   recover();
                   continue;
                   }

--- a/mscore/zoombox.cpp
+++ b/mscore/zoombox.cpp
@@ -150,7 +150,7 @@ void ZoomBox::setLogicalZoom(const ZoomIndex index, const qreal logicalLevel)
                   // Convert the value to an integer percentage using half-to-even rounding (a.k.a. banker's rounding).
                   const auto logicalLevelPercentage = static_cast<int>((100.0 * logicalLevel) - std::remainder(100.0 * logicalLevel, 1.0));
 
-                  qDebug("ZoomBox::setLogicalZoom(): Formatting logical zoom level as %d%% (rounded from %f)", logicalLevelPercentage, logicalLevel);
+                  // qDebug("ZoomBox::setLogicalZoom(): Formatting logical zoom level as %d%% (rounded from %f)", logicalLevelPercentage, logicalLevel);
                   setItemText(static_cast<int>(ZoomIndex::ZOOM_FREE), QString("%1%").arg(logicalLevelPercentage));
 
                   _previousLogicalLevel = logicalLevel;


### PR DESCRIPTION
Obviously this is for local debugging, not the release build here, but figured to log it via PR