### PR TITLE
Various Fixes

### DIFF
--- a/global/settings/types/preferencekeys.h
+++ b/global/settings/types/preferencekeys.h
@@ -206,6 +206,7 @@
 #define PREF_UI_CANVAS_SCROLL_LIMITSCROLLAREA               "ui/canvas/scroll/limitScrollArea"
 #define PREF_UI_APP_NUDGESTEP_10                            "ui/score/nudgeStepCtrl"
 #define PREF_UI_APP_NUDGESTEP_1                             "ui/score/nudgeStep"
+#define PREF_UI_APP_INSPECTOR_DELAY_MS                      "ui/application/inspector/update/delay"
 #define PREF_UI_APP_STARTUP_CHECKUPDATE                     "ui/application/startup/checkUpdate"
 #define PREF_UI_APP_STARTUP_CHECK_EXTENSIONS_UPDATE         "ui/application/startup/checkExtensionsUpdate"
 #define PREF_UI_APP_STARTUP_SHOWNAVIGATOR                   "ui/application/startup/showNavigator"

--- a/libmscore/box.cpp
+++ b/libmscore/box.cpp
@@ -59,10 +59,12 @@ void Box::layout()
                   e->layout();
                   auto _text = toText(e);
                   if (_text->frameType() != FrameType::NO_FRAME) {
-                        qreal x = leftMargin() * DPMM;
-                        qreal y = topMargin() * DPMM;
-                        auto frame   = _text->frameWidth().val() * spatium();
-                        auto padding = _text->paddingWidth().val() * spatium();
+                        const qreal lm = leftMargin() * DPMM;
+                        const qreal tm = topMargin() * DPMM;
+                        const qreal frame   = _text->frameWidth().val() * spatium();
+                        const qreal padding = _text->paddingWidth().val() * spatium();
+                        qreal x = lm;
+                        qreal y = tm;
                         bool negY = (_text->align() & Align::BOTTOM);
                         bool negX = (_text->align() & Align::RIGHT);
                         if (!(_text->align() & Align::HCENTER)) {
@@ -818,10 +820,10 @@ void VBox::layout()
             if (e->isText()) {
                   auto _text = toText(e);
                   if (_text->frameType() != FrameType::NO_FRAME) {
+                        const qreal frame   = _text->frameWidth().val() * spatium();
+                        const qreal padding = _text->paddingWidth().val() * spatium();
                         qreal x = leftMargin() * DPMM;
                         qreal y = topMargin() * DPMM;
-                        auto frame   = _text->frameWidth().val() * spatium();
-                        auto padding = _text->paddingWidth().val() * spatium();
                         bool negY = (_text->align() & Align::BOTTOM);
                         bool negX = (_text->align() & Align::RIGHT);
 

--- a/libmscore/input.cpp
+++ b/libmscore/input.cpp
@@ -197,9 +197,11 @@ void InputState::moveInputPos(Element* e)
       if (e == 0)
             return;
 
-      Segment* s;
+      Segment* s = nullptr;
       if (e->isChordRest())
             s = toChordRest(e)->segment();
+      else if (e->isNote())
+            s = toNote(e)->chord()->segment();
       else
             s = toSegment(e);
 

--- a/libmscore/textbase.cpp
+++ b/libmscore/textbase.cpp
@@ -3155,11 +3155,13 @@ void TextBase::draw(QPainter* p) const
             // Draw background within text-frame
             QRectF bb     = bbox().adjusted(frameWidthVal, frameWidthVal, -frameWidthVal, -frameWidthVal);
             QRectF pageBB = pageBoundingRect().adjusted(frameWidthVal, frameWidthVal, -frameWidthVal, -frameWidthVal);
-            bool skip = (parent() && parent()->isBox());
-            if (MScore::noGui) {;}
-            else if (!skip && !score()->getViewer().empty()) {
-                  for (MuseScoreView* view : score()->getViewer())
-                        view->drawBackgroundOffset(p, bb, pageBB, this);
+            bool isZAltered = propertyDefault(Pid::Z) != z();
+            if (MScore::noGui) {}
+            else if (!score()->getViewer().empty()) {
+                  for (MuseScoreView* view : score()->getViewer()) {
+                        if (!isZAltered)
+                              view->drawBackgroundOffset(p, bb, pageBB, this);
+                        }
                   }
             else p->fillRect(bb, Qt::white);
 

--- a/libmscore/textframe.cpp
+++ b/libmscore/textframe.cpp
@@ -74,21 +74,24 @@ void TBox::layout()
       else
             ; // y = 0;
 #endif
-      qreal x = leftMargin() * DPMM;
-      qreal y = topMargin() * DPMM;
-      auto frame   = _text->frameWidth().val() * spatium();
-      auto padding = _text->paddingWidth().val() * spatium();
+      const qreal lm = leftMargin() * DPMM;
+      const qreal tm = topMargin() * DPMM;
+      const qreal bm = bottomMargin() * DPMM;
+      const qreal frame   = _text->frameWidth().val() * spatium();
+      const qreal padding = _text->paddingWidth().val() * spatium();
+      qreal x = lm;
+      qreal y = tm;
       bool negX = (_text->align() & Align::RIGHT);
       if (_text->hasFrame()) {
             if (!(_text->align() & Align::HCENTER)) {
                   x += (negX ? -frame   : +frame);
                   x += (negX ? -padding : +padding);
                   }
-            y += _text->frameWidth().val() * spatium();
-            y += _text->paddingWidth().val() * spatium();
+            y += frame;
+            y += padding;
             }
       _text->setPos(x, y);
-      h += topMargin() * DPMM + bottomMargin() * DPMM;
+      h += tm + bm - frame;
       bbox().setRect(0.0, 0.0, w, h);
 
       MeasureBase::layout();  // layout LayoutBreak's

--- a/libmscore/textlinebase.cpp
+++ b/libmscore/textlinebase.cpp
@@ -105,52 +105,7 @@ void TextLineBaseSegment::draw(QPainter* painter) const
                   }
             }
 
-      if (!_text->empty()) {
-            _text->setVisible(tl->visible());
-            bool isCenteredText = (tl->beginTextPlace() == PlaceText::CENTERED) || (tl->beginTextPlace() == PlaceText::CENTERED_BROKEN);
-            auto horizon = isCenteredText ? textLine.center() : _text->ipos();
-            auto userOffset = _text->offset();
-            auto lineStrokeOffset = QPointF(0.0, _text->getVAlignOffset());
-            // Note: TextBase stores angle, yet is unused at the moment. Separate angles in future?
-            auto angle  = isCenteredText ? lineAngle : 0.0;
-
-            // Apply user x-y + line width offsets after rotation
-            painter->translate(horizon);
-            painter->rotate(angle);
-            painter->translate(lineStrokeOffset);
-            painter->translate(userOffset);
-
-                  _text->draw(painter);
-
-            painter->translate(-userOffset);
-            painter->translate(-lineStrokeOffset);
-            painter->rotate(-angle);
-            painter->translate(-horizon);
-            }
-
-      if (!_endText->empty()) {
-            _endText->setVisible(tl->visible());
-            auto horizon = textLine.p2();
-            auto userOffset = _endText->offset();
-            auto lineStrokeOffset = QPointF(0.0, _endText->getVAlignOffset());
-            auto angle = lineAngle;
-
-            // Apply user x-y + line-width offsets after rotation
-            painter->translate(horizon);
-            painter->rotate(angle);
-            painter->translate(lineStrokeOffset);
-            painter->translate(userOffset);
-
-                  _endText->draw(painter);
-            
-            painter->translate(-userOffset);
-            painter->translate(-lineStrokeOffset);
-            painter->rotate(-angle);
-            painter->translate(-horizon);
-            }
-
-      if ((npoints == 0) || (score() && (score()->printing() || !score()->showInvisible()) && !tl->lineVisible()))
-            return;
+      bool noLine = (npoints == 0) || (score() && (score()->printing() || !score()->showInvisible()) && !tl->lineVisible());
 
       // color for line (text color comes from the text properties)
 #if 0
@@ -160,6 +115,7 @@ void TextLineBaseSegment::draw(QPainter* painter) const
       else
             color = tl->lineColor();
 #endif
+   if (!noLine) {
 
       if (staff())
             strokeWidth *= mag();
@@ -419,7 +375,51 @@ void TextLineBaseSegment::draw(QPainter* painter) const
                               }
                         }
                   }
+            }
+      }
+      // Draw text after line so that it can have higher Z-Order on print
+      if (!_text->empty()) {
+            _text->setVisible(tl->visible());
+            bool isCenteredText = (tl->beginTextPlace() == PlaceText::CENTERED) || (tl->beginTextPlace() == PlaceText::CENTERED_BROKEN);
+            auto horizon = isCenteredText ? textLine.center() : _text->ipos();
+            auto userOffset = _text->offset();
+            auto lineStrokeOffset = QPointF(0.0, _text->getVAlignOffset());
+            // Note: TextBase stores angle, yet is unused at the moment. Separate angles in future?
+            auto angle  = isCenteredText ? lineAngle : 0.0;
 
+            // Apply user x-y + line width offsets after rotation
+            painter->translate(horizon);
+            painter->rotate(angle);
+            painter->translate(lineStrokeOffset);
+            painter->translate(userOffset);
+
+                  _text->draw(painter);
+
+            painter->translate(-userOffset);
+            painter->translate(-lineStrokeOffset);
+            painter->rotate(-angle);
+            painter->translate(-horizon);
+            }
+
+      if (!_endText->empty()) {
+            _endText->setVisible(tl->visible());
+            auto horizon = textLine.p2();
+            auto userOffset = _endText->offset();
+            auto lineStrokeOffset = QPointF(0.0, _endText->getVAlignOffset());
+            auto angle = lineAngle;
+
+            // Apply user x-y + line-width offsets after rotation
+            painter->translate(horizon);
+            painter->rotate(angle);
+            painter->translate(lineStrokeOffset);
+            painter->translate(userOffset);
+
+                  _endText->draw(painter);
+
+            painter->translate(-userOffset);
+            painter->translate(-lineStrokeOffset);
+            painter->rotate(-angle);
+            painter->translate(-horizon);
             }
 
       }

--- a/mscore/events.cpp
+++ b/mscore/events.cpp
@@ -342,6 +342,10 @@ void ScoreView::focusOutEvent(QFocusEvent* event)
 
 bool ScoreView::startTextEditingOnMouseRelease(QMouseEvent* mouseEvent)
       {
+      if (editData.control()) {
+            return false;
+            }
+
       if (!editData.element || mouseEvent->button() != Qt::LeftButton)
             return false;
 
@@ -433,11 +437,12 @@ void ScoreView::mousePressEventNormal(QMouseEvent* ev)
 
       Qt::KeyboardModifiers keyState = ev->modifiers();
       SelectType st = SelectType::SINGLE;
+      bool ctrl = keyState & Qt::ControlModifier;
       if (keyState == Qt::NoModifier)
             st = SelectType::SINGLE;
       else if (keyState & Qt::ShiftModifier)
             st = SelectType::RANGE;
-      else if (keyState & Qt::ControlModifier)
+      else if (ctrl)
             st = SelectType::ADD;
 
       Element* e = editData.element;
@@ -474,6 +479,11 @@ void ScoreView::mousePressEventNormal(QMouseEvent* ev)
                   }
             else {
                   if (st == SelectType::ADD) {
+                        if (e->isTextBase()) {
+                              // Unpriming current text will omit unintended editing of previous element
+                              // after, e.g., selecting an overlapped text via ctrl modifier:
+                              toTextBase(e)->setPrimed(false);
+                              }
                         // convert range to list
                         if (e->score()->selection().isRange()) {
                               e->score()->selection().setState(SelState::LIST);
@@ -498,8 +508,13 @@ void ScoreView::mousePressEventNormal(QMouseEvent* ev)
                               }
                         }
                   if (e) {
-                        if (!e->selected())
+                        if (!e->selected()) {
                               e->score()->select(e, st, -1);
+                              if (e->isTextBase() && ctrl) {
+                                    toTextBase(e)->setPrimed(true);
+                                    updateEditElement();
+                                    }
+                              }
                         else if (st != SelectType::ADD) {
                               modifySelection = true;
                               elementToSelect = e;
@@ -608,7 +623,19 @@ void ScoreView::mousePressEvent(QMouseEvent* ev)
                         toTextBase(editData.element)->setPrimed(false);
                         }
 
-                  auto en = elementNear(editData.startMove);
+                  bool useRecentSelection = false;
+                  auto el = editData.element;
+                  if (el && el->isTextBase() && toTextBase(el)->isPrimed()) {
+                        auto ens = elementsNear(editData.startMove);
+                        for (auto en : ens) {
+                              if (en == el) {
+                                    useRecentSelection = true;
+                                    break;
+                                    }
+                              }
+                        }
+
+                  auto en = useRecentSelection ? el : elementNear(editData.startMove);
                   if (en && (en->isStaffLines() || en->isStaff()))
                         en = nullptr;
                   setEditElement(en);

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -348,14 +348,14 @@ const std::list<const char*> MuseScore::_allToggleOptionsMenuEntries {
             "toggle-options-move-playback-position-to-start",
 
             "separator-Layout",
-            "toggle-options-noteheads-behind-staff", 
+            "toggle-options-noteheads-behind-staff",
             "toggle-options-noteheads-behind-ledger",
             "toggle-options-ties-consider-ledgers",
             "toggle-options-ties-uniformity",
             "toggle-options-fingering-voicing-layout",
             "toggle-options-fingering-tightening-layout",
             "toggle-options-colored-alteration-noteheads",
-            
+
             "separator-Interaction",
             "toggle-options-mouse-hover",
             "toggle-options-vertical-note-drag-allowed",
@@ -592,7 +592,7 @@ void updateExternalValuesFromPreferences() {
       MScore::overrideNoteheadColor = preferences.getColor(PREF_UI_SCORE_OVERRIDE_NOTEHEAD_COLOR);
       MScore::overrideNoteheadLoweredColor = preferences.getColor(PREF_UI_SCORE_OVERRIDE_NOTEHEAD_LOWERED_COLOR);
       MScore::overrideNoteheadRaisedColor = preferences.getColor(PREF_UI_SCORE_OVERRIDE_NOTEHEAD_RAISED_COLOR);
-      MScore::overrideOnlyAllColor = preferences.getBool(PREF_UI_SCORE_OVERRIDE_ONLY_ALL_COLOR);      
+      MScore::overrideOnlyAllColor = preferences.getBool(PREF_UI_SCORE_OVERRIDE_ONLY_ALL_COLOR);
       MScore::overrideSlursColor = preferences.getColor(PREF_UI_SCORE_OVERRIDE_SLURS_COLOR);
       MScore::overrideStaffLinesColor = preferences.getColor(PREF_UI_SCORE_OVERRIDE_STAFFLINES_COLOR);
       MScore::overrideStaffTextColor = preferences.getColor(PREF_UI_SCORE_OVERRIDE_STAFF_TEXT_COLOR);
@@ -601,7 +601,7 @@ void updateExternalValuesFromPreferences() {
 
       MScore::noteheadsBehindStaff = preferences.getBool(PREF_UI_SCORE_NOTEHEADS_BEHIND_STAFF_LINES);
       MScore::noteheadsBehindLedger = preferences.getBool(PREF_UI_SCORE_NOTEHEADS_BEHIND_LEDGER_LINES);
-      
+
       MScore::cursorMoveByBeat = preferences.getBool(PREF_SCORE_PLAYBACK_CURSOR_MOVE_BY_BEAT);
       MScore::cursorMoveByMeasure = preferences.getBool(PREF_SCORE_PLAYBACK_CURSOR_ENTIRE_MEASURE);
       MScore::cursorDrawnBehindStaff = preferences.getBool(PREF_SCORE_PLAYBACK_CURSOR_BACKGROUND);
@@ -615,7 +615,7 @@ void updateExternalValuesFromPreferences() {
 
       MScore::highlightNotes  = preferences.getBool(PREF_SCORE_PLAYBACK_HIGHLIGHT_NOTES);
       MScore::highlightRests  = preferences.getBool(PREF_SCORE_PLAYBACK_HIGHLIGHT_RESTS);
-      MScore::highlightMore   = preferences.getBool(PREF_SCORE_PLAYBACK_HIGHLIGHT_MORE);  
+      MScore::highlightMore   = preferences.getBool(PREF_SCORE_PLAYBACK_HIGHLIGHT_MORE);
       MScore::highlightLyrics = preferences.getBool(PREF_SCORE_PLAYBACK_HIGHLIGHT_LYRICS);
       MScore::honorEnPassantVisibility = preferences.getBool(PREF_SCORE_PLAYBACK_HONOR_EN_PASSANT_VISIBLE);
 
@@ -856,8 +856,8 @@ void MuseScore::populateToggleOptionsMenu()
                   const char* option = &s[15]; // toggle-options-*
                   auto action = getAction(s);
                   bool pref = false;
-                  
-                  // Maintain these with cmdToggleOptions():                                    
+
+                  // Maintain these with cmdToggleOptions():
                   if (0==strcmp(option, "only-all-color"))
                         pref = MScore::overrideOnlyAllColor;
                   else if (0==strcmp(option, "colored-alteration-noteheads"))
@@ -1438,7 +1438,7 @@ MuseScore::MuseScore()
             _statusBar->addPermanentWidget(new QWidget(this), 2);
             _statusBar->addPermanentWidget(new QWidget(this), 100);
             _statusBar->addPermanentWidget(_modeText, 0);
-      
+
             searchCombo = new SearchComboBox;
                   searchCombo->setObjectName("searchCombo");
                   searchCombo->setParent(_statusBar);
@@ -1461,7 +1461,7 @@ MuseScore::MuseScore()
                   playMode->addItem(tr("Audio track"));
                   playMode->setToolTip(tr("Switch play mode"));
                   connect(playMode, SIGNAL(activated(int)), SLOT(switchPlayMode(int)));
-                  
+
                   _statusBar->addPermanentWidget(playMode);
                   _statusBar->addPermanentWidget(layerSwitch);
                   }
@@ -2796,8 +2796,6 @@ void MuseScore::selectionChanged(SelState selectionState)
             else
                   _pianoTools->clearSelection();
             }
-      if (_inspector)
-            updateInspector();
       }
 
 //---------------------------------------------------------
@@ -3674,8 +3672,8 @@ void MuseScore::midiCtrlReceived(int controller, int value)
       if (!cv)
             return;
       if (!isMidiInEnabled())
-            return;      
-      
+            return;
+
       auto score = cv->score();
       // Observation: [Sustain (>0 is ON)(=0 is OFF) is received twice for some reason thru PortMIDI...
       if (score && controller == CTRL_SUSTAIN) {
@@ -6597,7 +6595,11 @@ void MuseScore::endCmd(bool undoRedo)
       else {
             selectionChanged(SelState::NONE);
             }
-      updateInspector();
+      // Suffer the inspector a slight (ms) programmable delay to smooth navigation
+      QTimer::singleShot(preferences.getInt(PREF_UI_APP_INSPECTOR_DELAY_MS), this, [&]() {
+            updateInspector();
+            });
+
       updatePaletteBeamMode();
 #ifdef SCRIPT_INTERFACE
       getPluginEngine()->endEndCmd(this);
@@ -6753,8 +6755,8 @@ void MuseScore::cmd(QAction* a, const QString& cmd)
             bool isNoteEntry =
                   (_sstate == STATE_NOTE_ENTRY_METHOD_STEPTIME ||
                   _sstate == STATE_NOTE_ENTRY_METHOD_REPITCH ||
-                  _sstate == STATE_NOTE_ENTRY_METHOD_RHYTHM); 
-            
+                  _sstate == STATE_NOTE_ENTRY_METHOD_RHYTHM);
+
             if (isNoteEntry) {
                   // Note Entry - Delete current chord, or move to previous chord in current track
                   auto& is = cs->inputState();

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -7250,10 +7250,6 @@ Timeline* MuseScore::timeline() const
 
 ScriptRecorder* MuseScore::getScriptRecorder()
       {
-#ifdef MSCORE_UNSTABLE
-      if (scriptRecorder)
-            return &scriptRecorder->scriptRecorder();
-#endif
       return nullptr;
       }
 

--- a/mscore/preferences.cpp
+++ b/mscore/preferences.cpp
@@ -278,6 +278,7 @@ void Preferences::init(bool storeInMemoryOnly)
             {PREF_UI_APP_STARTUP_CHECKUPDATE,                      new BoolPreference(checkUpdateStartup)},
             {PREF_UI_APP_NUDGESTEP_10,                             new DoublePreference(1.0, true)},
             {PREF_UI_APP_NUDGESTEP_1,                              new DoublePreference(0.1, true)},
+            {PREF_UI_APP_INSPECTOR_DELAY_MS,                       new IntPreference(200, true)},
             {PREF_UI_APP_STARTUP_CHECKUPDATE,                      new BoolPreference(checkUpdateStartup, false)},
             {PREF_UI_APP_STARTUP_CHECK_EXTENSIONS_UPDATE,          new BoolPreference(checkExtensionsUpdateStartup, false)},
             {PREF_UI_APP_STARTUP_SHOWNAVIGATOR,                    new BoolPreference(false, false)},


### PR DESCRIPTION
### Various Updates:

+ **Fix: Ctrl+Click** would go into edit mode after MouseOff of previous text element (overlapping text)
Additionally, allow editing the CTRL-Selected edit when "double-clicking" again afterwards, taking care
not to allow accidental editing of the "underlapped" text item. This has been a slight quirk for a long time when dealing with "creative" text element overlappings, so this makes the experience much smoother

3.6.2 Attempting to Ctrl Click onto an overlap: The required action for me was to ctrl cycle then on mouse-up it would go into edit-mode of the "under" element, and I'd have to ESC, and then enter into edit mode via keyboard shortcut:

[362ctrledit.webm](https://github.com/user-attachments/assets/8f7a9bfd-aec2-4ae3-aaa2-28827f0743fd)

Improved:

[37ctrledit.webm](https://github.com/user-attachments/assets/3fd9fa8b-50f6-49d2-9b4e-7be7fdf32aa6)


+ **Text Boxes with enabled text frame will include the calculation of frame thickness**,  keeping it within the confines of the height of the text box. Did this earlier (keeping the text and frame inside the Text Box, but apparently accidentally omitted considering the frame thickness (only included the margins)

3.6.2:

[362Tbox.webm](https://github.com/user-attachments/assets/4e90bf59-7897-42b5-8a0a-78df480e61c5)


Improved:

[37TBox.webm](https://github.com/user-attachments/assets/fc6e38c5-c505-4116-b6c4-5e2f727dfb63)


+ **Z-Order altered texts with frames will no longer will have automatic background drawing**, allowing for regular transparency for overlaying to achieve the same default 3.6.2 behavior

+ **TextLines will draw texts after drawing the line** so that text overlays the line (not behind) in case the line overlaps the text due to thickness/offset

+ **Fix Crash: when selecting notehead in Note Entry when Mouse Entry is toggled off**

+ **Inspector + Navigation has a smoother experience**
Inspector updating slightly snags when e.g. holding down navigational arrows: skips can be seen in ScoreView and "felt". The inspector updating is slightly heavy in that it destructs the last, constructs new memory allocations, and then performs a bunch of signal/slot connections, and I think it was being called twice (once during each selection change, and once during the endCmd() generically, specifically when navigating). I omit the selection change update (_note to self: maybe it's possible to perform a selection change without an endCmd()? Might want to be careful here_), and include a delay before actually updating so that the ScoreView update takes precedence when navigating since navigating quickly causes this slightly snag feel, and the delay is programmable (defaults to 200ms) via the Advanced Preference:
`ui/application/inspector/update/delay`. Nothing fancy for efficiency gains, but it does *feel* better (not exactly as smooth as when the Inspector isn't showing, but definitely better) and that is what I was going for.

+ Aside: Script Recorder nullified (probably not required since it only works when UNSTABLE mode, but whatever)