### PR TITLE
Fixes: Toggle option for playback cursor state not being saved + Playback cursor resetting 

### DIFF
--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -606,6 +606,9 @@ void updateExternalValuesFromPreferences() {
       MScore::cursorMoveByMeasure = preferences.getBool(PREF_SCORE_PLAYBACK_CURSOR_ENTIRE_MEASURE);
       MScore::cursorDrawnBehindStaff = preferences.getBool(PREF_SCORE_PLAYBACK_CURSOR_BACKGROUND);
 
+      MScore::cursorResetToStart = preferences.getBool(PREF_SCORE_PLAYBACK_BRING_POSITION_TO_START);
+      MScore::selectionFollowsCursor = preferences.getBool(PREF_SCORE_PLAYBACK_SELECT_POSITION_ON_STOP);
+
       MScore::systemBracketMultiplier = preferences.getDouble(PREF_UI_SCORE_BRACKET_MULTIPLIER);
       MScore::fingeringTextOmitVoicing = preferences.getBool(PREF_UI_SCORE_FINGERING_OMIT_VOICING);
       MScore::fingeringTextOmitTightening = preferences.getBool(PREF_UI_SCORE_FINGERING_OMIT_TIGHTENING);

--- a/mscore/seq.cpp
+++ b/mscore/seq.cpp
@@ -1148,8 +1148,9 @@ void Seq::collectEvents(int utick, bool viaUserNavigation)
             }
 
       updateEventsEnd();
-      auto eventAtTick = events.find(utick);
-      playPos = mscore->loop() ? events.find(cs->loopInTick().ticks()) : eventAtTick;
+
+      // Attempted to use events.find(utick) iinstead of events.cbegin(), but will lose play position:
+      playPos = mscore->loop() ? events.find(cs->loopInTick().ticks()) : events.cbegin();
       playlistChanged = false;
       unmarkNotes();
       mutex.unlock();


### PR DESCRIPTION
**Note to self**:  Apparently the change from **events.cbegin** to **events.find(utick)** was involved in my attempt to fix seeing the playback cursor jumping quickly behind and then forward again during navigation, but it doesn't seem to be necessary for the fix, and it was causing problems by losing the cursor position after starting/stopping more than once, so reverting.

The toggle option problem was just an oversight