### PR TITLE
Fix playback regarding large user-induced navigation

### DIFF
--- a/mscore/events.cpp
+++ b/mscore/events.cpp
@@ -849,7 +849,7 @@ void ScoreView::mouseMoveEvent(QMouseEvent* me)
                   break;
 
             case ViewState::PLAY:
-                  if (drag)
+                  if (!MScore::currentSystemAlwaysTop && drag)
                         dragScoreView(me);
                   break;
 

--- a/mscore/seq.cpp
+++ b/mscore/seq.cpp
@@ -1150,8 +1150,18 @@ void Seq::collectEvents(int utick, bool viaUserNavigation)
 
       updateEventsEnd();
 
-      // Attempted to use events.find(utick) iinstead of events.cbegin(), but will lose play position:
-      playPos = mscore->loop() ? events.find(cs->loopInTick().ticks()) : events.cbegin();
+      // Observation:  Seeking occurs after this current function
+      // Because of quick visual "jump-backs", attempted to use
+      // events.find(utick) instead of events.cbegin(), but that
+      // can somehow lose position upon start/stop
+
+      // Why was playPos updated here? One reason is that it occurs earlier/prior to ::heartBeatTimeout,
+      // allowing its guiPos loop in relation to playPos to be using the correct playPos at that time
+
+      if (mscore->loop())
+            playPos = events.find(cs->loopInTick().ticks());
+      else {;} // playPos = events.cbegin();
+
       playlistChanged = false;
       unmarkNotes();
       mutex.unlock();
@@ -1232,6 +1242,10 @@ void Seq::setPos(int utick)
 
       playFrame = cs->utick2utime(utick) * MScore::sampleRate;
       playPos   = events.lower_bound(utick);
+      guiPos    = playPos; // safeguard against heartBeatTimeout using old guiPos
+
+      unmarkNotes();
+
       mutex.unlock();
       }
 


### PR DESCRIPTION
+ There were still instances of having a lingering "Marked" note on score during playback when  jumping with larger motions than per chord (via mouse). Finally figured out that there was a discrepancy between guiPos and playPos in the process/heartbeat functions, leading to an anomalous position along with a lingering old marking (a race condition of sorts). All the while, doing the original intention which was to fix that "jumping backwards" for a split second when navigating during playback that annoyingly occurs in 3.6.2

Hopefully this is enough to not have to mess with it anymore

+ Aside: I also disable dragging score here while in Playback state if the "**Current System Always On Top**" option is enabled, since it counters such an action and makes it all but useless (and jitters the screen view)