### PR TITLE
Smorgasbord

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -246,9 +246,14 @@ endif (NOT MSVC)
 if (APPLE)
    if (XCODE)
       set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17 -fPIC -stdlib=libc++ -Wno-inconsistent-missing-override -Wno-deprecated-register")
+      set(CMAKE_CXX_STANDARD 17)
+      set(CMAKE_CXX_STANDARD_REQUIRED ON)
    else (XCODE)
       set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++17 -fPIC -stdlib=libc++ -Wno-inconsistent-missing-override -Wno-deprecated-register")
+	  set(CMAKE_CXX_STANDARD 17)
+      set(CMAKE_CXX_STANDARD_REQUIRED ON)
    endif (XCODE)
+   
    # This is necessary for genManual to be executed during the build phase,
    # it needs to be able to get the Qt libs.
    # TODO: is it still needed? genManual is removed.

--- a/audio/drivers/alsa.cpp
+++ b/audio/drivers/alsa.cpp
@@ -567,18 +567,20 @@ void AlsaDriver::write(int n, float* l, float* r)
                   void* bp[2];
                   bp[0] = lbuffer;
                   bp[1] = rbuffer;
-                  if ((err = snd_pcm_writen(_play_handle, bp, n)) < 0)
-                        qDebug("AlsaDriver::write(): failed (%s)", snd_strerror(err));
+                  if ((err = snd_pcm_writen(_play_handle, bp, n)) < 0) {
+                        // qDebug("AlsaDriver::write(): failed (%s)", snd_strerror(err));
+                        }
                   }
             else if (_play_access == SND_PCM_ACCESS_RW_INTERLEAVED) {
                   short buffer[n * 2];
                   _play_func(l, (char*)buffer, 4, n);
                   _play_func(r, (char*)(buffer + 1), 4, n);
-                  if ((err = snd_pcm_writei(_play_handle, buffer, n)) < 0)
-                        qDebug("AlsaDriver::write(): failed (%s)", snd_strerror(err));
+                  if ((err = snd_pcm_writei(_play_handle, buffer, n)) < 0) {
+                        // qDebug("AlsaDriver::write(): failed (%s)", snd_strerror(err));
+                        }
                   }
             else {
-                  qDebug("AlsaDriver::write(): unsupported access type %d", _play_access);
+                  // qDebug("AlsaDriver::write(): unsupported access type %d", _play_access);
                   return;
                   }
             }

--- a/libmscore/chord.cpp
+++ b/libmscore/chord.cpp
@@ -3853,12 +3853,12 @@ void Chord::layoutArticulations3(Slur* slur)
             if (aShape.intersects(sShape)) {
                   qreal d = score()->styleS(Sid::articulationMinDistance).val() * spatium();
                   if (slur->up()) {
-                        d += qMax(aShape.minVerticalDistance(sShape), 0.0);
+                        d = qMax(aShape.minVerticalDistance(sShape), 0.0);
                         a->rypos() -= d;
                         aShape.translateY(-d);
                         }
                   else {
-                        d += qMax(sShape.minVerticalDistance(aShape), 0.0);
+                        d = qMax(sShape.minVerticalDistance(aShape), 0.0);
                         a->rypos() += d;
                         aShape.translateY(d);
                         }

--- a/libmscore/chord.h
+++ b/libmscore/chord.h
@@ -79,7 +79,7 @@ class Chord final : public ChordRest {
 
       qreal upPos()   const override;
       qreal downPos() const override;
-      qreal centerX() const;
+
       void addLedgerLines();
       void processSiblings(std::function<void(Element*)> func) const;
 
@@ -164,6 +164,8 @@ class Chord final : public ChordRest {
       QPointF stemPosBeam() const override;      ///< page coordinates
       qreal stemPosX() const override;
       qreal rightEdge() const override;
+
+      qreal centerX() const;
 
       bool underBeam() const;
       Hook* hook() const                     { return _hook; }

--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -3306,7 +3306,8 @@ void Score::cmdIncDecDuration(int nSteps, bool stepDotted)
                   }
             }
       else {
-            initialDuration = _is.duration();
+            const bool repitch = NoteEntryMethod::REPITCH == _is.noteEntryMethod();
+            initialDuration = repitch ? cr->durationType() : _is.duration();
             }
       TDuration d = (nSteps != 0) ? initialDuration.shiftRetainDots(nSteps, stepDotted) : initialDuration;
       if (!d.isValid())

--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -116,6 +116,25 @@ void CmdState::setTick(const Fraction& t)
       }
 
 //---------------------------------------------------------
+//   setTick - Explicit start/end setting: discretion advised
+//---------------------------------------------------------
+
+void CmdState::setTick(TickType tt, const Fraction& t)
+      {
+      if (_locked) {
+            qDebug() << "Failed: CmdState locked";
+            return;
+            }
+
+      if (tt == TickType::StartTick)
+            _startTick = t;
+      else if (tt == TickType::EndTick)
+            _endTick = t;
+
+      setUpdateMode(UpdateMode::Layout);
+      }
+
+//---------------------------------------------------------
 //   setStaff
 //---------------------------------------------------------
 

--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -2852,7 +2852,7 @@ Element* Score::move(const QString& cmd)
                   if (selection().isRange()) {
                         cr = selection().firstChordRest();
                         }
-                  el = prevMeasure(cr);
+                  el = noteEntryMode() ? cr : prevMeasure(cr);
                   }
 
             if (el) {

--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -108,17 +108,10 @@ void CmdState::setTick(const Fraction& t)
       if (_locked)
             return;
 
-      if (_startTick == Fraction(-1,1) || t < _startTick) {
+      if (_startTick == Fraction(-1,1) || t < _startTick)
             _startTick = t;
-            qDebug()<<"START"<<t.print();
-            if (_startTick == Fraction(-1,1) || _startTick == Fraction(0,1)) {
-                  qDebug() << "Rock bottom" << "do break";
-                  }
-            }
-      if (_endTick == Fraction(-1,1) || t > _endTick) {
+      if (_endTick == Fraction(-1,1) || t > _endTick)
             _endTick = t;
-            qDebug()<<"END"<<t.print();
-            }
       setUpdateMode(UpdateMode::Layout);
       }
 
@@ -321,7 +314,6 @@ void CmdState::dump()
 
 void Score::update(bool resetCmdState)
       {
-      qDebug() << "update begin";
       bool updateAll = false;
       for (MasterScore* ms : *movements()) {
             CmdState& cs = ms->cmdState();
@@ -366,7 +358,6 @@ void Score::update(bool resetCmdState)
             }
       if (_selection.isRange() && !_selection.isLocked())
             _selection.updateSelectedElements();
-      qDebug() << "update end";
       }
 
 //---------------------------------------------------------
@@ -5163,7 +5154,6 @@ void Score::cmdAddFret(int fret)
 
 void Score::cmdRelayout()
       {
-      qDebug()<<"";
       setLayoutAll();
       }
 

--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -4768,6 +4768,7 @@ void Score::cmdUnsetVisible()
 void Score::cmdAddPitch(const EditData& ed, int note, bool addFlag, bool insert, bool useUpNote, bool below)
       {
       InputState& is = inputState();
+      const bool repitchMode = is.noteEntryMethod() == NoteEntryMethod::REPITCH;
       if (is.track() == -1)          // invalid state
             return;
       if (is.duration() == TDuration::DurationType::V_INVALID) {
@@ -4943,6 +4944,15 @@ void Score::cmdAddPitch(const EditData& ed, int note, bool addFlag, bool insert,
                                           }
                                     }
                               seg = seg->prev1MM(SegmentType::ChordRest | SegmentType::Clef | SegmentType::HeaderClef);
+                              }
+                        if (repitchMode) {
+                              if (!resetOctave() && (previousPitch > 0)) {
+                                    if (is.tick() == el->tick()) {
+                                          // calculate octave based on selection pitch
+                                          // instead of actual previous input pitch (previousPitch here is score selection)
+                                          curPitch = previousPitch;
+                                          }
+                                    }
                               }
                         octave = curPitch / PITCH_DELTA_OCTAVE;
                         }

--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -2646,7 +2646,13 @@ Element* Score::move(const QString& cmd)
                   Measure* m = _is.segment()->measure();
                   Segment* s = _is.segment()->prev1(SegmentType::ChordRest);
                   int track = _is.track();
-                  for (; s; s = s->prev1(SegmentType::ChordRest)) {
+
+                  if (auto scr = selection().cr()) {
+                        if (s && s->tick() > scr->tick()) {
+                              _is.moveInputPos(scr);
+                              }
+                        }
+                  else for (; s; s = s->prev1(SegmentType::ChordRest)) {
                         if (s->element(track) || (s->measure() != m && s->rtick().isZero())) {
                               if (s->element(track)) {
                                     el = s->nextChordRest(track, true);
@@ -2878,6 +2884,11 @@ Element* Score::move(const QString& cmd)
             el = nullptr;
             bool next = (cmd == "next-system");
             MeasureBase* dest = nullptr;
+
+            if (auto scr = selection().cr())
+                  if (!next && (_is.tick() > scr->tick()))
+                        cr = scr;
+
             if (cr) {
                   if (auto m = cr->findMeasureBase()) {
                         if (!next) {

--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -2841,18 +2841,20 @@ Element* Score::move(const QString& cmd)
                   }
             }
       else if (cmd == "prev-measure") {
-            cr = firstCR ? firstCR : cr;
+            const bool isRange = selection().isRange();
+            if (firstCR)
+                  cr = firstCR;
             auto currentTrack = noteEntryMode() ? _is.track() : 0;
             if (box && box->prevMeasure() && box->prevMeasure()->first())
                   el = box->prevMeasure()->first()->nextChordRest(0, false);
             if (cr) {
-                  if (selection().cr() && (cr->tick() != selection().cr()->tick())) {
-                        cr = selection().cr();
-                        }
-                  if (selection().isRange()) {
-                        cr = selection().firstChordRest();
-                        }
-                  el = noteEntryMode() ? cr : prevMeasure(cr);
+                  const auto scr = selection().cr();
+                  const auto fcr = selection().firstChordRest();
+                  if (isRange)
+                        cr = fcr;
+                  else if (scr && (cr->tick() != scr->tick()))
+                        cr = scr;
+                  el = (isRange && noteEntryMode()) ? cr : prevMeasure(cr);
                   }
 
             if (el) {

--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -318,10 +318,12 @@ void Score::update(bool resetCmdState)
       for (MasterScore* ms : *movements()) {
             CmdState& cs = ms->cmdState();
             ms->deletePostponed();
-            if (cs.layoutRange()) {
-                  for (Score* s : ms->scoreList())
-                        s->doLayoutRange(cs.startTick(), cs.endTick());
-                  updateAll = true;
+            if (!printing()) {
+                  if (cs.layoutRange()) {
+                        for (Score* s : ms->scoreList())
+                              s->doLayoutRange(cs.startTick(), cs.endTick());
+                        updateAll = true;
+                        }
                   }
             }
 

--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -759,6 +759,7 @@ Note* Score::setGraceNote(Chord* ch, int pitch, NoteType type, int len)
       {
       Note* note = new Note(this);
       Chord* chord = new Chord(this);
+      Segment* oseg = _is.segment();
 
       // allow grace notes to be added to other grace notes
       // by really adding to parent chord
@@ -791,6 +792,8 @@ Note* Score::setGraceNote(Chord* ch, int pitch, NoteType type, int len)
 
       undoAddElement(chord);
       select(note, SelectType::SINGLE, 0);
+      if (usingNoteEntryMethod(NoteEntryMethod::RHYTHM))
+            _is.setSegment(oseg);
       return note;
       }
 
@@ -4781,9 +4784,36 @@ void Score::cmdAddPitch(const EditData& ed, int note, bool addFlag, bool insert,
             }
 
       qreal previousPitch = -1;
+
+      // Grace-note entry: get previous pitch
+      int gracePitchOverride = -1;
       if (auto e = selection().element()) {
             if (e->isNote()) {
-                  previousPitch = toNote(e)->pitch();
+                  auto n = toNote(e);
+                  auto c = n->chord();
+                  previousPitch = n->pitch();
+                  if (c->isGrace()){
+                        int graceIdx = c->graceIndex();
+                        int prevGraceIdx = --graceIdx;
+                        auto parentChord = toChord(c->parent());
+                        const auto graceNotes = parentChord->graceNotes();
+                        for (Chord* graceChord : graceNotes) {
+                              bool havePrevGraceNote = (graceChord->graceIndex() == prevGraceIdx);
+                              if (havePrevGraceNote) {
+                                    // Use previous grace note for octave placement:
+                                    auto prevNote = graceNotes.at(prevGraceIdx)->upNote();
+                                    gracePitchOverride = prevNote->ppitch();
+                                    break;
+                                    }
+                              }
+                        if (gracePitchOverride < 0) {
+                              // No previous grace-note: use current selection for octave placement
+                              auto firstGraceNote = MScore::noteInputOctaveTendencyIsTopNote
+                                          ? graceNotes.front()->upNote()
+                                          : graceNotes.front()->downNote();
+                              gracePitchOverride = firstGraceNote->ppitch();
+                              }
+                        }
                   }
             }
 
@@ -4954,6 +4984,10 @@ void Score::cmdAddPitch(const EditData& ed, int note, bool addFlag, bool insert,
                                           }
                                     }
                               }
+
+                        if (gracePitchOverride > -1)
+                              curPitch = gracePitchOverride;
+
                         octave = curPitch / PITCH_DELTA_OCTAVE;
                         }
 

--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -1824,7 +1824,7 @@ void Score::upDown(bool up, UpDownMode mode)
                                     undo(new RemoveElement(ln->accidental()));
                               }
                         }
-                  if (mode == UpDownMode::OCTAVE_QUICK && !hasTie && !selection().isRange()) {
+                  if (mode == UpDownMode::OCTAVE_QUICK && !hasTie && noteEntryMode()) {
                         // This style of octave-shifting will guarantee the exact explicit accidental-type
                         // as it was before shifting - useful for transcribing in note-entry.
                         startCmd();

--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -5911,6 +5911,12 @@ void Score::cmd(const QAction* a, EditData& ed)
                   startCmd();
                   c.cmd(this, ed);
                   endCmd();
+
+                  if (const auto se = selection().element()) {
+                        for(MuseScoreView* v : qAsConst(viewer))
+                              v->adjustCanvasPosition(se, false);
+                        }
+
                   return;
                   }
             }

--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -108,10 +108,17 @@ void CmdState::setTick(const Fraction& t)
       if (_locked)
             return;
 
-      if (_startTick == Fraction(-1,1) || t < _startTick)
+      if (_startTick == Fraction(-1,1) || t < _startTick) {
             _startTick = t;
-      if (_endTick == Fraction(-1,1) || t > _endTick)
+            qDebug()<<"START"<<t.print();
+            if (_startTick == Fraction(-1,1) || _startTick == Fraction(0,1)) {
+                  qDebug() << "Rock bottom" << "do break";
+                  }
+            }
+      if (_endTick == Fraction(-1,1) || t > _endTick) {
             _endTick = t;
+            qDebug()<<"END"<<t.print();
+            }
       setUpdateMode(UpdateMode::Layout);
       }
 
@@ -314,6 +321,7 @@ void CmdState::dump()
 
 void Score::update(bool resetCmdState)
       {
+      qDebug() << "update begin";
       bool updateAll = false;
       for (MasterScore* ms : *movements()) {
             CmdState& cs = ms->cmdState();
@@ -358,6 +366,7 @@ void Score::update(bool resetCmdState)
             }
       if (_selection.isRange() && !_selection.isLocked())
             _selection.updateSelectedElements();
+      qDebug() << "update end";
       }
 
 //---------------------------------------------------------
@@ -5154,6 +5163,7 @@ void Score::cmdAddFret(int fret)
 
 void Score::cmdRelayout()
       {
+      qDebug()<<"";
       setLayoutAll();
       }
 

--- a/libmscore/dynamic.cpp
+++ b/libmscore/dynamic.cpp
@@ -227,12 +227,8 @@ void Dynamic::layout()
                   if (!e)
                         continue;
                   if (e->isChord() && (align() & Align::HCENTER)) {
-                        Chord* c = toChord(e);
-                        qreal noteHeadWidth = score()->noteHeadWidth() * c->mag();
-                        if (c->stem() && !c->up())  // stem down
-                              rxpos() += noteHeadWidth * .25;  // center on stem + optical correction
-                        else
-                              rxpos() += noteHeadWidth * .5;   // center on notehead
+                        const auto c = toChord(e);
+                        rxpos() += e->x() + c->centerX();
                         }
                   else
                         rxpos() += e->width() * .5;

--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -564,7 +564,9 @@ bool Score::rewriteMeasures(Measure* fm, Measure* lm, const Fraction& ns, int st
                   continue;
             nfm->setPrev(m1->prev());
             nlm->setNext(m2->next());
+            setPrinting(true);
             s->undo(new InsertMeasures(nfm, nlm));
+            setPrinting(false);
             }
       if (!fill.isZero())
             undoInsertTime(lm->endTick(), fill);
@@ -864,10 +866,13 @@ void Score::cmdAddTimeSig(Measure* fm, int staffIdx, TimeSig* ts, bool local)
             // we will only add time signatures if this succeeds
             // this means, however, that the rewrite cannot depend on the time signatures being in place
             if (mf) {
+                  setPrinting(true);
                   if (!mScore->rewriteMeasures(mf, ns, local ? staffIdx : -1)) {
                         undoStack()->current()->unwind();
+                        setPrinting(false);
                         return;
                         }
+                  setPrinting(false);
                   }
             // add the time signatures
             std::map<int, TimeSig*> masterTimeSigs;

--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -1290,6 +1290,7 @@ void Score::cmdAddTie(bool addToChord)
             if (noteEntryMode()) {
                   ChordRest* cr = nullptr;
                   Chord* c = note->chord();
+                  int staffMove = c->staffMove();
 
                   // set cursor at position after note
                   if (c->isGraceBefore()) {
@@ -1324,8 +1325,12 @@ void Score::cmdAddTie(bool addToChord)
 
                   // if no note to re-use, create one
                   NoteVal nval(note->noteVal());
-                  if (!n)
+                  if (!n) {
                         n = addPitch(nval, addFlag);
+                        if (staffMove) {
+                              undo(new ChangeChordStaffMove(n->chord(), staffMove));
+                              }
+                        }
                   else
                         select(n);
 
@@ -1354,6 +1359,11 @@ void Score::cmdAddTie(bool addToChord)
                                     note = nnote;
                                     _is.setLastSegment(_is.segment());
                                     nnote = addPitch(nval, true);
+                                    }
+                              }
+                        if (staffMove) {
+                              for (Note* tiedNote : n->tiedNotes()) {
+                                    undo(new ChangeChordStaffMove(tiedNote->chord(), staffMove));
                                     }
                               }
                         }

--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -564,9 +564,7 @@ bool Score::rewriteMeasures(Measure* fm, Measure* lm, const Fraction& ns, int st
                   continue;
             nfm->setPrev(m1->prev());
             nlm->setNext(m2->next());
-            setPrinting(true);
             s->undo(new InsertMeasures(nfm, nlm));
-            setPrinting(false);
             }
       if (!fill.isZero())
             undoInsertTime(lm->endTick(), fill);
@@ -866,6 +864,8 @@ void Score::cmdAddTimeSig(Measure* fm, int staffIdx, TimeSig* ts, bool local)
             // we will only add time signatures if this succeeds
             // this means, however, that the rewrite cannot depend on the time signatures being in place
             if (mf) {
+                  // When re-writing measures, theoretically there should be no need to doLayoutRange() until finalized
+                  // _printing flag will serve as a hack to denote not to perform layout during the operation
                   setPrinting(true);
                   if (!mScore->rewriteMeasures(mf, ns, local ? staffIdx : -1)) {
                         undoStack()->current()->unwind();
@@ -1343,7 +1343,9 @@ void Score::cmdAddTie(bool addToChord)
                         if (!lastAddedChord)
                               lastAddedChord = n->chord();
                         // n is not necessarily next note if duration span over measure
+
                         Note* nnote = searchTieNote(note);
+
                         while (nnote) {
                               // DEBUG: if duration spans over measure
                               // this does not set line for intermediate notes

--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -3545,6 +3545,10 @@ void Score::localTimeDelete()
 
       // Prepare for updating selection:
       nextCR = endSegment->nextChordRest(track);
+      if (auto previousMeasure = startSegment->measure()->prevMeasure()) {
+            auto lastCRofPrevMeasure = previousMeasure->last()->nextChordRest(track, true);
+            nextCR = lastCRofPrevMeasure;
+            }
 
       if (!checkTimeDelete(startSegment, endSegment))
             return;

--- a/libmscore/fermata.cpp
+++ b/libmscore/fermata.cpp
@@ -229,11 +229,13 @@ void Fermata::layout()
             setOffset(propertyDefault(Pid::OFFSET).toPointF());
       Element* e = s->element(track());
       if (e) {
-            if (e->isChord())
-                  rxpos() += score()->noteHeadWidth() * staff()->mag(Fraction(0, 1)) * .5;
-            else if (e->isRest()) {
+            if (e->isRest()) {
                   const Rest* rest = toRest(e);
                   rxpos() += e->x() + rest->centerX();
+                  }
+            else if (e->isChord()) {
+                  const auto chord = toChord(e);
+                  rxpos() += e->x() + chord->centerX(); // originally:  rxpos() += score()->noteHeadWidth() * staff()->mag(Fraction(0, 1)) * .5;
                   }
             else
                   rxpos() += e->x() - e->shape().left() + e->width() * staff()->mag(Fraction(0, 1)) * .5;

--- a/libmscore/fingering.cpp
+++ b/libmscore/fingering.cpp
@@ -10,6 +10,8 @@
 //  the file LICENCE.GPL
 //=============================================================================
 
+
+#include "arpeggio.h"
 #include "fingering.h"
 #include "score.h"
 #include "staff.h"
@@ -221,6 +223,10 @@ void Fingering::layout()
                         rxpos() -= left;
                   else
                         rxpos() -= n->x();
+
+                  qreal arpWidth = chord->arpeggio() ? chord->arpeggio()->bbox().width() : 0.0;
+                  rxpos() -= arpWidth;
+                  rxpos() -= (arpWidth * 0.25);
                   }
             // for other fingering styles, do not autoplace
 

--- a/libmscore/fingering.cpp
+++ b/libmscore/fingering.cpp
@@ -165,7 +165,8 @@ void Fingering::layout()
                               top -= md;
                               qreal diff = (bbox().bottom() + ipos().y() + yd + n->y()) - top;
                               if (diff > 0.0)
-                                    yd -= diff;
+                                    if (chord->beam())
+                                          yd -= diff;
                               if (offsetChanged() != OffsetChange::NONE) {
                                     // user moved element within the skyline
                                     // we may need to adjust minDistance, yd, and/or offset
@@ -201,7 +202,8 @@ void Fingering::layout()
                               bottom += md;
                               qreal diff = bottom - (bbox().top() + ipos().y() + yd + n->y());
                               if (diff > 0.0)
-                                    yd += diff;
+                                    if (chord->beam())
+                                          yd += diff;
                               if (offsetChanged() != OffsetChange::NONE) {
                                     // user moved element within the skyline
                                     // we may need to adjust minDistance, yd, and/or offset

--- a/libmscore/hairpin.cpp
+++ b/libmscore/hairpin.cpp
@@ -306,8 +306,7 @@ void HairpinSegment::layout()
                   rypos() += yd;
                   }
 
-            if (hairpin()->addToSkyline() && !hairpin()->lineVisible()
-                && !hairpin()->diagonal()) {
+            if (hairpin()->addToSkyline() && !hairpin()->diagonal()) {
                   // align dynamics with hairpin
                   if (sd && sd->autoplace() && sd->placement() == hairpin()->placement()
                       && (hairpin()->lineVisible() || !_text->empty())){

--- a/libmscore/joinMeasure.cpp
+++ b/libmscore/joinMeasure.cpp
@@ -23,10 +23,10 @@ namespace Ms {
 //    join measures from m1 upto (including) m2
 //---------------------------------------------------------
 
-void Score::cmdJoinMeasure(Measure* m1, Measure* m2)
+ChordRest* Score::cmdJoinMeasure(Measure* m1, Measure* m2)
       {
       if (!m1 || !m2)
-            return;
+            return nullptr;
       if (m1->isMMRest())
             m1 = m1->mmRestFirst();
       if (m2->isMMRest())
@@ -38,8 +38,8 @@ void Score::cmdJoinMeasure(Measure* m1, Measure* m2)
       ScoreRange range;
       range.read(m1->first(), m2->last());
 
-      Fraction tick1 = m1->tick();
-      Fraction tick2 = m2->endTick();
+      const Fraction tick1 = m1->tick();
+      const Fraction tick2 = m2->endTick();
 
       auto spanners = _spanner.findContained(tick1.ticks(), tick2.ticks());
       for (auto i : spanners)
@@ -114,7 +114,11 @@ void Score::cmdJoinMeasure(Measure* m1, Measure* m2)
                         }
                   }
             }
+      cmdState().setTick(TickType::StartTick, tick1);
       endCmd();
+
+      auto rv = inserted ? inserted->findChordRest(inserted->tick(), 0) : nullptr;
+      return rv;
       }
 
 }

--- a/libmscore/keysig.cpp
+++ b/libmscore/keysig.cpp
@@ -632,7 +632,15 @@ bool KeySig::setProperty(Pid propertyId, const QVariant& v)
                         return false;
                   break;
             }
-      triggerLayoutAll();
+      // triggerLayoutAll();
+
+      // update: layout range
+      if (parent()) {
+            const auto startTick = measure()->tick();
+            const auto endTick = score()->endTick();
+            score()->doLayoutRange(startTick, endTick);
+            }
+
       setGenerated(false);
       return true;
       }

--- a/libmscore/keysig.cpp
+++ b/libmscore/keysig.cpp
@@ -159,7 +159,7 @@ void KeySig::layout()
       if (measure() && measure()->system() && measure()->isFirstInSystem()
           && prevMeasure && prevMeasure->findSegment(SegmentType::KeySigAnnounce, tick())
           && !segment()->isKeySigAnnounceType())
-            naturalsOn = (keySigEvent().key() == Key::C);
+            naturalsOn = (Key::C == keySigEvent().key() && !prevMeasure->sectionBreak());
       if (track() == -1)
             naturalsOn = false;
 

--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -4378,6 +4378,25 @@ System* Score::collectSystem(LayoutContext& lc)
       }
 
 //---------------------------------------------------------
+//   updateMeasureNumbers
+//---------------------------------------------------------
+
+void Score::updateMeasureNumbers() {
+      auto start = measures()->first();
+      auto end = measures()->last();
+      for (auto mb = start; mb; mb = mb->next()) {
+            if (!mb->isMeasure())
+                  continue;
+
+            auto m = toMeasure(mb);
+            m->layoutMeasureNumber();
+
+            if (mb == end)
+                  break;
+          }
+      }
+
+//---------------------------------------------------------
 //   layoutSystemElements
 //---------------------------------------------------------
 

--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -5314,7 +5314,6 @@ class CmdStateLocker {
 
 void Score::doLayoutRange(const Fraction& st, const Fraction& et)
       {
-      qDebug() << st.print() << et.print();
       CmdStateLocker cmdStateLocker(this);
       LayoutContext lc(this);
 
@@ -5466,7 +5465,6 @@ void Score::doLayoutRange(const Fraction& st, const Fraction& et)
       lc.curSystem = collectSystem(lc);
 
       lc.layout();
-      qDebug() << "DONE" << st.print() << et.print();
       }
 
 //---------------------------------------------------------

--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -5314,6 +5314,7 @@ class CmdStateLocker {
 
 void Score::doLayoutRange(const Fraction& st, const Fraction& et)
       {
+      qDebug() << st.print() << et.print();
       CmdStateLocker cmdStateLocker(this);
       LayoutContext lc(this);
 
@@ -5465,6 +5466,7 @@ void Score::doLayoutRange(const Fraction& st, const Fraction& et)
       lc.curSystem = collectSystem(lc);
 
       lc.layout();
+      qDebug() << "DONE" << st.print() << et.print();
       }
 
 //---------------------------------------------------------

--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -5396,6 +5396,8 @@ void Score::doLayoutRange(const Fraction& st, const Fraction& et)
             lc.curSystem   = system;
             lc.systemList  = _systems.mid(systemIndex);
 
+            Q_ASSERT(systemIndex >= 0);
+
             if (systemIndex == 0)
                   lc.nextMeasure = _showVBox ? first() : firstMeasure();
             else {

--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -4555,6 +4555,24 @@ void Score::layoutSystemElements(System* system, LayoutContext& lc)
             }
 
       //-------------------------------------------------------------
+      // layout articulations
+      //-------------------------------------------------------------
+
+      for (Segment* s : sl) {
+            for (Element* e : s->elist()) {
+                  if (!e || !e->isChordRest() || !score()->staff(e->staffIdx())->show())
+                        continue;
+                  ChordRest* cr = toChordRest(e);
+                  // articulations
+                  if (cr->isChord()) {
+                        Chord* c = toChord(cr);
+                        c->layoutArticulations();
+                        c->layoutArticulations2();
+                        }
+                  }
+            }
+
+      //-------------------------------------------------------------
       // layout fingerings, add beams to skylines
       //-------------------------------------------------------------
 
@@ -4621,24 +4639,6 @@ void Score::layoutSystemElements(System* system, LayoutContext& lc)
                   }
             for (auto staffIdx : recreateShapes)
                   s->createShape(staffIdx);
-            }
-
-      //-------------------------------------------------------------
-      // layout articulations
-      //-------------------------------------------------------------
-
-      for (Segment* s : sl) {
-            for (Element* e : s->elist()) {
-                  if (!e || !e->isChordRest() || !score()->staff(e->staffIdx())->show())
-                        continue;
-                  ChordRest* cr = toChordRest(e);
-                  // articulations
-                  if (cr->isChord()) {
-                        Chord* c = toChord(cr);
-                        c->layoutArticulations();
-                        c->layoutArticulations2();
-                        }
-                  }
             }
 
       //-------------------------------------------------------------

--- a/libmscore/layoutbreak.cpp
+++ b/libmscore/layoutbreak.cpp
@@ -302,12 +302,14 @@ bool LayoutBreak::setProperty(Pid propertyId, const QVariant& v)
                   break;
             }
 
-      if (propertyId == Pid::START_WITH_MEASURE_ONE)
-            triggerLayoutToEnd();
-      else {
-            triggerLayout();
-            if (parent() && measure()->next())
-                  measure()->next()->triggerLayout();
+      if (parent()) {
+            if (propertyId == Pid::START_WITH_MEASURE_ONE)
+                  triggerLayoutToEnd();
+            else {
+                  triggerLayout();
+                  if (measure()->next())
+                        measure()->next()->triggerLayout();
+                  }
             }
 
       setGenerated(false);

--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -2645,6 +2645,8 @@ bool Measure::isAnacrusis() const
 
 bool Measure::isFirstInSystem() const
       {
+      if (!system()) return false;
+
       IF_ASSERT_FAILED(system()) {
             return false;
             }

--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -2585,6 +2585,10 @@ bool Measure::stemless(int staffIdx) const
       return staff->stemless(tick()) || _mstaves[staffIdx]->stemless() || staff->staffType(tick())->stemless();
       }
 
+//---------------------------------------------------------
+//   nextSectionBreak
+//---------------------------------------------------------
+
 LayoutBreak* Measure::nextSectionBreak() const
       {
       const MeasureBase* mb = static_cast<const MeasureBase*>(this);
@@ -2597,6 +2601,22 @@ LayoutBreak* Measure::nextSectionBreak() const
             } while (mb && !mb->isMeasure());   // loop until reach next actual measure or end of score
 
       return nullptr;
+      }
+
+//---------------------------------------------------------
+//   nextLayoutBreakMeasure
+//    or end
+//---------------------------------------------------------
+
+const MeasureBase* Measure::nextLayoutBreakMeasure() const
+      {
+      auto mb = toMeasureBase(this);
+      while (mb && mb->noBreak()) {
+            if (const auto nmb = mb->next()) {
+                  mb = (mb != nmb) ? nmb : nullptr;
+                  }
+            }
+      return mb;
       }
 
 //---------------------------------------------------------

--- a/libmscore/measure.h
+++ b/libmscore/measure.h
@@ -234,6 +234,7 @@ class Measure final : public MeasureBase {
       bool visible(int staffIdx) const;
       bool stemless(int staffIdx) const;
       LayoutBreak* nextSectionBreak() const;
+      const MeasureBase* nextLayoutBreakMeasure() const;
       bool isAnacrusis() const;
       bool isFirstInSystem() const;
       bool isFirstInSection() const;

--- a/libmscore/noteentry.cpp
+++ b/libmscore/noteentry.cpp
@@ -581,6 +581,25 @@ void Score::repitchNote(const Position& p, bool replace)
             next = nextChordRest(next);
       if (next)
             _is.moveInputPos(next->segment());
+
+      if (const auto inputSlur = _is.slur()) {
+            // also extend slur in Repitch mode:
+            if (inputSlur->endElement() == inputSlur->startElement())
+                  inputSlur->frontSegment()->reset();
+            Chord* chord = toNote(lastTiedNote)->chord();
+            s->undoChangeProperty(Pid::SPANNER_TICKS, chord->tick() - inputSlur->tick());
+            for (ScoreElement* se : inputSlur->linkList()) {
+                  auto linkSlur = toSlur(se);
+                  for (ScoreElement* ee : chord->linkList()) {
+                        Element* e = static_cast<Element*>(ee);
+                        if (e->score() == linkSlur->score() && e->track() == linkSlur->track2()) {
+                              linkSlur->score()->undo(new ChangeSpannerElements(linkSlur, linkSlur->startElement(), e));
+                              break;
+                              }
+                        }
+                  }
+            }
+
       _is.updateLastPitch(note->pitch());
       }
 

--- a/libmscore/noteentry.cpp
+++ b/libmscore/noteentry.cpp
@@ -368,6 +368,40 @@ void Score::putNote(const Position& p, bool replace)
       ChordRest* cr = _is.cr();
       bool addToChord = false;
 
+      // Allow A-G on a grace-note entry instead of replacing parent-chord note:
+      if (auto el = selection().element()) { // single element
+            if (el->isNote()) {
+                  auto n = toNote(el);
+                  if (auto c = n->chord()) {
+                        if (c->isGrace()) {
+                              if (cr) {
+                                    score()->repitchNote(p, n, true);
+                                    // setGraceNote(toChord(cr), nval.pitch, NoteType::APPOGGIATURA, MScore::division/2);
+                                    // setGraceNote(toChord(cr), nval.pitch, iconTypeToNoteType(_graceInputState), iconTypeToLen(_graceInputState));
+                                    score()->addRefresh(cr->canvasBoundingRect());
+
+                                    // Get next grace note:
+                                    int graceIdx = c->graceIndex();
+                                    int nextGraceIdx = ++graceIdx;
+                                    auto parentChord = toChord(cr);
+                                    const auto graceNotes = parentChord->graceNotes();
+                                    Note* nextNote{0};
+                                    for (Chord* graceChord : graceNotes) {
+                                          if (graceChord->graceIndex() == nextGraceIdx) {
+                                                nextNote = graceNotes.at(nextGraceIdx)->upNote();
+                                                break;
+                                                }
+                                          }
+                                    if (!nextNote)
+                                          nextNote = parentChord->upNote();
+                                    select(nextNote);
+                                    return;
+                                    }
+                              }
+                        }
+                  }
+            }
+
       if (cr) {
             // retrieve total duration of current chord
             TDuration d = cr->durationType();
@@ -508,6 +542,88 @@ void Score::repitchNote(const Position& p, bool replace)
 
       Note* firstTiedNote = 0;
       Note* lastTiedNote = note;
+
+      // Grace note handling:
+      auto& entryGraceNotes = chord->graceNotes();
+      if (!entryGraceNotes.empty()) {
+            if (auto el = selection().element()) {
+                  auto c = el->isNote() ? toNote(el)->chord() : nullptr;
+                  auto& toSelect = entryGraceNotes.front();
+                  auto noteEntryChord = chord;
+                  if (el->isRest() || (c && (c != noteEntryChord) && (c->parent() != chord))) {
+                        // 1) Note Entry Position mustn't be equivalent to score selection before beginning repitch of grace notes
+                        // b/c repitching will apply to the "next" grace note, not the one "selected" - to repitch the first grace-note
+                        // requires there to be a score selection distinct from its parent chord and itself
+                        auto toChange = toSelect->upNote();
+                        auto toSelect = score()->repitchNote(p, toChange, true);
+                        score()->addRefresh(cr->canvasBoundingRect());
+                        select(toSelect);
+                        return;
+                        }
+                  else if (c->isGrace()) {
+                        // 2) Grace-note currently selected, so repitch the next grace note if it exists, else its parent chord
+                        int graceIdx = c->graceIndex();
+                        int nextGraceIdx = ++graceIdx;
+                        auto parentChord = chord;
+                        const auto graceNotes = parentChord->graceNotes();
+                        Note* nextNote{0};
+
+                        for (Chord* graceChord : graceNotes) {
+                              if (graceChord->graceIndex() == nextGraceIdx) {
+                                    nextNote = graceNotes.at(nextGraceIdx)->upNote();
+                                    break;
+                                    }
+                              }
+
+                        bool updatedParent = false;
+                        if (!nextNote) {
+                              nextNote = parentChord->upNote();
+                              updatedParent = true;
+                              }
+
+                        auto toSelect = score()->repitchNote(p, nextNote, true);
+                        score()->addRefresh(cr->canvasBoundingRect());
+                        select(toSelect); // select prev note
+                        if (updatedParent)
+                              _is.moveToNextInputPos();
+
+                        return;
+                        }
+                  }
+            }
+
+      if (auto el = selection().element()) {
+            if (el->isNote()) {
+                  auto n = toNote(el);
+                  if (auto c = n->chord()) {
+                        if (c->isGrace()) {
+                              if (cr) {
+                                    score()->repitchNote(p, n, true);
+                                    score()->addRefresh(cr->canvasBoundingRect());
+
+                                    // Get next grace note:
+                                    int graceIdx = c->graceIndex();
+                                    int nextGraceIdx = ++graceIdx;
+                                    auto parentChord = toChord(cr);
+                                    const auto graceNotes = parentChord->graceNotes();
+                                    Note* nextNote{0};
+                                    for (Chord* graceChord : graceNotes) {
+                                          if (graceChord->graceIndex() == nextGraceIdx) {
+                                                nextNote = graceNotes.at(nextGraceIdx)->upNote();
+                                                break;
+                                                }
+                                          }
+                                    if (!nextNote)
+                                          nextNote = parentChord->upNote();
+                                    select(nextNote);
+                                    return;
+                                    }
+                              }
+                        }
+                  }
+            }
+
+
       if (replace) {
             std::vector<Note*> notes = chord->notes();
             // break all ties into current chord
@@ -602,6 +718,172 @@ void Score::repitchNote(const Position& p, bool replace)
 
       _is.updateLastPitch(note->pitch());
       }
+
+//---------------------------------------------------------
+//   repitchNote
+// Unused for now
+//---------------------------------------------------------
+Note* Score::repitchNote(const Position& p, const Note* n, bool replace)
+      {
+      Segment* s      = p.segment;
+      Fraction tick   = s->tick();
+      Staff* st       = staff(p.staffIdx);
+      ClefType clef   = st->clef(tick);
+
+      NoteVal nval;
+      bool error = false;
+      AccidentalType at = _is.accidentalType();
+      if (_is.drumset() && _is.drumNote() != -1) {
+            nval.pitch = _is.drumNote();
+            }
+      else {
+            AccidentalVal acci = (at == AccidentalType::NONE ? s->measure()->findAccidental(s, p.staffIdx, p.line, error) : Accidental::subtype2value(at));
+            if (error)
+                  return nullptr;
+            int step   = absStep(p.line, clef);
+            int octave = step / 7;
+            nval.pitch = step2pitch(step) + octave * 12 + int(acci);
+
+            if (styleB(Sid::concertPitch))
+                  nval.tpc1 = step2tpc(step % 7, acci);
+            else {
+                  nval.pitch += st->part()->instrument(s->tick())->transpose().chromatic;
+                  nval.tpc2 = step2tpc(step % 7, acci);
+                  }
+            }
+
+      if (!_is.segment())
+            return nullptr;
+
+      Chord* chord;
+      ChordRest* cr = _is.cr();
+
+      if (n)
+            cr = n->chord();
+      else if (auto singleEl = selection().element())
+            if (singleEl->isNote())
+                  cr = toNote(singleEl)->chord();
+
+      if (!cr) {
+            cr = _is.segment()->nextChordRest(_is.track());
+            if (!cr)
+                  return nullptr;
+            }
+
+      if (cr->isRest()) { //skip rests
+            ChordRest* next = nextChordRest(cr);
+            while(next && !next->isChord())
+                  next = nextChordRest(next);
+            if (next)
+                  _is.moveInputPos(next->segment());
+            return nullptr;
+            }
+      else {
+            chord = toChord(cr);
+            }
+      Note* note = new Note(this);
+      note->setParent(chord);
+      note->setTrack(chord->track());
+      note->setNval(nval);
+
+      Note* firstTiedNote = 0;
+      Note* lastTiedNote = note;
+      if (replace) {
+            std::vector<Note*> notes = chord->notes();
+            // break all ties into current chord
+            // these will exist only if user explicitly moved cursor to a tied-into note
+            // in ordinary use, cursor will autoamtically skip past these during note entry
+            for (Note* n : notes) {
+                  if (n->tieBack())
+                        undoRemoveElement(n->tieBack());
+                  }
+            // for single note chords only, preserve ties by changing pitch of all forward notes
+            // the tie forward itself will be added later
+            // multi-note chords get reduced to single note chords anyhow since we remove the old notes below
+            // so there will be no way to preserve those ties
+            if (notes.size() == 1 && notes.front()->tieFor()) {
+                  Note* tn = notes.front()->tieFor()->endNote();
+                  while (tn) {
+                        Chord* tc = tn->chord();
+                        if (tc->notes().size() != 1) {
+                              undoRemoveElement(tn->tieBack());
+                              break;
+                              }
+                        if (!firstTiedNote)
+                              firstTiedNote = tn;
+                        lastTiedNote = tn;
+                        undoChangePitch(tn, note->pitch(), note->tpc1(), note->tpc2());
+                        if (tn->tieFor())
+                              tn = tn->tieFor()->endNote();
+                        else
+                              break;
+                        }
+                  }
+            // remove all notes from chord
+            // the new note will be added below
+            while (!chord->notes().empty())
+                  undoRemoveElement(chord->notes().front());
+      }
+      // add new note to chord
+      undoAddElement(note);
+      bool forceAccidental = false;
+      if (_is.accidentalType() != AccidentalType::NONE) {
+            NoteVal nval2 = noteValForPosition(p, AccidentalType::NONE, error);
+            forceAccidental = (nval.pitch == nval2.pitch);
+            }
+      if (forceAccidental) {
+            int tpc = styleB(Sid::concertPitch) ? nval.tpc1 : nval.tpc2;
+            AccidentalVal alter = tpc2alter(tpc);
+            at = Accidental::value2subtype(alter);
+            Accidental* a = new Accidental(this);
+            a->setAccidentalType(at);
+            a->setRole(AccidentalRole::USER);
+            a->setParent(note);
+            undoAddElement(a);
+            }
+      setPlayNote(true);
+      setPlayChord(true);
+      // recreate tie forward if there is a note to tie to
+      // one-sided ties will not be recreated
+      if (firstTiedNote) {
+            Tie* tie = new Tie(this);
+            tie->setStartNote(note);
+            tie->setEndNote(firstTiedNote);
+            tie->setTick(tie->startNote()->tick());
+            tie->setTick2(tie->endNote()->tick());
+            tie->setTrack(note->track());
+            undoAddElement(tie);
+            }
+      select(lastTiedNote);
+      // move to next Chord
+      ChordRest* next = nextChordRest(lastTiedNote->chord());
+      while (next && !next->isChord())
+            next = nextChordRest(next);
+      if (next)
+            _is.moveInputPos(next->segment());
+
+      if (const auto inputSlur = _is.slur()) {
+            // also extend slur in Repitch mode:
+            if (inputSlur->endElement() == inputSlur->startElement())
+                  inputSlur->frontSegment()->reset();
+            Chord* chord = toNote(lastTiedNote)->chord();
+            s->undoChangeProperty(Pid::SPANNER_TICKS, chord->tick() - inputSlur->tick());
+            for (ScoreElement* se : inputSlur->linkList()) {
+                  auto linkSlur = toSlur(se);
+                  for (ScoreElement* ee : chord->linkList()) {
+                        Element* e = static_cast<Element*>(ee);
+                        if (e->score() == linkSlur->score() && e->track() == linkSlur->track2()) {
+                              linkSlur->score()->undo(new ChangeSpannerElements(linkSlur, linkSlur->startElement(), e));
+                              break;
+                              }
+                        }
+                  }
+            }
+
+      _is.updateLastPitch(note->pitch());
+      return note;
+      }
+
 
 //---------------------------------------------------------
 //   insertChord

--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -2330,9 +2330,9 @@ MeasureBase* Score::insertMeasuresFromScore(Score* scoreSource, const Selection&
       std::vector<MeasureBase*> insertedMeasures;
       int safeGuard = 0;
       const int maxIterations = 9999;
-      int sNo = mbStart->no();
-      int eNo = mbEnd->no();
-      for (auto mbCurrent = mbStart; mbCurrent && (mbCurrent->no() <= eNo); mbCurrent = mbCurrent->next()) {
+      int startIdx = mbStart->index();
+      int endIdx  = mbEnd->index();
+      for (auto mbCurrent = mbStart; mbCurrent && (mbCurrent->index() <= endIdx); mbCurrent = mbCurrent->next()) {
             bool firstIteration = insertedMeasures.empty();
             MeasureBase* mbNext;
 
@@ -2346,20 +2346,20 @@ MeasureBase* Score::insertMeasuresFromScore(Score* scoreSource, const Selection&
                   return nullptr;
                   }
             if (!firstIteration) {
-                  int cNo = mbCurrent->no();
-                  int pNo = mbCurrent->prev() ? mbCurrent->prev()->no() : -1;
+                  int currIdx = mbCurrent->index();
+                  int prevIdx = mbCurrent->prev() ? mbCurrent->prev()->no() : -1;
 
                   // Ain't Misbehavin'
                   if (!mbCurrent->isBox()) {
-                        if (!cNo)
+                        if (!currIdx)
                               break;
-                        else if (cNo == sNo) {
+                        else if (currIdx == startIdx) {
                               // ...OK when including entire score
                               if (mbCurrent->index() == mbStart->index())
                                     break;
                               }
                         }
-                  if (cNo == pNo)
+                  if (currIdx == prevIdx)
                         break;
                   else if (mbCurrent == mbStart)
                         return nullptr;

--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -2383,6 +2383,8 @@ MeasureBase* Score::insertMeasuresFromScore(Score* scoreSource, const Selection&
                   }
 
             mbNext->setScore(scoreDest);
+            if (!mbPrevious)
+                  mbNext->setSystem(nullptr);
             mbNext->setPrev(mbPrevious);
             mbNext->setNext(&mbInsert);
             mbPrevious = mbNext;

--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -1319,7 +1319,6 @@ Measure* Score::getCreateMeasure(const Fraction& tick)
 void Score::addElement(Element* element)
       {
       Element* parent = element->parent();
-      element->triggerLayout();
 
 //      qDebug("Score(%p) Element(%p)(%s) parent %p(%s)",
 //         this, element, element->name(), parent, parent ? parent->name() : "");
@@ -1442,7 +1441,21 @@ void Score::addElement(Element* element)
             default:
                   break;
             }
-      element->triggerLayout();
+
+      bool skipLayout = false;
+
+      if (element->isBarLine()) {
+            skipLayout = true;
+            }
+      if (element->isSegment()) {
+            auto s = toSegment(element);
+            if (s->isTimeSig() || s->isTimeSigType()) {
+                  skipLayout = true;
+                  }
+            }
+
+      if (!skipLayout)
+            element->triggerLayout();
       }
 
 //---------------------------------------------------------

--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -5611,7 +5611,6 @@ void MasterScore::setUpdateAllNoLayout()
 
 void MasterScore::setLayoutAll(int staff, const Element* e)
       {
-      qDebug() << "";
       _cmdState.setTick(Fraction(0,1));
       _cmdState.setTick(measures()->last() ? measures()->last()->endTick() : Fraction(0,1));
 

--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -5611,6 +5611,7 @@ void MasterScore::setUpdateAllNoLayout()
 
 void MasterScore::setLayoutAll(int staff, const Element* e)
       {
+      qDebug() << "";
       _cmdState.setTick(Fraction(0,1));
       _cmdState.setTick(measures()->last() ? measures()->last()->endTick() : Fraction(0,1));
 

--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -5462,6 +5462,21 @@ void MasterScore::setUpdateAll()
       }
 
 //---------------------------------------------------------
+//   setUpdateAllNoLayout
+//   regular (above method) considers if updateAll is greater
+//   than current mode, so if it's slated to do a tick-based
+//   update, then UpdateAll is overriden by the range-based
+//   command. This function will override any range-based command
+//   state for a screen update only, without having to
+//   completely reset the command state
+//---------------------------------------------------------
+
+void MasterScore::setUpdateAllNoLayout()
+      {
+      _cmdState._setUpdateMode(UpdateMode::UpdateAll);
+      }
+
+//---------------------------------------------------------
 //   setLayoutAll
 //---------------------------------------------------------
 

--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -5194,6 +5194,122 @@ void Score::changeVoice(int voice)
       endCmd();
       }
 
+//---------------------------------------------------------
+//   iconTypeToNoteType
+///  IconType is transformed to NoteType
+//---------------------------------------------------------
+
+NoteType Score::iconTypeToNoteType(IconType value)
+      {
+      switch(value)  {
+            case IconType::ACCIACCATURA:
+                  return NoteType::ACCIACCATURA;
+            case IconType::APPOGGIATURA:
+                  return NoteType::APPOGGIATURA;
+            case IconType::GRACE4:
+                  return NoteType::GRACE4;
+            case IconType::GRACE16:
+                  return NoteType::GRACE16;
+            case IconType::GRACE32:
+                  return NoteType::GRACE32;
+            case IconType::GRACE8_AFTER:
+                  return NoteType::GRACE8_AFTER;
+            case IconType::GRACE16_AFTER:
+                  return NoteType::GRACE16_AFTER;
+            case IconType::GRACE32_AFTER:
+                  return NoteType::GRACE32_AFTER;
+            default:
+                  return NoteType::NORMAL;
+            }
+      }
+
+//---------------------------------------------------------
+//   iconTypeToDuration
+///  IconType is transformed to DurationType
+//---------------------------------------------------------
+
+TDuration Score::iconTypeToDuration(IconType value)
+      {
+      switch(value)  {
+            case IconType::ACCIACCATURA:
+                  return TDuration(TDuration::DurationType::V_EIGHTH);
+            case IconType::APPOGGIATURA:
+                  return TDuration(TDuration::DurationType::V_EIGHTH);
+            case IconType::GRACE4:
+                  return TDuration(TDuration::DurationType::V_QUARTER);
+            case IconType::GRACE16:
+                  return TDuration(TDuration::DurationType::V_16TH);
+            case IconType::GRACE32:
+                  return TDuration(TDuration::DurationType::V_32ND);
+            case IconType::GRACE8_AFTER:
+                  return TDuration(TDuration::DurationType::V_EIGHTH);
+            case IconType::GRACE16_AFTER:
+                  return TDuration(TDuration::DurationType::V_16TH);
+            case IconType::GRACE32_AFTER:
+                  return TDuration(TDuration::DurationType::V_32ND);
+            default:
+                  return TDuration(TDuration::DurationType::V_INVALID);
+            }
+      }
+
+//---------------------------------------------------------
+//   iconTypeToSymId
+///  IconType is transformed to SymId
+//---------------------------------------------------------
+
+SymId Score::iconTypeToSymId(IconType value)
+      {
+      switch(value)  {
+            case IconType::ACCIACCATURA:
+                  return SymId::note8thUp;
+            case IconType::APPOGGIATURA:
+                  return SymId::note8thUp;
+            case IconType::GRACE4:
+                  return SymId::noteQuarterUp;
+            case IconType::GRACE16:
+                  return SymId::note16thUp;
+            case IconType::GRACE32:
+                  return SymId::note32ndUp;
+            case IconType::GRACE8_AFTER:
+                  return SymId::note8thUp;
+            case IconType::GRACE16_AFTER:
+                  return SymId::note16thUp;
+            case IconType::GRACE32_AFTER:
+                  return SymId::note32ndUp;
+            default:
+                  return SymId::noSym;
+            }
+      }
+
+//---------------------------------------------------------
+//   iconTypeToLen
+///  Get note lengh from iconType
+//---------------------------------------------------------
+
+int Score::iconTypeToLen(IconType value)
+      {
+      switch(value)  {
+            case IconType::ACCIACCATURA:
+                  return MScore::division/2;
+            case IconType::APPOGGIATURA:
+                  return MScore::division/2;
+            case IconType::GRACE4:
+                  return MScore::division;
+            case IconType::GRACE16:
+                  return MScore::division/4;
+            case IconType::GRACE32:
+                  return MScore::division/8;
+            case IconType::GRACE8_AFTER:
+                  return MScore::division/2;
+            case IconType::GRACE16_AFTER:
+                  return MScore::division/4;
+            case IconType::GRACE32_AFTER:
+                  return MScore::division/8;
+            default:
+                  return -1;
+            }
+      }
+
 #if 0
 //---------------------------------------------------------
 //   cropPage - crop a single page score to the content

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -255,6 +255,12 @@ enum class UpdateMode {
       Layout,           // do partial layout for tick range
       };
 
+
+enum class TickType {   // for explicit cmdState updates
+      StartTick,
+      EndTick,
+      };
+
 //---------------------------------------------------------
 //   CmdState
 //
@@ -292,6 +298,7 @@ class CmdState {
       bool updateAll() const   { return int(_updateMode) >= int(UpdateMode::UpdateAll); }
       bool updateRange() const { return _updateMode == UpdateMode::Update; }
       void setTick(const Fraction& t);
+      void setTick(TickType tt, const Fraction& t);
       void setStaff(int staff);
       void setElement(const Element* e);
       void unsetElement(const Element* e);
@@ -623,6 +630,8 @@ class Score : public QObject, public ScoreElement {
       System* collectSystem(LayoutContext&);
       void layoutSystemElements(System* system, LayoutContext& lc);
       void getNextMeasure(LayoutContext&);      // get next measure for layout
+
+      void updateMeasureNumbers();
 
       void resetAllPositions();
 
@@ -1113,7 +1122,7 @@ class Score : public QObject, public ScoreElement {
 
       ChordRest* cmdSplitMeasure(ChordRest*);
       Segment* splitMeasure(Segment*);
-      void cmdJoinMeasure(Measure*, Measure*);
+      ChordRest* cmdJoinMeasure(Measure*, Measure*);
       int pageNumberOffset() const          { return _pageNumberOffset; }
       void setPageNumberOffset(int v)       { _pageNumberOffset = v; }
 

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -782,6 +782,7 @@ class Score : public QObject, public ScoreElement {
       void cmdAddTimeSig(Measure*, int staffIdx, TimeSig*, bool local);
 
       virtual inline void setUpdateAll();
+      virtual inline void setUpdateAllNoLayout();
       inline void setLayoutAll(int staff = -1, const Element* e = nullptr);
       inline void setLayout(const Fraction& tick, int staff, const Element* e = nullptr);
       inline void setLayout(const Fraction& tick1, const Fraction& tick2, int staff1, int staff2, const Element* e = nullptr);
@@ -1389,6 +1390,7 @@ class MasterScore : public Score {
       void addMovement(MasterScore* score);
 
       virtual void setUpdateAll() override;
+      virtual void setUpdateAllNoLayout();
 
       void setLayoutAll(int staff = -1, const Element* e = nullptr);
       void setLayout(const Fraction& tick, int staff, const Element* e = nullptr);
@@ -1506,6 +1508,7 @@ inline QQueue<MidiInputEvent>* Score::midiInputQueue()          { return _master
 inline std::list<MidiInputEvent>* Score::activeMidiPitches()    { return _masterScore->activeMidiPitches(); }
 
 inline void Score::setUpdateAll()                      { _masterScore->setUpdateAll();          }
+inline void Score::setUpdateAllNoLayout()              { _masterScore->setUpdateAllNoLayout();  }
 
 inline void Score::setLayoutAll(int staff, const Element* e) { _masterScore->setLayoutAll(staff, e); }
 inline void Score::setLayout(const Fraction& tick, int staff, const Element* e) { _masterScore->setLayout(tick, staff, e); }

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -812,6 +812,11 @@ class Score : public QObject, public ScoreElement {
       void cmdOverrideColor(const char*);
       bool cmdToggleOptions(const QString&);
 
+      NoteType iconTypeToNoteType(IconType);
+      TDuration iconTypeToDuration(IconType);
+      SymId iconTypeToSymId(IconType);
+      int iconTypeToLen(IconType);
+
       void colorItem(Element*);
       QList<Part*>& parts()                { return _parts; }
       const QList<Part*>& parts() const    { return _parts; }

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -769,6 +769,7 @@ class Score : public QObject, public ScoreElement {
       void cloneVoice(int strack, int dtrack, Segment* sf, const Fraction& lTick, bool link = true, bool spanner = true);
 
       void repitchNote(const Position& pos, bool replace);
+      Note* repitchNote(const Position& pos, const Note*, bool replace);
       void regroupNotesAndRests(const Fraction&  startTick, const Fraction& endTick, int track);
       bool checkTimeDelete(Segment*, Segment*);
       void timeDelete(Measure*, Segment*, const Fraction&);

--- a/libmscore/scorefile.cpp
+++ b/libmscore/scorefile.cpp
@@ -238,6 +238,7 @@ void Score::writeMovement(XmlWriter& xml, bool selectionOnly)
                               else
                                     forceTimeSig = false;
                               }
+                        // Largest consumption of time for file-saving:
                         writeMeasure(xml, m, staffIdx, writeSystemElements, forceTimeSig);
                         }
                   xml.etag();
@@ -538,7 +539,6 @@ QImage Score::createThumbnail()
       {
       LayoutMode mode = layoutMode();
       setLayoutMode(LayoutMode::PAGE);
-      doLayout();
 
       Page* page = pages().at(0);
       QRectF fr  = page->abbox();

--- a/libmscore/select.cpp
+++ b/libmscore/select.cpp
@@ -1385,6 +1385,15 @@ std::list<Note*> Selection::uniqueNotes(int track) const
 
 void Selection::extendRangeSelection(ChordRest* cr)
       {
+      const auto startTick = tickStart();
+      const auto newTick = cr->tick();
+      const bool prev = newTick < startTick;
+      const bool grace = prev && cr->isChord() && !toChord(cr)->graceNotesBefore().empty() ? false : true;
+      auto& sf = score()->selectionFilter();
+      // If extending to the left and grace-note(s) exist on destination chord, then filter out grace-notes
+      // to aid in range-based slur applications
+      sf.setFiltered(SelectionFilterType::GRACE_NOTE, grace);
+
       extendRangeSelection(cr->segment(),
          cr->nextSegmentAfterCR(SegmentType::ChordRest
             | SegmentType::EndBarLine

--- a/libmscore/slur.cpp
+++ b/libmscore/slur.cpp
@@ -508,7 +508,6 @@ bool SlurSegment::isEdited() const
 Slur::Slur(const Slur& s)
    : SlurTie(s)
       {
-      _sourceStemArrangement = s._sourceStemArrangement;
       }
 
 //---------------------------------------------------------
@@ -1053,16 +1052,6 @@ Slur::Slur(Score* s)
       }
 
 //---------------------------------------------------------
-//   calcStemArrangement
-//---------------------------------------------------------
-
-int calcStemArrangement(Element* start, Element* end)
-      {
-      return (start && toChord(start)->stem() && toChord(start)->stem()->up() ? 2 : 0)
-           + (end && end->isChord() && toChord(end)->stem() && toChord(end)->stem()->up() ? 4 : 0);
-      }
-
-//---------------------------------------------------------
 //   write
 //---------------------------------------------------------
 
@@ -1075,8 +1064,6 @@ void Slur::write(XmlWriter& xml) const
       if (!xml.canWrite(this))
             return;
       xml.stag(this);
-      if (xml.clipboardmode())
-            xml.tag("stemArr", calcStemArrangement(startElement(), endElement()));
       SlurTie::writeProperties(xml);
       xml.etag();
       }
@@ -1088,10 +1075,6 @@ void Slur::write(XmlWriter& xml) const
 bool Slur::readProperties(XmlReader& e)
       {
       const QStringRef& tag(e.name());
-      if (tag == "stemArr") {
-            _sourceStemArrangement = e.readInt();
-            return true;
-            }
       return SlurTie::readProperties(e);
       }
 
@@ -1182,15 +1165,6 @@ SpannerSegment* Slur::layoutSystem(System* system)
                               }
                         Chord* c1 = startCR()->isChord() ? toChord(startCR()) : 0;
                         Chord* c2 = endCR()->isChord()   ? toChord(endCR())   : 0;
-
-                        if (_sourceStemArrangement != -1) {
-                              if (_sourceStemArrangement != calcStemArrangement(c1, c2)) {
-                                    // copy & paste from incompatible stem arrangement, so reset bezier points
-                                    for (int g = 0; g < (int)Ms::Grip::GRIPS; ++g) {
-                                          slurSegment->ups((Ms::Grip)g) = UP();
-                                          }
-                                    }
-                              }
 
                         if (c1 && c1->beam() && c1->beam()->cross()) {
                               // TODO: stem direction is not finalized, so we cannot use it here

--- a/libmscore/slur.h
+++ b/libmscore/slur.h
@@ -54,7 +54,6 @@ class SlurSegment final : public SlurTieSegment {
 class Slur final : public SlurTie {
 
       void slurPosChord(SlurPos*);
-      int _sourceStemArrangement = -1;
 
    public:
       Slur(Score* = 0);

--- a/libmscore/slurtie.cpp
+++ b/libmscore/slurtie.cpp
@@ -178,8 +178,9 @@ void SlurTieSegment::editDrag(EditData& ed)
                                     if (km != (Qt::ShiftModifier | Qt::ControlModifier)) {
                                           Chord* c = note->chord();
                                           ed.view->setDropTarget(note);
-                                          if (c->part() == spanner->part() && c != spanner->endCR())
-                                                changeAnchor(ed, c);
+                                          if (c->part() == spanner->part() && c != spanner->endCR()) {
+                                                ; // Change anchor only for larger Shift+Move operations, not simple nudges [changeAnchor(ed, c);]
+                                                }
                                           }
                                     }
                               }

--- a/libmscore/spanner.cpp
+++ b/libmscore/spanner.cpp
@@ -531,7 +531,7 @@ bool Spanner::setProperty(Pid propertyId, const QVariant& v)
       {
       switch (propertyId) {
             case Pid::SPANNER_TICK:
-                  triggerLayout(); // spanner may have moved to another system
+                  // triggerLayout(); // spanner may have moved to another system
                   setTick(v.value<Fraction>());
                   setStartElement(0);     // invalidate
                   setEndElement(0);       //
@@ -539,7 +539,7 @@ bool Spanner::setProperty(Pid propertyId, const QVariant& v)
                         score()->addSpanner(this);
                   break;
             case Pid::SPANNER_TICKS:
-                  triggerLayout(); // spanner may now span for a smaller number of systems
+                  // triggerLayout(); // spanner may now span for a smaller number of systems
                   setTicks(v.value<Fraction>());
                   setEndElement(0);       // invalidate
                   break;

--- a/libmscore/splitMeasure.cpp
+++ b/libmscore/splitMeasure.cpp
@@ -29,9 +29,12 @@ namespace Ms {
 
 ChordRest* Score::cmdSplitMeasure(ChordRest* cr)
       {
+      auto startTick = cr->measure()->tick();
       startCmd();
       Segment* newSeg = splitMeasure(cr->segment());
+      cmdState().setTick(TickType::StartTick, startTick);
       endCmd();
+
       return newSeg ? newSeg->nextChordRest(cr->track()) : nullptr;
       }
 

--- a/libmscore/textedit.cpp
+++ b/libmscore/textedit.cpp
@@ -449,6 +449,18 @@ bool TextBase::edit(EditData& ed)
                               }
                         break;
 
+                  case Qt::Key_M:
+                        // Arbitrary (Ctrl+M) for switching to LH Guitar fingering
+                        // Based on my personal shortcut for doing this outside of editing similar
+                        // to my beam-styling shortcuts
+                        if (ctrlPressed && isFingering()) {
+                              s = "";
+                              Tid value = (tid() == Tid::LH_GUITAR_FINGERING) ? Tid::FINGERING : Tid::LH_GUITAR_FINGERING;
+                              setTid(value);
+                              styleChanged();
+                              layout();
+                              }
+                        break;
                   case Qt::Key_0: // FALL_THROUGH
                   case Qt::Key_1:
                   case Qt::Key_2:

--- a/libmscore/timesig.cpp
+++ b/libmscore/timesig.cpp
@@ -10,6 +10,7 @@
 //  the file LICENCE.GPL
 //=============================================================================
 
+#include "measure.h"
 #include "score.h"
 #include "segment.h"
 #include "staff.h"
@@ -503,7 +504,30 @@ bool TimeSig::setProperty(Pid propertyId, const QVariant& v)
                         return false;
                   break;
             }
-      triggerLayoutAll();      // TODO
+      // triggerLayoutAll();      // TODO
+
+      // Layout from measure to next time-sig
+      if (parent()) {
+            const auto zeroFrac = Fraction(0,1);
+            const auto m = measure();
+            const auto scoreEndTick = score()->endTick();
+            const auto startTick = m ? m->tick() : zeroFrac;
+            Fraction endTick = startTick;
+
+            if (m && m->staff())
+            if (const auto nts = m->staff()->nextTimeSig(startTick))
+                  endTick = nts->tick();
+
+            if (endTick == startTick)
+                  endTick = scoreEndTick;
+
+            if (startTick >= zeroFrac)
+                  score()->cmdState().setTick(TickType::StartTick, startTick);
+
+            score()->cmdState().setTick(TickType::EndTick, endTick);
+            // Observation: seems a doLayoutRange() is unnecessary here (it's called elsewhere)
+            }
+
       setGenerated(false);
       return true;
       }

--- a/libmscore/timesig.cpp
+++ b/libmscore/timesig.cpp
@@ -514,15 +514,19 @@ bool TimeSig::setProperty(Pid propertyId, const QVariant& v)
             const auto startTick = m ? m->tick() : zeroFrac;
             Fraction endTick = startTick;
 
-            if (m && m->staff())
-            if (const auto nts = m->staff()->nextTimeSig(startTick))
+            if (m && m->staff()) {
+            if (const auto nts = m->staff()->nextTimeSig(startTick)) {
                   endTick = nts->tick();
+                  }
+                  }
 
-            if (endTick == startTick)
+            if (endTick == startTick) {
                   endTick = scoreEndTick;
+                  }
 
-            if (startTick >= zeroFrac)
+            if (startTick >= zeroFrac) {
                   score()->cmdState().setTick(TickType::StartTick, startTick);
+                  }
 
             score()->cmdState().setTick(TickType::EndTick, endTick);
             // Observation: seems a doLayoutRange() is unnecessary here (it's called elsewhere)

--- a/libmscore/undo.cpp
+++ b/libmscore/undo.cpp
@@ -1887,7 +1887,13 @@ void InsertRemoveMeasures::insertMeasures()
                   key->staff()->setKey(key->segment()->tick(), key->keySigEvent());
             }
 
-      score->setLayoutAll();
+      const auto prevMeasure = fm->prevMeasureMM();
+      const auto startTick  = prevMeasure ? prevMeasure->tick() : fm->tick();
+      const auto nextMeasure = lm->nextMeasure() ? lm->nextMeasure()->nextLayoutBreakMeasure() : nullptr;
+      const auto endTick = nextMeasure ? nextMeasure->endTick() : lm->endTick();
+
+      score->doLayoutRange(startTick, endTick);
+      score->updateMeasureNumbers();
 
       //
       // connect ties
@@ -2001,7 +2007,13 @@ void InsertRemoveMeasures::removeMeasures()
                   }
             }
 
-      score->setLayoutAll();
+      const auto prevMeasure = fm->prevMeasureMM();
+      const auto startTick  = prevMeasure ? prevMeasure->tick() : fm->tick();
+      const auto nextMeasure = lm->nextMeasure() ? lm->nextMeasure()->nextLayoutBreakMeasure() : nullptr;
+      const auto endTick = nextMeasure ? nextMeasure->endTick() : lm->endTick();
+
+      score->doLayoutRange(startTick, endTick);
+      score->updateMeasureNumbers();
       }
 
 //---------------------------------------------------------
@@ -2219,7 +2231,17 @@ void ChangeClefType::flip(EditData*)
       clef->staff()->setClef(clef);
       Segment* segment = clef->segment();
       updateNoteLines(segment, clef->track());
-      clef->triggerLayoutAll();      // TODO: reduce layout to clef range
+      // clef->triggerLayoutAll();      // TODO: reduce layout to clef range
+
+      // update: layout range
+      if (const auto score = clef->score()) {
+            const auto startTick  = clef->measure()->tick();
+            const auto staff = clef->staff();
+            const auto nextClefTick = staff ? staff->nextClefTick(startTick) : score->endTick();
+            const auto endTick = nextClefTick;
+
+            score->doLayoutRange(startTick, endTick);
+            }
 
       concertClef     = ocl;
       transposingClef = otc;
@@ -2370,7 +2392,8 @@ void ChangeSpannerElements::flip(EditData*)
             }
       startElement = oldStartElement;
       endElement   = oldEndElement;
-      spanner->triggerLayout();
+      // triggerLayout() here was updating spanners way too often because of frequent flip() calls during changes:
+      // spanner->triggerLayout();
       }
 
 //---------------------------------------------------------

--- a/libmscore/undo.cpp
+++ b/libmscore/undo.cpp
@@ -1887,12 +1887,14 @@ void InsertRemoveMeasures::insertMeasures()
                   key->staff()->setKey(key->segment()->tick(), key->keySigEvent());
             }
 
-      const auto prevMeasure = fm->prevMeasureMM();
-      const auto startTick  = prevMeasure ? prevMeasure->tick() : fm->tick();
-      const auto nextMeasure = lm->nextMeasure() ? lm->nextMeasure()->nextLayoutBreakMeasure() : nullptr;
-      const auto endTick = nextMeasure ? nextMeasure->endTick() : lm->endTick();
-
-      score->doLayoutRange(startTick, endTick);
+      if (!score->printing()) {
+            const auto prevMeasure = fm->prevMeasureMM();
+            const auto startTick  = prevMeasure ? prevMeasure->tick() : fm->tick();
+            const auto nextMeasure = lm->nextMeasure() ? lm->nextMeasure()->nextLayoutBreakMeasure() : nullptr;
+            const auto endTick = nextMeasure ? nextMeasure->endTick() : lm->endTick();
+            score->cmdState().setTick(startTick);
+            score->cmdState().setTick(endTick);
+            }
       score->updateMeasureNumbers();
 
       //
@@ -2007,12 +2009,15 @@ void InsertRemoveMeasures::removeMeasures()
                   }
             }
 
-      const auto prevMeasure = fm->prevMeasureMM();
-      const auto startTick  = prevMeasure ? prevMeasure->tick() : fm->tick();
-      const auto nextMeasure = lm->nextMeasure() ? lm->nextMeasure()->nextLayoutBreakMeasure() : nullptr;
-      const auto endTick = nextMeasure ? nextMeasure->endTick() : lm->endTick();
+      if (!score->printing()) {
+            const auto prevMeasure = fm->prevMeasureMM();
+            const auto startTick  = prevMeasure ? prevMeasure->tick() : fm->tick();
+            const auto nextMeasure = lm->nextMeasure() ? lm->nextMeasure()->nextLayoutBreakMeasure() : nullptr;
+            const auto endTick = nextMeasure ? nextMeasure->endTick() : lm->endTick();
+            score->cmdState().setTick(startTick);
+            score->cmdState().setTick(endTick);
+            }
 
-      score->doLayoutRange(startTick, endTick);
       score->updateMeasureNumbers();
       }
 

--- a/libmscore/volta.cpp
+++ b/libmscore/volta.cpp
@@ -341,8 +341,8 @@ SpannerSegment * Volta::layoutSystem(System * system)
 
 void Volta::setVelocity() const
       {
-      Measure* startMeasure = Spanner::startMeasure();
-      Measure* endMeasure = Spanner::endMeasure();
+      Measure* startMeasure = Spanner::findStartMeasure();
+      Measure* endMeasure = Spanner::findEndMeasure();
 
       if (startMeasure && endMeasure) {
             if (!endMeasure->repeatEnd())

--- a/mscore/editelement.cpp
+++ b/mscore/editelement.cpp
@@ -151,6 +151,8 @@ void ScoreView::startEdit(bool editMode)
       if (editData.element->isTBox())
             editData.element = toTBox(editData.element)->text();
 
+      _score->cmdState()._setUpdateMode(UpdateMode::UpdateAll);
+
       Element* e = editData.element;
       setFocus();
       editData.clearData();

--- a/mscore/events.cpp
+++ b/mscore/events.cpp
@@ -1022,8 +1022,9 @@ void ScoreView::keyPressEvent(QKeyEvent* ev)
 
                   ScoreViewCmdContext ctx(this, /* updateGrips */ true);
 
-                  if (!editData.element->edit(editData))
+                  if (!editData.element->edit(editData)) {
                         handleArrowKeyPress(ev);
+                        }
                   }
             return;
             }
@@ -1092,8 +1093,9 @@ void ScoreView::keyPressEvent(QKeyEvent* ev)
                         mscore->endCmd();
                         return;
                         }
-                  if (textEdit)
+                  if (textEdit) {
                         mscore->textTools()->updateTools(editData);
+                        }
                   return;
                   }
             }

--- a/mscore/events.cpp
+++ b/mscore/events.cpp
@@ -31,6 +31,7 @@
 #include "libmscore/shadownote.h"
 #include "libmscore/staff.h"
 #include "libmscore/stafflines.h"
+#include "libmscore/slur.h"
 #include "libmscore/text.h"
 #include "libmscore/textedit.h"
 #include "libmscore/stafftext.h"
@@ -997,6 +998,8 @@ void ScoreView::keyPressEvent(QKeyEvent* ev)
       editData.modifiers = ev->modifiers();
       editData.s         = ev->text();
 
+      const auto e = editData.element;
+
       if (state != ViewState::EDIT) {
             const bool shiftModifier = ev->modifiers() & Qt::ShiftModifier;
             if (hasEditGrips() && !(shiftModifier && ev->key() == Qt::Key_Backtab)) {
@@ -1014,7 +1017,7 @@ void ScoreView::keyPressEvent(QKeyEvent* ev)
                                     }
                               // Move focus to default grip if arrow keys are pressed and no grip is focused
                               if (editData.curGrip == Grip::NO_GRIP)
-                                    editData.curGrip = editData.element->defaultGrip();
+                                    editData.curGrip = e->defaultGrip();
                               break;
                         default:
                               break;
@@ -1022,9 +1025,8 @@ void ScoreView::keyPressEvent(QKeyEvent* ev)
 
                   ScoreViewCmdContext ctx(this, /* updateGrips */ true);
 
-                  if (!editData.element->edit(editData)) {
+                  if (!e->edit(editData))
                         handleArrowKeyPress(ev);
-                        }
                   }
             return;
             }
@@ -1033,11 +1035,11 @@ void ScoreView::keyPressEvent(QKeyEvent* ev)
             qDebug("keyPressEvent key 0x%02x(%c) mod 0x%04x <%s> nativeKey 0x%02x scancode %d",
                editData.key, editData.key, int(editData.modifiers), qPrintable(editData.s), ev->nativeVirtualKey(), ev->nativeScanCode());
 
-      if (editData.element->isLyrics()) {
+      if (e->isLyrics()) {
             if (editKeyLyrics())
                   return;
             }
-      else if (editData.element->isHarmony()) {
+      else if (e->isHarmony()) {
             if (editData.key == Qt::Key_Space && !(editData.modifiers & CONTROL_MODIFIER)) {
                   harmonyBeatsTab(true, editData.modifiers & Qt::ShiftModifier);
                   return;
@@ -1052,22 +1054,26 @@ void ScoreView::keyPressEvent(QKeyEvent* ev)
                   return;
                   }
             }
-      else if (editData.element->isFiguredBass()) {
+      else if (e->isFiguredBass()) {
             if (editData.key == Qt::Key_Space && !(editData.modifiers & CONTROL_MODIFIER)) {
                   figuredBassTab(false, editData.modifiers & Qt::ShiftModifier);
                   return;
                   }
             }
-      else if (editData.element->isSticking()) {
+      else if (e->isSticking()) {
             if (editKeySticking())
                   return;
             }
-      else if (editData.element->isFingering()) {
+      else if (e->isFingering()) {
             if (editData.key == Qt::Key_Tab || editData.key == Qt::Key_Backtab) {
-                  if (editData.element->edit(editData)) {
+                  if (e->edit(editData)) {
                         return;
                         }
                   }
+            }
+      else if (e->isSpannerSegment()) {
+            const auto seg = toSpannerSegment(e);
+            cmdGotoElement(seg); // update view during extension/contraction
             }
 
       ScoreViewCmdContext cc(this, hasEditGrips());
@@ -1087,15 +1093,14 @@ void ScoreView::keyPressEvent(QKeyEvent* ev)
 #endif
 
       if (!((editData.modifiers & Qt::ShiftModifier) && (editData.key == Qt::Key_Backtab))) {
-            if (editData.element->edit(editData)) {
+            if (e->edit(editData)) {
                   if (state != ViewState::EDIT) {
                         // textTab or other function may have terminated edit mode
                         mscore->endCmd();
                         return;
                         }
-                  if (textEdit) {
+                  if (textEdit)
                         mscore->textTools()->updateTools(editData);
-                        }
                   return;
                   }
             }

--- a/mscore/events.cpp
+++ b/mscore/events.cpp
@@ -660,6 +660,8 @@ void ScoreView::mousePressEvent(QMouseEvent* ev)
                   break;
 
             case ViewState::NOTE_ENTRY: {
+                  const int voiceFilter = 1 + _score->inputState().voice(); // 0=All, 1=Voice-1 etc.
+                  bool shift = (ev->modifiers() & Qt::ShiftModifier);
                   _score->startCmd();
                   bool restMode = _score->inputState().rest();
                   if (ev->button() == Qt::RightButton)
@@ -667,7 +669,13 @@ void ScoreView::mousePressEvent(QMouseEvent* ev)
                   if (MScore::disableMouseEntry) {
                         if (auto el = elementAt(editData.pos)) {
                               if (!el->isStaffLines()) {
-                                    _score->select(el);
+                                    if (shift) {
+                                          _score->select(el, SelectType::RANGE);
+                                          _score->cmdCycleVoiceFilter(voiceFilter);
+                                          }
+                                    else
+                                          _score->select(el);
+
                                     if (el->isNote() || el->isRest())
                                           _score->inputState().moveInputPos(el);
                                     else changeState(ViewState::NORMAL);
@@ -676,14 +684,15 @@ void ScoreView::mousePressEvent(QMouseEvent* ev)
                               else if (auto m = toStaffLines(el)->measure()) {
                                     if (auto f = m->first()) {
                                           if (auto cr = f->nextChordRest(el->track())) {
-                                                if (cr->isChord())
-                                                      _score->select(toChord(cr)->upNote());
-                                                else _score->select(cr);
-                                                _score->select(m, SelectType::RANGE, cr->staffIdx());
+                                                if (!shift) {
+                                                      _score->deselectAll();
+                                                      _score->select(m, SelectType::RANGE, cr->staffIdx());
+                                                      // Default into a voice-1 under these circumstances:
+                                                      _score->cmdCycleVoiceFilter();
+                                                      }
+                                                else _score->select(cr, SelectType::RANGE);
+
                                                 _score->inputState().moveInputPos(cr);
-                                                // Default into a voice-1 measure selection when in Note Entry
-                                                // Alternatively, pass track for retaining current voice
-                                                _score->cmdCycleVoiceFilter();
                                                 }
                                           }
                                     }

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -6789,7 +6789,7 @@ void MuseScore::cmd(QAction* a, const QString& cmd)
                   auto oseg = is.segment();
                   if (auto cr = cs->selection().firstChordRest()) {
                         auto track = cr->track();
-                        if (cv && isRange) {
+                        if (cv && (isRange || cr->isGrace())) {
                               cv->cmd(getAction("delete")); // Specifically not cs->cmdDeleteSelection();
                               }
                         else if (cr->isRest()) {

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -6779,12 +6779,14 @@ void MuseScore::cmd(QAction* a, const QString& cmd)
                   (_sstate == STATE_NOTE_ENTRY_METHOD_STEPTIME ||
                   _sstate == STATE_NOTE_ENTRY_METHOD_REPITCH ||
                   _sstate == STATE_NOTE_ENTRY_METHOD_RHYTHM);
+            bool rhythmMethod = _sstate == STATE_NOTE_ENTRY_METHOD_RHYTHM;
             auto ee = cv->getEditElement();
 
             if (isNoteEntry) {
                   // Note Entry - Delete current chord, or move to previous chord in current track
                   auto& is = cs->inputState();
                   auto  iTick = is.tick();
+                  auto oseg = is.segment();
                   if (auto cr = cs->selection().firstChordRest()) {
                         auto track = cr->track();
                         if (cv && isRange) {
@@ -6826,6 +6828,11 @@ void MuseScore::cmd(QAction* a, const QString& cmd)
                         cs->startCmd();
                            cs->cmdDeleteSelection();
                         cs->endCmd();
+                        }
+
+                  if (rhythmMethod) {
+                        is.setSegment(oseg);
+                        cs->setPlayPos(oseg->tick(), true);
                         }
                   }
             else if (!ee || !cv->editMode()) {

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -6779,6 +6779,7 @@ void MuseScore::cmd(QAction* a, const QString& cmd)
                   (_sstate == STATE_NOTE_ENTRY_METHOD_STEPTIME ||
                   _sstate == STATE_NOTE_ENTRY_METHOD_REPITCH ||
                   _sstate == STATE_NOTE_ENTRY_METHOD_RHYTHM);
+            auto ee = cv->getEditElement();
 
             if (isNoteEntry) {
                   // Note Entry - Delete current chord, or move to previous chord in current track
@@ -6786,7 +6787,7 @@ void MuseScore::cmd(QAction* a, const QString& cmd)
                   auto  iTick = is.tick();
                   if (auto cr = cs->selection().firstChordRest()) {
                         auto track = cr->track();
-                        if (isRange) {
+                        if (cv && isRange) {
                               cv->cmd(getAction("delete")); // Specifically not cs->cmdDeleteSelection();
                               }
                         else if (cr->isRest()) {
@@ -6826,6 +6827,24 @@ void MuseScore::cmd(QAction* a, const QString& cmd)
                            cs->cmdDeleteSelection();
                         cs->endCmd();
                         }
+                  }
+            else if (!ee || !cv->editMode()) {
+                  cv->cmd(getAction("delete"));
+                  return;
+                  }
+            else if (ee) {
+                  cv->changeState(ViewState::NORMAL);
+
+                  cs->startCmd();
+                  if (ee->isSpannerSegment()) {
+                        auto sseg = toSpannerSegment(ee);
+                        auto span = sseg->spanner();
+                        cs->deleteItem(span);
+                        }
+                  else {
+                        cs->deleteItem(ee);
+                        }
+                  cs->endCmd();
                   }
             else if (_sstate != STATE_NORMAL) {
                   undoRedo(true);

--- a/mscore/palette.cpp
+++ b/mscore/palette.cpp
@@ -898,6 +898,9 @@ bool Palette::applyPaletteElement(Element* element, Qt::KeyboardModifiers modifi
                   int endStaff   = firstStaffOnly ? 1 : sel.staffEnd();
                   for (int i = startStaff; i < endStaff; ++i) {
                         Spanner* spanner = static_cast<Spanner*>(element->clone());
+                        spanner->setTick(startSegment->tick());
+                        if (endSegment)
+                              spanner->setTick2(endSegment->tick());
                         spanner->setScore(score);
                         spanner->styleChanged();
                         score->cmdAddSpanner(spanner, i, startSegment, endSegment);

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -4596,7 +4596,7 @@ void ScoreView::startNoteEntry()
       setMouseTracking(true);
       if (!MScore::disableMouseEntry)
             shadowNote->setVisible(true);
-      _score->setUpdateAll();
+      _score->setUpdateAllNoLayout();
       _score->update();
 
       Staff* staff = _score->staff(is.track() / VOICES);

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -4093,6 +4093,11 @@ void ScoreView::textTab(bool back)
 
       TextBase* ot = toTextBase(oe);
 
+      const System* oeSys = ot->findMeasureBase() ? ot->findMeasureBase()->system() : nullptr;
+      const System* oeNextSys{0};
+      if (oeSys) if (auto nmb = oeSys->lastMeasure()->findMeasureBase()->next())
+            oeNextSys = nmb->system();
+
       if (oe->isHarmony()) {
             harmonyBeatsTab(true, back);
             return;
@@ -4239,6 +4244,15 @@ void ScoreView::textTab(bool back)
             return;
             }
       Note* nn = toNote(el);
+
+      const auto gotoSys = nn->chord()->measure()->system();
+      bool gotoIsBeyondNextSys = (gotoSys != oeSys && gotoSys != oeNextSys);
+      if (gotoIsBeyondNextSys) {
+            // Safeguard jumping too far away from current position by finalizing onto
+            // original (current) text selection
+            score()->select(oe);
+            return;
+            }
 
       // go to note
       cmdGotoElement(nn);

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -3940,7 +3940,13 @@ void ScoreView::cmd(const char* s)
                            "Please select a range of measures to join and try again"));
                         }
                   else {
-                        cv->score()->cmdJoinMeasure(m1, m2);
+                        if (auto cr = cv->score()->cmdJoinMeasure(m1, m2)) {
+                              Element* toSelect = cr;
+                              if (cr->isChord())
+                                    toSelect = toChord(cr)->upNote();
+                              cv->score()->select(toSelect);
+                              // a resulting multi-measure rest gives a wrong updated view...
+                              }
                         }
                   }},
             {{"measure-properties"}, [](ScoreView* cv, const QByteArray&) {

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -4535,7 +4535,8 @@ void ScoreView::startNoteEntry()
                   }
             }
 
-      Element* el = _score->selection().element();
+      Element* oel = _score->selection().element();
+      Element* el = oel;
       if (!el)
             el = _score->selection().firstChordRest();
       if (el == 0 || (el->type() != ElementType::CHORD && el->type() != ElementType::REST && el->type() != ElementType::NOTE)) {
@@ -4562,6 +4563,17 @@ void ScoreView::startNoteEntry()
             if (note == 0)
                   note = c->upNote();
             el = note;
+
+            if (oel) {
+                  if (oel->isSlurSegment()) {
+                        auto ss = toSlurSegment(oel);
+                        auto s = ss->slur();
+                        el = (ss == s->backSegment()) ? s->endElement() : s->startElement();
+                        if (el->isChord())
+                              el = toChord(el)->upNote();
+                        }
+                  }
+
             defaultDuration = c->durationType();
             }
       else if (el->type() == ElementType::REST) {

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -4002,8 +4002,21 @@ void ScoreView::cmd(const char* s)
                   int idxStaff = track2staff(inputTrack);
 
                   cv->setDropTarget(nullptr);
+
+
+                  if (cv->editMode())
+                        cv->changeState(ViewState::NORMAL);
+
                   cv->score()->startCmd();
-                     cv->score()->cmdDeleteSelection();
+
+                  const auto ee = cv->getEditElement();
+                  if (ee && ee->isSpannerSegment()) {
+                        auto sseg = toSpannerSegment(ee);
+                        auto span = sseg->spanner();
+                        cv->score()->deleteItem(span);
+                        }
+                  else cv->score()->cmdDeleteSelection();
+
                   cv->score()->endCmd();
 
                   if (is.noteEntryMode()) {

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -5643,9 +5643,9 @@ void ScoreView::cmdAddHairpin(HairpinType type)
             // Update layout and exit
             score()->startCmd();
                sh->layout();
+               sh->triggerLayout();
                mscore->currentScoreView()->updateGrips();
             score()->endCmd();
-            score()->doLayout();
             return;
             }
 

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -5245,6 +5245,7 @@ void ScoreView::adjustCanvasPosition(const Element* el, bool playBack, int staff
             auto end = spanner->endElement();
             auto terminus = (spanner->frontSegment() == ss) ? start : end;
             m = toMeasure(terminus->findMeasure());
+            el = terminus;
             }
       else if (el->isSpanner()) {
             Element* se = static_cast<const Spanner*>(el)->startElement();
@@ -5351,9 +5352,10 @@ void ScoreView::adjustCanvasPosition(const Element* el, bool playBack, int staff
                   }
             }
       else if (editing){
-            // keep position while editing and currentSystemAlwaysTop is off
-            showRect.setY(r.y());
-            showRect.setHeight(r.height());
+            auto ry = sys->canvasBoundingRect().y();
+            auto h = sys->canvasBoundingRect().height();
+            showRect.setY(ry);
+            showRect.setHeight(h);
             }
 
       if (shadowNote->visible())

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -2303,7 +2303,8 @@ void ScoreView::updateHover(const QPointF& position)
 
       auto selected     = score()->selection().element();
       auto pastHover    = dropTarget;
-      auto presentHover = elementNear(toLogical(point));
+      const qreal zoomThresh  = 0.33;
+      Element* presentHover = logicalZoomLevel() > zoomThresh ? elementNear(toLogical(point)) : nullptr;
 
       auto logicalPos = toLogical(point);
       editData.pos = logicalPos;

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -2791,6 +2791,126 @@ void ScoreView::cmdGotoElement(Element* e)
       }
 
 //---------------------------------------------------------
+//   selectSlur
+//
+//    Forward can be achieved by using the "Select next slur from position"
+//    command, but it only activates when in Edit Mode to allow for
+//    duplicate shortcut definitions
+//    E.g., Slur [S] for "forward", [Alt+S] for "backward", where [S] won't
+//    work until a slur is selected, and edit mode is on (it isn't enabled by
+//    default when selected via mouse
+//
+//    TODO: Maybe adv. prefewrence for staying on track instead of using entire staff?
+//    TODO: lower_bound & upper_bound for more efficient spanner map traversal
+//
+//    C++ Observation: std::reverse() is not supported for multi-maps [c++17],
+//          but auto type deduction of lambdas was introduced in [c++14]
+//---------------------------------------------------------
+
+void ScoreView::selectSlur(bool backward)
+      {
+      const bool forward = !backward;
+
+      //---------------------------------------------------------
+      //    Outer Lambda: getNextSpannerSegment
+      //---------------------------------------------------------
+      auto getNextSpannerSegment = [&](const Element* selected, const bool backward) -> SpannerSegment* {
+            if (!selected)
+                  return nullptr;
+            const auto selectedSpannerSegment = selected->isSpannerSegment() ? toSpannerSegment(selected) : nullptr;
+            const auto selectedSpanner = selectedSpannerSegment ? selectedSpannerSegment->spanner() : nullptr;
+            SpannerSegment* result = nullptr;
+            bool foundSelf = !selectedSpannerSegment;
+
+            //---------------------------------------------------------
+            //    Inner Lambda: theLogic
+            //---------------------------------------------------------
+            auto theLogic = [&](const auto& it, bool& foundSelf) -> SpannerSegment* {
+                  const auto rejected = nullptr;
+                  const auto s = it->second;
+                  const int begin = it->first;
+
+                  const int selectedPos = selectedSpanner ? selectedSpanner->tick().ticks() : selected->tick().ticks();
+                  const int selectedTrack = score()->noteEntryMode() ? score()->inputTrack() : selected->track();
+                  const auto selectedType = selectedSpanner ? selectedSpanner->type() : ElementType::SLUR;
+                  const auto selectedStaff = selected->staff();
+
+                  if (backward && (begin > selectedPos))
+                        return rejected;
+                  else if (forward && (begin < selectedPos))
+                        return rejected;
+
+                  const bool sameSpanner = selectedSpanner && (selectedSpanner == s);
+                  const bool sameType  = (s->type() == selectedType);
+                  const bool sameTrack = (s->track() == selectedTrack); (void) sameTrack; // Option? Choice between same track or same staff?
+                  const bool sameStaff = (s->staff() == selectedStaff);
+
+                  if (sameSpanner) {
+                        foundSelf = true;
+                        return rejected;
+                        }
+                  if (sameType && sameStaff) {
+                        if (!foundSelf && (begin == selectedPos))
+                              return rejected;
+                        else return backward ? s->backSegment() : s->frontSegment();
+                        }
+                  else return rejected;
+                  };
+
+
+            auto spanners = score()->spannerMap().map();
+            // auto spanners = overlap ? score()->spannerMap().findOverlapping(begin, end) : score()->spannerMap().findContained(begin, end);
+
+            if (backward) {
+                  for (auto it = spanners.rbegin(); it != spanners.rend(); ++it) {
+                        result = theLogic(it, foundSelf);
+                        if (result)
+                              break;
+                        }
+                  }
+            else if (forward) {
+                  for (auto it = spanners.begin(); it != spanners.end(); ++it) {
+                        result = theLogic(it, foundSelf);
+                        if (result)
+                              break;
+                        }
+                  }
+
+            return result;
+            };
+
+      //---------------------------------------------------------
+      //    lambda: activateSpanner
+      //---------------------------------------------------------
+      auto activateSpanner = [this](SpannerSegment* selectMe) -> void {
+            if (!selectMe)
+                  return;
+            changeState(ViewState::NORMAL);
+            score()->select(selectMe);
+            cmdGotoElement(selectMe);
+            startEditMode(selectMe);
+            };
+
+      auto& selection  = score()->selection();
+      const auto e = selection.isRange() ? selection.elements().front() : selection.isSingle() ? selection.element() : nullptr;
+      if (!e)
+            return;
+
+      const auto selectedSpannerSegment = e->isSpannerSegment() ? toSpannerSegment(e) : nullptr;
+      auto selectedSpanner = selectedSpannerSegment ? selectedSpannerSegment->spanner() : nullptr;
+      if (selectedSpanner) {
+            const auto toSelect = backward ? selectedSpanner->frontSegment() : selectedSpanner->backSegment();
+            if (selectedSpannerSegment != toSelect) {
+                  activateSpanner(toSelect);
+                  return;
+                  }
+            }
+
+      auto nextSpannerSegment = getNextSpannerSegment(e, backward);
+      activateSpanner(nextSpannerSegment);
+      }
+
+//---------------------------------------------------------
 //   ticksTab
 //---------------------------------------------------------
 
@@ -3272,62 +3392,10 @@ void ScoreView::cmd(const char* s)
       //            ; // TODO:state         sm->postEvent(new CommandEvent(cmd));
       //            }},
             {{"select-slur"}, [](ScoreView* cv, const QByteArray&) {
-                  Element* e = nullptr;
-                  int beginning = 0;
-                  int tick      = 0;
-                  int track     = 0;
-                  auto score = cv->score();
-                  auto& sel  = score->selection();
-                  if (sel.isRange()) {
-                        e = sel.elements().front();
-                        tick = sel.tickEnd().ticks();
-                        if (sel.firstChordRest())
-                              track = sel.firstChordRest()->track();
-                        }
-                  if (sel.isSingle()) {
-                        e = sel.element();
-                        tick = e->tick().ticks();
-                        track = e->track();
-                        }
-                  if (!e) return;
-
-                  // Will consider entire staff's voicing, but use Note-Entry's track info initially
-                  track = score->noteEntryMode() ? score->inputTrack() : -1;
-
-                  if (e->isSlurSegment()) {
-                        // Go to previous (or overlapping) slur of current position in same track
-                        auto overlappingSpanners = score->spannerMap().findOverlapping(tick, tick);
-                        std::vector<SlurSegment*> overlappingSlurSegments;
-                        for (auto i : overlappingSpanners) {
-                               auto s = i.value;
-                               if (s->isSlur()) {
-                                     if (s->track() == track || (s->staff() == e->staff() && track < 0)) {
-                                           auto slur = toSlur(s);
-                                           overlappingSlurSegments.emplace_back(slur->backSegment());
-                                           }
-                                     }
-                               }
-                        if (e == overlappingSlurSegments.front())
-                              --tick;
-                        else beginning = tick;
-                        }
-
-                  auto spanners = score->spannerMap().findOverlapping(beginning, tick);
-                  std::reverse(spanners.begin(), spanners.end());
-                  for (auto interval : spanners) {
-                        auto spanner = interval.value;
-                        if (spanner->isSlur()) {
-                              if (spanner->track() == track || (spanner->staff() == e->staff() && track < 0)) {
-                                    auto slur = toSlur(spanner);
-                                    auto ss = slur->backSegment();
-                                    if (ss == e) continue;
-                                    cv->changeState(ViewState::NORMAL);
-                                    score->select(ss);
-                                    cv->cmdGotoElement(ss);
-                                    break;
-                                    }
-                              }
-                        }
+                  cv->selectSlur(true);
+                  }},
+            {{"select-slur-forward"}, [](ScoreView* cv, const QByteArray&) {
+                  cv->selectSlur(false);
                   }},
             {{"scr-prev"}, [](ScoreView* cv, const QByteArray&) {
                   cv->screenPrev();
@@ -5171,8 +5239,12 @@ void ScoreView::adjustCanvasPosition(const Element* el, bool playBack, int staff
       else if (el->isMeasureBase())
             m = static_cast<const MeasureBase*>(el);
       else if (el->isSpannerSegment()) {
-            Element* se = static_cast<const SpannerSegment*>(el)->spanner()->startElement();
-            m = static_cast<Measure*>(se->findMeasure());
+            auto ss = toSpannerSegment(el);
+            auto spanner = ss->spanner();
+            auto start = spanner->startElement();
+            auto end = spanner->endElement();
+            auto terminus = (spanner->frontSegment() == ss) ? start : end;
+            m = toMeasure(terminus->findMeasure());
             }
       else if (el->isSpanner()) {
             Element* se = static_cast<const Spanner*>(el)->startElement();

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -6460,13 +6460,22 @@ void ScoreView::setControlCursorVisible(bool v)
 
 void ScoreView::cmdTuplet(int n, ChordRest* cr)
       {
-      if ((cr->durationType() < TDuration(TDuration::DurationType::V_512TH) && cr->durationType() != TDuration(TDuration::DurationType::V_MEASURE))
-          || (cr->durationType() < TDuration(TDuration::DurationType::V_256TH) && n > 3)
-          || (cr->durationType() < TDuration(TDuration::DurationType::V_128TH) && n > 7)
-          ) {
-            mscore->noteTooShortForTupletDialog();
-            return;
+      const auto dt = cr->durationType();
+      const auto dtMs  = TDuration(TDuration::DurationType::V_MEASURE);
+      if (dt != dtMs) {
+            bool ok = true;
+            const auto dt512 = TDuration(TDuration::DurationType::V_512TH);
+            const auto dt256 = TDuration(TDuration::DurationType::V_256TH);
+            const auto dt128 = TDuration(TDuration::DurationType::V_128TH);
+            if (dt < dt512 && dt != dtMs) ok = !ok;
+            else if (dt < dt256 && n > 3) ok = !ok;
+            else if (dt < dt128 && n > 7) ok = !ok;
+            if (!ok) {
+                  mscore->noteTooShortForTupletDialog();
+                  return;
+                  }
             }
+
       Measure* measure = cr->measure();
       if (measure && measure->isMMRest())
             return;

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -3626,6 +3626,32 @@ void ScoreView::cmd(const char* s)
                   else
                         cv->cmdGotoElement(cv->score()->lastElement());
                   }},
+            {{"next-articulation"}, [](ScoreView* cv, const QByteArray&) {
+                  auto& selection = cv->score()->selection();
+                  auto st = selection.isRange() ? SelectType::ADD : SelectType::SINGLE;
+                  for (auto el : selection.elements()) {
+                        if (el->isNote()) {
+                              auto c = toNote(el)->chord();
+                              auto& arts = c->articulations();
+                              if (!arts.empty()) {
+                                    el = arts.front();
+                                    cv->score()->select(el, st);
+                                    }
+                              }
+                        else if (el->isArticulation()) {
+                              auto art = toArticulation(el);
+                              auto cr = art->chordRest();
+                              if (cr->isChord()) {
+                                    auto c = toChord(cr);
+                                    auto next = c->nextArticulationOrLyric(art);
+                                    if (!next)
+                                          next = c->articulations().front();
+                                    cv->score()->select(next, st);
+                                    }
+                              }
+                        }
+                  cv->updateAll();
+                  }},
             {{"first-element"}, [](ScoreView* cv, const QByteArray&) {
                   cv->cmdGotoElement(cv->score()->firstElement(false));
                   }},

--- a/mscore/scoreview.h
+++ b/mscore/scoreview.h
@@ -329,6 +329,7 @@ class ScoreView : public QWidget, public MuseScoreView {
       void setLoopCursor(PositionCursor* curLoop, const Fraction& tick, bool isInPos);
       void cmdMoveCR(bool left);
       void cmdGotoElement(Element*);
+      void selectSlur(bool backward=true);
       bool checkCopyOrCut();
       QVariant inputMethodQuery(Qt::InputMethodQuery query) const override;
       void startFotomode();

--- a/mscore/shortcut.cpp
+++ b/mscore/shortcut.cpp
@@ -4795,6 +4795,13 @@ Shortcut Shortcut::_sc[] = {
          },
       {
          MsWidget::SCORE_TAB,
+         STATE_NORMAL | STATE_NOTE_ENTRY,
+         "next-articulation",
+         QT_TRANSLATE_NOOP("action","Select next articulation of Chord"),
+         QT_TRANSLATE_NOOP("action","Select next articulation of Chord"),
+         },
+      {
+         MsWidget::SCORE_TAB,
          STATE_NORMAL,
          "toggle-mmrest",
          QT_TRANSLATE_NOOP("action","Toggle 'Create Multimeasure Rest'"),

--- a/mscore/shortcut.cpp
+++ b/mscore/shortcut.cpp
@@ -1469,11 +1469,21 @@ Shortcut Shortcut::_sc[] = {
          STATE_NORMAL | STATE_NOTE_ENTRY | STATE_EDIT,
          "select-slur",
          QT_TRANSLATE_NOOP("action","Selection (slur)"),
-         QT_TRANSLATE_NOOP("action","Select previous slur from position"),
+         QT_TRANSLATE_NOOP("action","Select previous spanner from position of same type (Slur is Default)"),
          0,
          Icons::Invalid_ICON,
          Qt::WindowShortcut
          },
+      {
+         MsWidget::SCORE_TAB,
+         STATE_EDIT,
+         "select-slur-forward",
+         QT_TRANSLATE_NOOP("action","Selection (slur) forward"),
+         QT_TRANSLATE_NOOP("action","Select next slur from position"),
+         0,
+         Icons::Invalid_ICON,
+         Qt::WindowShortcut
+      },
       {
          MsWidget::SCORE_TAB,
          STATE_NORMAL | STATE_NOTE_ENTRY,

--- a/mscore/shortcut.cpp
+++ b/mscore/shortcut.cpp
@@ -1503,7 +1503,7 @@ Shortcut Shortcut::_sc[] = {
          },
       {
          MsWidget::SCORE_TAB,
-         STATE_NORMAL | STATE_NOTE_ENTRY,
+         STATE_NORMAL | STATE_NOTE_ENTRY | STATE_EDIT,
          "delete",
          QT_TRANSLATE_NOOP("action","Delete"),
          QT_TRANSLATE_NOOP("action","Delete"),
@@ -3742,7 +3742,7 @@ Shortcut Shortcut::_sc[] = {
          },
       {                     // mapped to undo in note entry mode
          MsWidget::SCORE_TAB,
-         STATE_NORMAL | STATE_NOTE_ENTRY,
+         STATE_NORMAL | STATE_NOTE_ENTRY | STATE_EDIT,
          "backspace",
          QT_TRANSLATE_NOOP("action","Backspace"),
 //         0,

--- a/mtest/libmscore/selectionfilter/selectionfilter6-base-ref.xml
+++ b/mtest/libmscore/selectionfilter/selectionfilter6-base-ref.xml
@@ -8,7 +8,6 @@
       <durationType>quarter</durationType>
       <Spanner type="Slur">
         <Slur>
-          <stemArr>0</stemArr>
           <ticks_f>1/4</ticks_f>
           </Slur>
         <next>
@@ -40,7 +39,6 @@
       <durationType>quarter</durationType>
       <Spanner type="Slur">
         <Slur>
-          <stemArr>0</stemArr>
           <ticks_f>1/4</ticks_f>
           </Slur>
         <next>


### PR DESCRIPTION
For testing purposes, I copied a collection of notation from a popular series so that I could take notes of what went wrong or what intuitively occurred along the way. Kind of got sloppy with about 80 commits or so in the process, but they need to be brought into the main branch here.

This is "Part I". Probably make a hit-list.

- 3.7 Evolution Fix: Layout: wrong dynamic+hairpin alignment (https://github.com/Jojo-Schmitz/MuseScore/issues/975 on 3.7 Evolution) 
- 3.7 Evolution Fix: had inability to apply certain tuples to a whole measure rest (E.g. Debussy in 9/8): https://github.com/Jojo-Schmitz/MuseScore/issues/971

Newer behavior:
- **Backspace Key** will delete range selection
- **Backspace Key** can erase line-segments and when in edit-mode
- **Range selection** extending left-wise will omit grace notes. Sounds strange, but makes it easier to perform a slur on the main note while omitting grace-notes when backtracking. Pulling back to the right will include them into the range selection
- **Fingering Entry**: CTRL+M ("Hardwired" for now) will switch style to LH-Guitar fingering and back to regular again while entering Fingerings
- **Finger Entry**: Since this moves to a score's next note (skipping rests like repitch mode), if user is editing in the middle of score with a bunch of sections of rests (pre-layout activity for example for multiple sections) and then a note further ahead exists in the score, a large jump will occur when moving forward. Now, _if the next note on score is beyond a full system, Finger entry will stop._ at last entry position


- **Note-Entry (Repitch):** can pass through graces notes to update them via A-G like regular notes (though the note entry cursor still remains as it normally does in the process). Post-grace notes don't work for this.
- **Note-Entry (Repitch):** at the end of a system the note-entry may jump way ahead to a note, skipping rests in between, and attempting to pull back via previous measure for instance to get back to the system of "score-selection" was taking me to the previous rest or something further ahead.
- **Note-Entry (Repitch):** Not 100% sure about keeping this, but if note entry position is on the selection itself (not a streamlined note entry), the octave calculation for a pitch-entry will be based on its top-note and not the previous chord's top-note. This can be a time-saver if used intelligently, or counter-productive depending. Maybe should make a preference to enable/disable it.
- **Note-Entry (Repitch):** allows for slurs to extend like in Step Time during entry (not sure why it wasn't allowed, probably an oversight)
- **Note-Entry (Repitch):** Double/Half durations (for corrective action) will now take into account the score selection duration, not the note-entry duration

- Note-Entry position is more appropriate after editing a slur (extending/contracting)
- Remove Measure will result in a selection of the previous rest rather than afterwards, mainly because of the possibility of e.g. being at the end of a system and having vertical boxes afterwards and not wanting to jump forward to get to the next measure.
- **Note Entry Mode + Range selection**: [next/prev measure]  will bring selection to the beginning/end of the range (within the range) while regular left/right will take outside of the range. May take a while to acclimate 
- **Note Entry Mode + Range selection**: now allowed to extend range via [Shift+Left Click] and will retain current voice
- **Note Entry Mode + Range selection**: will do "quick octave" (only explicit accidentals will exist after an octave up/down position) command, whereas regular range-selection will do the default octave shift commands
- **New Command**: Next Articulation: Useful to grab an articulation that needs its direction changed quickly instead of relying on the [next/prev element] command when there are many notes and whatever else exists


- **Rhythm Entry**: Backspace will quickly convert a duration into a rest while not changing note-entry position. User should mainly convert to rests during Repitch phase, but this is allowed without having to toggle to rest-entry
- Slurs will no longer rebase anchors if nudged by a left/right arrow key, but only with larger motions (ctrl+left/right)

- **Update ScoreView when extending/contracting a slur** in edit-mode (when node reaches a different system especially).  Also applies to pedals, etc. Found it especially useful for when needing to "Select Slur" command to get the slur of a previous system in order to extend it to another system and see what's going on while doing it.

**Layout:**
- Articulations: layout before slurs now. 
- Articulations: are less further away from slurs now
- Fingering: peculiar offsetting with non-beamed notes no longer occurs
- Fingering: layout to the left of arpeggios (previously didn't regard them)
- Fixed: I allowed for natural courtesy Key Signature on a new system when switching keys in an earlier commit, but forgot to omit doing this when a section break exists at the end of the previous system.
- Update Center of Single ChordRest (Measure) now will center a fermata and dynamic mark

**Efficiency**: [a.k.a. speed performance benefit]
- Efficiency:  Cycle of hairpin style is faster now (noticed the slowdown at 100 pages in)
- Efficiency: Placements of LayoutBreak
- Efficiency: Placements of Text Line / Pedals
- Efficiency: Fixed slowdown of selection of edit-element (slur) when first loading a large score
- Efficiency: setProperty() for slurs would perform unnecessary layouts
- Efficiency: Insert/Remove/Split/Join measures is faster now
- Efficiency: Insert TimeSig/KeySig/Clef should be faster now in larger scores
- Efficiency: Purposefully removed a full score layout when saving score because of wait-time on a large (100+ paged) score. Slow-down was caused by a pre-layout of score prior to forming a thumbnail image for MSCZ file
- Efficiency: Note-Entry activation immediately after loading score without performing another action first caused an unnecessary full score layout. Slow for large scores.
- Fix slur locking up after copy/paste of certain situations (nodes wouldn't move). 


**Crashes**:
- Zoomed way out (in order to scroll quickly through pages) could crash with the "hover highlight" ability when the approximation of elements get too close. Now, hovering is disabled at around 33% or lesser zoom level
- Clone Measures function needed some updates to solidify its functionality: Cloning a full score with title frame onto the first measure of another score for instance would cause a crash.

**Select Slur Command**
- Now with Command: "Select next slur from position" which can be defined with "S" (default slur function), so user can have Alt+S for "select previous slur", and once a slur is selected,  "S" can move to the next slur
- Selects also other segment lines like Pedals and Crescendos

Backport (MSS4): Tie honors cross-staff status during Note Entry
