### PR TITLE
Harmony Texts: Editing will traverse Chord Symbols attached to Fret Diagrams

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -3565,6 +3565,16 @@ void Score::cmdRangeToList(bool rests)
                                     }
                               }
                         }
+                  else if (e->isFretDiagram()) {
+                        if (auto h = toFretDiagram(e)->harmony())
+                              select(h);
+                        }
+                  else if (e->isHarmony()) {
+                        if (auto p = toHarmony(e)->parent()) {
+                              if (p->isFretDiagram())
+                                    select(p);
+                              }
+                        }
                   }
             }
       // Default command (last, of course)

--- a/libmscore/fret.cpp
+++ b/libmscore/fret.cpp
@@ -1874,6 +1874,27 @@ void FretDiagram::setTrack(int val)
       }
 
 //---------------------------------------------------------
+//   startEdit
+//---------------------------------------------------------
+
+void FretDiagram::startEdit(EditData& editData)
+      {
+      auto _harmony = harmony();
+      if (!_harmony) {
+            _harmony = new Harmony(score());
+            _harmony->setTrack(track());
+            _harmony->setParent(this);
+            _harmony->setHarmonyType(HarmonyType::STANDARD);
+            score()->startCmd();
+            score()->undoAddElement(_harmony);
+            score()->endCmd();
+            }
+      editData.element = _harmony;
+      score()->select(_harmony, SelectType::SINGLE, 0);
+      _harmony->startEdit(editData);
+      }
+
+//---------------------------------------------------------
 //   endEditDrag
 //---------------------------------------------------------
 

--- a/libmscore/fret.h
+++ b/libmscore/fret.h
@@ -243,6 +243,9 @@ class FretDiagram final : public Element {
       bool acceptDrop(EditData&) const override;
       Element* drop(EditData&) override;
 
+      bool isEditable() const override { return true; }
+      void startEdit(EditData&) override;
+
       void endEditDrag(EditData& editData) override;
       void scanElements(void* data, void (*func)(void*, Element*), bool all=true) override;
 

--- a/mscore/editelement.cpp
+++ b/mscore/editelement.cpp
@@ -104,11 +104,14 @@ void ScoreView::startEditMode(Element* e)
             changeState(ViewState::NORMAL);
       editData.element = e;
       changeState(ViewState::EDIT);
+      e = editData.element;
       if (e->isTextBase()) {
             auto txt = toTextBase(e);
-            TextEditData* ted = static_cast<TextEditData*>(editData.getData(e));
-            TextCursor* currentCursor = &ted->cursor;
-            txt->selectAll(currentCursor);
+            if (!txt->plainText().isEmpty()) {
+                  TextEditData* ted = static_cast<TextEditData*>(editData.getData(e));
+                  TextCursor* currentCursor = &ted->cursor;
+                  txt->selectAll(currentCursor);
+                  }
             }
       adjustCanvasPosition(e, false);
       }

--- a/mscore/editharmony.cpp
+++ b/mscore/editharmony.cpp
@@ -14,6 +14,7 @@
 #include "scoreview.h"
 #include "texttools.h"
 #include "libmscore/chordrest.h"
+#include "libmscore/fret.h"
 #include "libmscore/harmony.h"
 #include "libmscore/score.h"
 #include "libmscore/segment.h"
@@ -28,18 +29,19 @@ namespace Ms {
 void ScoreView::harmonyTab(bool back)
       {
       Harmony* harmony = toHarmony(editData.element);
-      if (!harmony->parent() || !harmony->parent()->isSegment()) {
-            qDebug("no segment parent");
+      Segment* segment = nullptr;
+
+      if (auto p = harmony->parent())
+            segment = toSegment(p->isFretDiagram() ? p->parent() : p);
+
+      if (!segment) {
+            qDebug() << "Error:" << "no parent segment";
             return;
             }
+
       int track        = harmony->track();
       HarmonyType ht   = harmony->harmonyType();
       Tid tid          = harmony->tid();
-      Segment* segment = toSegment(harmony->parent());
-      if (!segment) {
-            qDebug("harmonyTicksTab: no segment");
-            return;
-            }
 
       // moving to next/prev measure
 
@@ -101,18 +103,19 @@ void ScoreView::harmonyTab(bool back)
 void ScoreView::harmonyBeatsTab(bool noterest, bool back)
       {
       Harmony* harmony = toHarmony(editData.element);
-      if (!harmony->parent() || !harmony->parent()->isSegment()) {
-            qDebug("no segment parent");
+      Segment* segment = nullptr;
+      if (auto p = harmony->parent())
+            segment = toSegment(p->isFretDiagram() ? p->parent() : p);
+
+      if (!segment) {
+            qDebug() << "Error:" << "no parent segment";
             return;
             }
+
       int track        = harmony->track();
       HarmonyType ht   = harmony->harmonyType();
       Tid tid          = harmony->tid();
-      Segment* segment = toSegment(harmony->parent());
-      if (!segment) {
-            qDebug("no segment");
-            return;
-            }
+
       Measure* measure = segment->measure();
       Fraction tick = segment->tick();
 
@@ -178,6 +181,15 @@ void ScoreView::harmonyBeatsTab(bool noterest, bool back)
                   Harmony* h = toHarmony(e);
                   harmony = h;
                   break;
+                  }
+            else if (e->isFretDiagram()) {
+                  if (e->track() == track) {
+                        FretDiagram* fd = toFretDiagram(e);
+                        harmony = fd->harmony();
+                        if (harmony && harmony->tid() != tid)
+                              harmony = nullptr;
+                        break;
+                        }
                   }
             }
 

--- a/mscore/pianotools.cpp
+++ b/mscore/pianotools.cpp
@@ -223,8 +223,12 @@ void HPiano::changeSelection(const Selection& selection)
       // Single-selection of Harmony/Fretboard Diagram
       if (const auto e = selection.element()) {
             std::vector<int> harmonyPitches;
-            const auto h = e->isHarmony() ? toHarmony(e) : nullptr;
+            auto h = e->isHarmony() ? toHarmony(e) : nullptr;
             const auto fd = e->isFretDiagram() ? toFretDiagram(e) : nullptr;
+
+            if (h && h->rootTpc() == Tpc::TPC_INVALID)
+                  h = nullptr;
+
             const auto pitches = h ? h->getRealizedHarmony().pitches() : fd ? fd->pitches() : QList<int>{};
             for (const auto& pitch : pitches)
                   harmonyPitches.emplace_back(pitch);


### PR DESCRIPTION

+ **Update**: Just as with regular chord symbol editing, **user may move forward/backward via [spacebar] between chord symbols attached to fretboard diagrams**

Alterations from
**3.6.2/4.x** Spacebar (for navigation) from fretboard diagram's chord symbol will do absolutely nothing
**3.6.2/4.x** Spacebar from a chord symbol to a chord symbol attached to a fretboard diagram will *erase* that chord symbol, and it won't be undoable.
**3.6.2/4.x** attempting to edit a fretboard diagram will do nothing.

+ **Editing a fretboard diagram now will edit an attached Chord Symbol or begin a new one**. Previously editing didn't do anything. Can be achieved via double-click or the command.

+ Custom **Range-To-List command** which offers alternative "cycle" (between stems and beams for example) **now includes selecting a Chord Symbol attached to a Fret Diagram if a Fret Diagram is selected, and vice versa**

+ Fix potential crash from an assert when traversing chord symbols if the chord symbol is in an invalid state (no tonal pitch class deduced) while in Debug build