### PR TITLE
Fix: Timeline contiguity of Rehearsal Marks

### DIFF
--- a/audio/drivers/alsa.cpp
+++ b/audio/drivers/alsa.cpp
@@ -391,15 +391,15 @@ bool AlsaDriver::recover()
       snd_pcm_status_alloca (&stat);
 
       if ((err = snd_pcm_status (_play_handle, stat)) < 0) {
-            qDebug("Alsa_driver: recover: pcm_status(): %s",  snd_strerror (err));
+            // qDebug("Alsa_driver: recover: pcm_status(): %s",  snd_strerror (err));
             return false;
             }
       if (snd_pcm_status_get_state (stat) == SND_PCM_STATE_XRUN) {
             struct timeval tnow, trig;
             gettimeofday (&tnow, 0);
             snd_pcm_status_get_trigger_tstamp (stat, &trig);
-            qDebug("AlsaDriver: recover: stat = %02x, xrun of at least %8.3lf ms", _stat,
-               1e3 * tnow.tv_sec - 1e3 * trig.tv_sec + 1e-3 * tnow.tv_usec - 1e-3 * trig.tv_usec);
+            // qDebug("AlsaDriver: recover: stat = %02x, xrun of at least %8.3lf ms", _stat,
+               // 1e3 * tnow.tv_sec - 1e3 * trig.tv_sec + 1e-3 * tnow.tv_usec - 1e-3 * trig.tv_usec);
             }
 
       if (pcmStop()) {

--- a/mscore/timeline.cpp
+++ b/mscore/timeline.cpp
@@ -1564,8 +1564,10 @@ bool Timeline::addMetaValue(int x, int pos, QString metaText, int row, ElementTy
       bool isRehearsalMark = (elementType == ElementType::REHEARSAL_MARK);
 
       if (isRehearsalMark && _contiguousRM) {
-            if (x == 0)
+            if ((lastPositionEnd == 0) || (lastPositionEnd > pos)) {
+                  x = 0;
                   lastPositionEnd = 0;
+                  }
             x = pos = lastPositionEnd;
             }
 


### PR DESCRIPTION
Apparently didn't take into consideration the first rehearsal mark of a score being at an arbitrary position rather than expecting it to be in the first measure when doing testing earlier... 

+ Also remove some qDebug() statements regarding ALSA
 