### PR TITLE
Smorgasbord 2

### DIFF
--- a/global/settings/types/preferencekeys.h
+++ b/global/settings/types/preferencekeys.h
@@ -141,6 +141,8 @@
 #define PREF_SCORE_NOTE_INPUT_ENTRY_STATUS_COLOR            "ui/score/noteEntry/toggleStatusColor"
 #define PREF_SCORE_NOTE_INPUT_ENTRY_STATUS_ENABLE           "ui/score/noteEntry/toggleStatus"
 
+#define PREF_SCORE_NOTE_INPUT_ENTRY_AUTO_SWITCH_MODE        "ui/score/noteEntry/autoSwitchRhythmRepitch"
+
 #define PREF_SCORE_FINGERING_ALPHANUMERIC_AUTOFORWARD       "score/fingering/autoForwardWithAlphaNumerics"
 #define PREF_SCORE_STYLE_DEFAULTSTYLEFILE                   "score/style/defaultStyleFile"
 #define PREF_SCORE_STYLE_PARTSTYLEFILE                      "score/style/partStyleFile"

--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -587,6 +587,11 @@ void Score::expandVoice()
 
 Note* Score::cmdAddInterval(int val, const std::vector<Note*>& nl)
       {
+      if (MScore::noteEntryAutoSwitchModes) {
+            if (usingNoteEntryMethod(NoteEntryMethod::RHYTHM)) {
+                  _is.setNoteEntryMethod(NoteEntryMethod::REPITCH);
+                  }
+            }
       auto inputSeg = _is.segment();
       Note* ret = nullptr;      
       startCmd();
@@ -4770,6 +4775,11 @@ void Score::cmdUnsetVisible()
 
 void Score::cmdAddPitch(const EditData& ed, int note, bool addFlag, bool insert, bool useUpNote, bool below)
       {
+      if (MScore::noteEntryAutoSwitchModes) {
+            if (usingNoteEntryMethod(NoteEntryMethod::RHYTHM)) {
+                  _is.setNoteEntryMethod(NoteEntryMethod::REPITCH);
+                  }
+            }
       InputState& is = inputState();
       const bool repitchMode = is.noteEntryMethod() == NoteEntryMethod::REPITCH;
       if (is.track() == -1)          // invalid state

--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -2630,8 +2630,6 @@ Element* Score::move(const QString& cmd)
       Measure* oim = ois ? ois->measure() : nullptr;
 
       if (cmd == "next-chord" && cr) {
-            auto iCr = _is.cr();
-
             if (noteEntryMode())
                   _is.moveToNextInputPos();
 
@@ -2650,17 +2648,13 @@ Element* Score::move(const QString& cmd)
                   Segment* nis = _is.segment();
                   Measure* nim = nis ? nis->measure() : nullptr;
                   if (m != oim && m != nim) {
-                        if (noteEntryMethod() == NoteEntryMethod::REPITCH)
-                              el = iCr;
-                        else
+                        if (noteEntryMethod() != NoteEntryMethod::REPITCH)
                               el = cr;
                         }
                   // do not use if new input segment is current cr
                   // this means input cursor just caught up to current selection
                   else if (cr && nis == cr->segment() && !isRange) {
-                        if (noteEntryMethod() == NoteEntryMethod::REPITCH)
-                              el = iCr;
-                        else
+                        if (noteEntryMethod() != NoteEntryMethod::REPITCH)
                               el = cr;
                         }
                   }

--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -2681,6 +2681,10 @@ Element* Score::move(const QString& cmd)
                               _is.moveInputPos(scr);
                               }
                         }
+                  else if (noteEntryMode() && isRange) {
+                        if (lastCR)
+                              s = lastCR->nextSegmentAfterCR(SegmentType::ChordRest);
+                        }
                   else for (; s; s = s->prev1(SegmentType::ChordRest)) {
                         if (s->element(track) || (s->measure() != m && s->rtick().isZero())) {
                               if (s->element(track)) {
@@ -2710,12 +2714,14 @@ Element* Score::move(const QString& cmd)
                   Measure* m = toChordRest(el)->measure();
                   Segment* nis = _is.segment();
                   Measure* nim = nis ? nis->measure() : nullptr;
-                  if (m != oim && m != nim)
-                        el = cr;
-                  // do not use if new input segment is current cr
-                  // this means input cursor just caught up to current selection
-                  else if (cr && nis == cr->segment())
-                        el = cr;
+                  if (!isRange) {
+                        if (m != oim && m != nim)
+                              el = cr;
+                        // do not use if new input segment is current cr
+                        // this means input cursor just caught up to current selection
+                        else if (cr && nis == cr->segment())
+                              el = cr;
+                        }
                   }
             else if (!el)
                   el = cr;
@@ -2844,44 +2850,53 @@ Element* Score::move(const QString& cmd)
                   el = cr;
             }
       else if (cmd == "next-measure") {
-            auto currentTrack = noteEntryMode() ? _is.track() : 0;
-            if (isRange)
+            const int currentTrack = noteEntryMode() ? _is.track() : 0;
+            if (isRange) {
                   cr = lastCR;
-            if (box && box->nextMeasure() && box->nextMeasure()->first())
-                  el = box->nextMeasure()->first()->nextChordRest(0, false);
-            if (cr) {
-                  if (selection().cr() && (cr->tick() != selection().cr()->tick()))
-                        cr = selection().cr();
-                  el = nextMeasure(cr);
+                  el = noteEntryMode() ? cr : nextMeasure(cr);
+                  }
+            else if (box) {
+                  if (auto nm = box->nextMeasure())
+                        if (auto fs = nm->first())
+                              el = fs->nextChordRest(0);
                   }
 
-            if (el) {
-                  auto oldEl = el;
-                  auto m = el->findMeasure();
-                  if (cr && m == cr->measure() && m->last()) {
-                        el = m->last()->nextChordRest(el->track(), true);
-                        if (!el) {
-                              el = oldEl;
+            if (!isRange) {
+                  if (cr) {
+                        auto scr = selection().cr();
+                        if (scr && cr->tick() != scr->tick())
+                              cr = selection().cr();
+                        el = nextMeasure(cr);
+                        }
+                  if (el) {
+                        auto oel = el;
+                        auto m = el->findMeasure();
+                        if (cr && (m == cr->measure()) && m->last()) {
+                              el = m->last()->nextChordRest(el->track(), true);
+                              if (!el)
+                                    el = oel;
                               }
                         }
-                  if (noteEntryMode()) {
-                        _is.moveInputPos(el);
-                        auto desiredTrackCR = _is.segment()->nextChordRest(currentTrack);
-                        auto inputTick = _is.tick();
-                        if (desiredTrackCR && desiredTrackCR->tick() <= inputTick) {
-                              auto note = desiredTrackCR->isChord() ? toChord(desiredTrackCR)->upNote() : nullptr;
-                              if (note) el = note; else el = desiredTrackCR;
-                              }
+                  }
+            if (noteEntryMode() && el) {
+                  _is.moveInputPos(el);
+                  auto desiredTrackCR = _is.segment()->nextChordRest(currentTrack);
+                  auto inputTick = _is.tick();
+                  if (desiredTrackCR && desiredTrackCR->tick() <= inputTick) {
+                        auto note = desiredTrackCR->isChord() ? toChord(desiredTrackCR)->upNote() : nullptr;
+                        if (note) el = note; else el = desiredTrackCR;
                         }
                   }
             }
       else if (cmd == "prev-measure") {
-            const bool isRange = selection().isRange();
+            const int currentTrack = noteEntryMode() ? _is.track() : 0;
             if (firstCR)
                   cr = firstCR;
-            auto currentTrack = noteEntryMode() ? _is.track() : 0;
-            if (box && box->prevMeasure() && box->prevMeasure()->first())
-                  el = box->prevMeasure()->first()->nextChordRest(0, false);
+            else if (box) {
+                  if (auto pm = box->prevMeasure())
+                        if (auto fs = pm->first())
+                              el = fs->nextChordRest(0);
+                  }
             if (cr) {
                   const auto scr = selection().cr();
                   const auto fcr = selection().firstChordRest();
@@ -2911,18 +2926,23 @@ Element* Score::move(const QString& cmd)
                   return nullptr;
 
             el = nullptr;
-            bool next = (cmd == "next-system");
+            const bool next = (cmd == "next-system");
+            const bool prev = !next;
+            bool atStartOfMeasure = false;
             MeasureBase* dest = nullptr;
 
-            if (auto scr = selection().cr())
-                  if (!next && (_is.tick() > scr->tick()))
+            if (auto scr = selection().cr()) {
+                  if (prev && (_is.tick() > scr->tick()))
                         cr = scr;
+                  }
+            else if (isRange)
+                  cr = prev ? firstCR : lastCR;
 
             if (cr) {
+                  atStartOfMeasure = (cr->tick() == cr->measure()->tick());
                   if (auto m = cr->findMeasureBase()) {
-                        if (!next) {
-                              bool atStartOfMeasure = (cr->tick() == cr->measure()->tick());
-                              dest = atStartOfMeasure ? m->prev() : m;
+                        if (prev) {
+                              dest = (atStartOfMeasure && !isRange) ? m->prev() : m;
                               }
                         else if (auto s = m->system()) {
                               if (auto lm = s->lastMeasure()) {

--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -5673,16 +5673,6 @@ void Score::undoRemoveMeasures(Measure* m1, Measure* m2, bool preserveTies)
       for (Segment* s = m1->first(); s != m2->last(); s = s->next1()) {
             if (!s->isChordRestType())
                   continue;
-
-            // Make sure annotations are removed once, even if this segment contains linked copies of the same annotation
-            // (the linked copy would be removed by undoRemoveElement)
-            while (!s->annotations().empty()) {
-                  Element* annotation = s->annotations().front();
-                  if (!annotation)
-                        continue;
-                  undoRemoveElement(annotation);
-                  }
-
             for (int track = 0; track < ntracks(); ++track) {
                   Element* e = s->element(track);
                   if (!e || !e->isChord())

--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -3137,6 +3137,24 @@ void Score::enterRest(const TDuration& d, InputState* externalInputState)
 void Score::removeChordRest(ChordRest* cr, bool clearSegment)
       {
       QList<Segment*> segments;
+
+      auto tick = cr->tick().ticks();
+      auto spanners = spannerMap().findOverlapping(tick,tick);
+      std::vector<Spanner*> toRemove;
+      for (auto interval : spanners) {
+            Spanner* s = interval.value;
+            if (s->anchor() == Spanner::Anchor::MEASURE || s->anchor() == Spanner::Anchor::NOTE)
+                  continue;
+            if (s->startCR() == cr) {
+                  if (s->isSlur()) {
+                        toRemove.push_back(s);
+                        }
+                  }
+            }
+      for (auto remove : toRemove) {
+            undoRemoveElement(remove);
+            }
+
       for (ScoreElement*& e : cr->linkList()) {
             undo(new RemoveElement(static_cast<Element*>(e)));
             if (clearSegment) {

--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -2677,6 +2677,8 @@ void Score::cmdDeleteSelection()
                         select(toChord(cr)->upNote(), SelectType::SINGLE);
                   else
                         select(cr, SelectType::SINGLE);
+
+                  _is.moveToNextInputPos();
                   }
             }
       else if (tempVoiceFilter) {

--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -2557,6 +2557,8 @@ void Score::cmdDeleteSelection()
       Segment* s1 = nullptr;
       Segment* s2 = nullptr;
       Chord* graceParentChord{0};
+      const auto scr = selection().cr();
+      bool cursorHasSamePosition = scr && (_is.tick() == scr->tick());
       if (isRange) {
             s1 = selection().startSegment();
             s2 = selection().endSegment();
@@ -2564,9 +2566,8 @@ void Score::cmdDeleteSelection()
                                                    staff2track(selection().staffEnd()), selectionFilter());
             }
       else {
-            if (auto scr = selection().cr()) {
-                  if (scr->isGrace())
-                        graceParentChord = toChord(scr->parent());
+            if (scr && scr->isGrace()) {
+                  graceParentChord = toChord(scr->parent());
                   }
             // deleteItem modifies selection().elements() list,
             // so we need a local copy:
@@ -2683,7 +2684,8 @@ void Score::cmdDeleteSelection()
                   else
                         select(cr, SelectType::SINGLE);
 
-                  _is.moveToNextInputPos();
+                  if (!cursorHasSamePosition)
+                        _is.moveToNextInputPos();
                   }
             }
       else if (tempVoiceFilter) {

--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -5671,8 +5671,26 @@ void Score::undoRemoveMeasures(Measure* m1, Measure* m2, bool preserveTies)
       //  handle ties which start before m1 and end in (m1-m2)
       //
       for (Segment* s = m1->first(); s != m2->last(); s = s->next1()) {
+            if (!s) {
+                  // This score is corrupted; handle it without crashing,
+                  // to help the user to fix corruptions by deleting the affected measures
+                  qDebug() << "Missing segments detected while deleting measures " << m1->no() << " to " << m2->no()
+                           << ". This score (" << name() << ") is corrupted. Continuing without deleting measure contents.";
+                  break;
+                  }
+
             if (!s->isChordRestType())
                   continue;
+
+            // Make sure annotations are removed once, even if this segment contains linked copies of the same annotation
+            // (the linked copy would be removed by undoRemoveElement)
+            while (!s->annotations().empty()) {
+                  Element* annotation = s->annotations().front();
+                  if (!annotation)
+                        continue;
+                  undoRemoveElement(annotation);
+                  }
+
             for (int track = 0; track < ntracks(); ++track) {
                   Element* e = s->element(track);
                   if (!e || !e->isChord())
@@ -5681,14 +5699,14 @@ void Score::undoRemoveMeasures(Measure* m1, Measure* m2, bool preserveTies)
                   for (Note* n : c->notes()) {
                         // Remove ties crossing measure range boundaries
                         Tie* t = n->tieBack();
-                        if (t && (t->startNote()->chord()->tick() < startTick)) {
+                        if (t && t->startNote() && (t->startNote()->chord()->tick() < startTick)) {
                               if (preserveTies)
                                     t->setEndNote(0);
                               else
                                     undoRemoveElement(t);
                               }
                         t = n->tieFor();
-                        if (t && (t->endNote()->chord()->tick() >= endTick))
+                        if (t && t->endNote() && (t->endNote()->chord()->tick() >= endTick))
                               undoRemoveElement(t);
 
                         // Do the same for other note-anchored spanners (e.g. glissandi).

--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -5673,6 +5673,16 @@ void Score::undoRemoveMeasures(Measure* m1, Measure* m2, bool preserveTies)
       for (Segment* s = m1->first(); s != m2->last(); s = s->next1()) {
             if (!s->isChordRestType())
                   continue;
+
+            // Make sure annotations are removed once, even if this segment contains linked copies of the same annotation
+            // (the linked copy would be removed by undoRemoveElement)
+            while (!s->annotations().empty()) {
+                  Element* annotation = s->annotations().front();
+                  if (!annotation)
+                        continue;
+                  undoRemoveElement(annotation);
+                  }
+
             for (int track = 0; track < ntracks(); ++track) {
                   Element* e = s->element(track);
                   if (!e || !e->isChord())

--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -2556,6 +2556,7 @@ void Score::cmdDeleteSelection()
       bool isRange = selection().isRange();
       Segment* s1 = nullptr;
       Segment* s2 = nullptr;
+      Chord* graceParentChord{0};
       if (isRange) {
             s1 = selection().startSegment();
             s2 = selection().endSegment();
@@ -2563,6 +2564,10 @@ void Score::cmdDeleteSelection()
                                                    staff2track(selection().staffEnd()), selectionFilter());
             }
       else {
+            if (auto scr = selection().cr()) {
+                  if (scr->isGrace())
+                        graceParentChord = toChord(scr->parent());
+                  }
             // deleteItem modifies selection().elements() list,
             // so we need a local copy:
             QList<Element*> el = selection().elements();
@@ -2684,18 +2689,31 @@ void Score::cmdDeleteSelection()
       else if (tempVoiceFilter) {
             ;
             }
-      else if (!crsSelectedAfterDeletion.empty()) {
-            std::vector<Element*> elementsToSelect;
-            for (auto cr : crsSelectedAfterDeletion) {
-                  if (cr) {
-                        if (cr->isChord())
-                              elementsToSelect.push_back(dynamic_cast<Element*>(toChord(cr)->upNote()));
-                        else if (cr->isRest())
-                              elementsToSelect.push_back(dynamic_cast<Element*>(cr));
+      if (!crsSelectedAfterDeletion.empty()) {
+            if (graceParentChord) {
+                  auto chords = graceParentChord->graceNotes();
+                  if (!chords.isEmpty()) {
+                        if (auto chord = chords.front()) {
+                              auto n = chord->upNote();
+                              select(n);
+                              }
+                        }
+                  else select(graceParentChord->upNote());
+                  }
+            else if (!noteEntryMode()) {
+                  std::vector<Element*> elementsToSelect;
+                  for (auto cr : crsSelectedAfterDeletion) {
+                        if (cr) {
+                              if (cr->isChord())
+                                    elementsToSelect.push_back(dynamic_cast<Element*>(toChord(cr)->upNote()));
+                              else if (cr->isRest())
+                                    elementsToSelect.push_back(dynamic_cast<Element*>(cr));
+                              }
+                        }
+                  for (auto el : elementsToSelect) {
+                        select(el, SelectType::ADD, 0);
                         }
                   }
-            for (auto el : elementsToSelect)
-                  select(el, SelectType::ADD, 0);
             }
       }
 

--- a/libmscore/input.cpp
+++ b/libmscore/input.cpp
@@ -230,20 +230,42 @@ void InputState::setSegment(Segment* s)
       }
 
 //---------------------------------------------------------
+//   updateAutoModeDuration
+//---------------------------------------------------------
+
+void InputState::updateAutoModeDuration()
+      {
+      if (MScore::noteEntryAutoSwitchModes) {
+            const bool rhythmMode = usingNoteEntryMethod(NoteEntryMethod::RHYTHM);
+            if (!rhythmMode)
+                  return;
+
+            // Non note-entry selection duration mustn't linger:
+            TDuration defaultDuration = TDuration::DurationType::V_QUARTER;
+            TDuration d = cr() ? cr()->durationType() : defaultDuration;
+            if (!d.isValid() || d.isZero() || d.isMeasure()) {
+                  d = defaultDuration;
+                  }
+            setDuration(d);
+            }
+      }
+
+//---------------------------------------------------------
 //   nextInputPos
 //---------------------------------------------------------
 
-Segment* InputState::nextInputPos() const
+Segment* InputState::nextInputPos(bool repitch) const
       {
       Measure* m = _segment->measure();
       Segment* s = _segment->next1(SegmentType::ChordRest);
-      bool repitching = _segment->score()->usingNoteEntryMethod(NoteEntryMethod::REPITCH);
+
       while (s) {
             if (s->element(_track) || s->measure() != m) {
                   auto nse = s->cr(track());
                   bool isRest = nse && nse->isRest();
-                  if (!repitching || !isRest)
+                  if (!repitch || !isRest) {
                         return s;
+                        }
                   }
             s = s->next1(SegmentType::ChordRest);
             }
@@ -257,22 +279,27 @@ Segment* InputState::nextInputPos() const
 
 void InputState::moveToNextInputPos()
       {
-      Segment* s   = nextInputPos();
+      Segment* s   = nextInputPos(usingNoteEntryMethod(NoteEntryMethod::REPITCH));
       _lastSegment = _segment;
       if (s) {
             _segment = s;
-            if (MScore::noteEntryAutoSwitchModes) {
-                  const bool rhythmMode = usingNoteEntryMethod(NoteEntryMethod::RHYTHM);
-                  if (MScore::noteEntryAutoSwitchModes && rhythmMode) {
-                        // Non note-entry selection duration mustn't linger:
-                        TDuration defaultDuration = TDuration::DurationType::V_QUARTER;
-                        TDuration d = cr() ? cr()->durationType() : defaultDuration;
-                        if (!d.isValid() || d.isZero() || d.isMeasure()) {
-                              d = defaultDuration;
-                              }
-                        setDuration(d);
-                        }
-                  }
+            updateAutoModeDuration();
+            }
+      }
+
+//---------------------------------------------------------
+//   moveToNextInputPos
+//   TODO: special case: note is first note of tie: goto to last note of tie
+//   Alternative function to allow override of directive to act as repitch
+//---------------------------------------------------------
+
+void InputState::moveToNextInputPos(bool repitch)
+      {
+      Segment* s   = nextInputPos(repitch);
+      _lastSegment = _segment;
+      if (s) {
+            _segment = s;
+            updateAutoModeDuration();
             }
       }
 
@@ -282,7 +309,7 @@ void InputState::moveToNextInputPos()
 
 bool InputState::endOfScore() const
       {
-      return (_lastSegment == _segment) && !nextInputPos();
+      return (_lastSegment == _segment) && !nextInputPos(usingNoteEntryMethod(NoteEntryMethod::REPITCH));
       }
 
 

--- a/libmscore/input.cpp
+++ b/libmscore/input.cpp
@@ -237,9 +237,14 @@ Segment* InputState::nextInputPos() const
       {
       Measure* m = _segment->measure();
       Segment* s = _segment->next1(SegmentType::ChordRest);
+      bool repitching = _segment->score()->usingNoteEntryMethod(NoteEntryMethod::REPITCH);
       while (s) {
-            if (s->element(_track) || s->measure() != m)
-                  return s;
+            if (s->element(_track) || s->measure() != m) {
+                  auto nse = s->cr(track());
+                  bool isRest = nse && nse->isRest();
+                  if (!repitching || !isRest)
+                        return s;
+                  }
             s = s->next1(SegmentType::ChordRest);
             }
       return 0;

--- a/libmscore/input.cpp
+++ b/libmscore/input.cpp
@@ -259,8 +259,21 @@ void InputState::moveToNextInputPos()
       {
       Segment* s   = nextInputPos();
       _lastSegment = _segment;
-      if (s)
+      if (s) {
             _segment = s;
+            if (MScore::noteEntryAutoSwitchModes) {
+                  const bool rhythmMode = usingNoteEntryMethod(NoteEntryMethod::RHYTHM);
+                  if (MScore::noteEntryAutoSwitchModes && rhythmMode) {
+                        // Non note-entry selection duration mustn't linger:
+                        TDuration defaultDuration = TDuration::DurationType::V_QUARTER;
+                        TDuration d = cr() ? cr()->durationType() : defaultDuration;
+                        if (!d.isValid() || d.isZero() || d.isMeasure()) {
+                              d = defaultDuration;
+                              }
+                        setDuration(d);
+                        }
+                  }
+            }
       }
 
 //---------------------------------------------------------

--- a/libmscore/input.h
+++ b/libmscore/input.h
@@ -61,7 +61,8 @@ class InputState {
       int _lastInputPitchDiff  { 0 };
       Direction _lastInputDirection { Direction::AUTO };
 
-      Segment* nextInputPos() const;
+      Segment* nextInputPos(bool repitch) const;
+      void updateAutoModeDuration();
 
    public:
       ChordRest* cr() const;
@@ -128,6 +129,7 @@ class InputState {
       void update(Selection& selection);
       void moveInputPos(Element* e);
       void moveToNextInputPos();
+      void moveToNextInputPos(bool repitch);
       bool endOfScore() const;
 
       void updateLastPitch(int p)         { _lastInputPitch = p;    }

--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -1566,100 +1566,94 @@ void Score::hideEmptyStaves(System* system, bool isFirstSystem)
 
 void Score::connectTies(bool silent)
       {
-      int tracks = nstaves() * VOICES;
-      Measure* m = firstMeasure();
+      const int tracks = nstaves() * VOICES;
+      const Measure* m = firstMeasure();
       if (!m)
             return;
 
-      SegmentType st = SegmentType::ChordRest;
-      for (Segment* s = m->first(st); s; s = s->next1(st)) {
-            for (int i = 0; i < tracks; ++i) {
-                  Element* e = s->element(i);
-                  if (e == 0 || !e->isChord())
-                        continue;
-                  Chord* c = toChord(e);
-                  for (Note* n : c->notes()) {
-                        // connect a tie without end note
-                        Tie* tie = n->tieFor();
-                        if (tie && !tie->endNote()) {
-                              Note* nnote;
-                              if (_mscVersion <= 114)
-                                    nnote = searchTieNote114(n);
-                              else
-                                    nnote = searchTieNote(n);
-                              if (nnote == 0) {
-                                    if (!silent) {
-                                          qDebug("next note at %d track %d for tie not found (version %d)", s->tick().ticks(), i, _mscVersion);
-                                          delete tie;
-                                          n->setTieFor(0);
-                                          }
+      //---------------------------------------------------------
+      //    lambda: connectTiesForChord
+      //---------------------------------------------------------
+      auto connectTiesForChord = [silent](Chord* c, Segment* s, int track) -> void {
+            for (Note* n : c->notes()) {
+                  // Laissez Vibre not implemented
+                  // if (n->laissezVib()) {
+                  //       continue;
+                  //       }
+
+                  // connect a tie without end note
+                  Tie* tie = n->tieFor();
+
+                  // Unimplemented:
+                  // if (tie) {
+                  //       tie->updatePossibleJumpPoints();
+                  //       }
+
+                  if (tie && /*!tie->isPartialTie() && */ !tie->endNote()) {
+                        Note* nnote;
+                        nnote = searchTieNote(n);
+                        if (!nnote) {
+                              if (!silent) {
+                                    qDebug("next note at %d track %d for tie not found", s->tick().ticks(), track);
+                                    delete tie;
+                                    n->setTieFor(nullptr);
+                                    }
+                              }
+                        else {
+                              tie->setEndNote(nnote);
+                              nnote->setTieBack(tie);
+                              }
+                        }
+                  // connect a glissando without initial note (old glissando format)
+                  for (Spanner* spanner : n->spannerBack()) {
+                        if (spanner->isGlissando() && !spanner->startElement()) {
+                              Note* initialNote = Glissando::guessInitialNote(n->chord());
+                              n->removeSpannerBack(spanner);
+                              if (initialNote) {
+                                    spanner->setStartElement(initialNote);
+                                    spanner->setEndElement(n);
+                                    spanner->setTick(initialNote->chord()->tick());
+                                    spanner->setTick2(n->chord()->tick());
+                                    spanner->setTrack(n->track());
+                                    spanner->setTrack2(n->track());
+                                    spanner->setParent(initialNote);
+                                    initialNote->add(spanner);
                                     }
                               else {
-                                    tie->setEndNote(nnote);
-                                    nnote->setTieBack(tie);
-                                    }
-                              }
-                        // connect a glissando without initial note (old glissando format)
-                        for (Spanner* spanner : n->spannerBack()) {
-                              if (spanner->isGlissando() && !spanner->startElement()) {
-                                    Note* initialNote = Glissando::guessInitialNote(n->chord());
-                                    n->removeSpannerBack(spanner);
-                                    if (initialNote) {
-                                          spanner->setStartElement(initialNote);
-                                          spanner->setEndElement(n);
-                                          spanner->setTick(initialNote->chord()->tick());
-                                          spanner->setTick2(n->chord()->tick());
-                                          spanner->setTrack(n->track());
-                                          spanner->setTrack2(n->track());
-                                          spanner->setParent(initialNote);
-                                          initialNote->add(spanner);
-                                          }
-                                    else {
-                                          delete spanner;
-                                          }
-                                    }
-                              }
-                        // spanner with no end element can happen during copy/paste
-                        for (Spanner* spanner : n->spannerFor()) {
-                              if (spanner->endElement() == nullptr) {
-                                    n->removeSpannerFor(spanner);
                                     delete spanner;
                                     }
                               }
                         }
-#if 0    // chords are set in tremolo->layout()
-                  // connect two note tremolos
-                  Tremolo* tremolo = c->tremolo();
-                  if (tremolo && tremolo->twoNotes() && !tremolo->chord2()) {
-                        for (Segment* ls = s->next1(st); ls; ls = ls->next1(st)) {
-                              Element* element = ls->element(i);
-                              if (!element)
-                                    continue;
-                              if (!element->isChord())
-                                    qDebug("cannot connect tremolo");
-                              else {
-                                    Chord* nc = toChord(element);
-                                    nc->setTremolo(tremolo);
-                                    tremolo->setChords(c, nc);
-                                    // cross-measure tremolos are not supported
-                                    // but can accidentally result from copy & paste
-                                    // remove them now
-                                    if (c->measure() != nc->measure())
-                                          c->remove(tremolo);
-                                    }
-                              break;
+
+                  // spanner with no end element can happen during copy/paste
+                  for (Spanner* spanner : n->spannerFor()) {
+                        if (spanner->endElement() == nullptr) {
+                              n->removeSpannerFor(spanner);
+                              delete spanner;
                               }
                         }
-#endif
-                  for (Chord* gc : qAsConst(c->graceNotes())) {
+                  }
+            };
+
+      SegmentType st = SegmentType::ChordRest;
+      for (Segment* s = m->first(st); s; s = s->next1(st)) {
+            for (int track = 0; track < tracks; ++track) {
+                  Element* e = s->element(track);
+                  if (e == 0 || !e->isChord()) {
+                        continue;
+                        }
+                  Chord* c = toChord(e);
+                  connectTiesForChord(c, s, track);
+                  for (Chord* gc : c->graceNotes()) {
+                        connectTiesForChord(gc, s, track);
                         for (Note* n : gc->notes()) {
                               // spanner with no end element apparently happens when reading some 206 files
                               // (and possibly in other situations too)
                               for (Spanner* spanner : n->spannerFor()) {
-                                   if (spanner->endElement() == nullptr) {
-                                         n->removeSpannerFor(spanner);
-                                         delete spanner;
-                                         }
+                                    if (spanner->endElement() == nullptr) {
+                                          n->removeSpannerFor(spanner);
+                                          delete spanner;
+                                          }
                                     }
                               }
                         }

--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -1566,94 +1566,100 @@ void Score::hideEmptyStaves(System* system, bool isFirstSystem)
 
 void Score::connectTies(bool silent)
       {
-      const int tracks = nstaves() * VOICES;
-      const Measure* m = firstMeasure();
+      int tracks = nstaves() * VOICES;
+      Measure* m = firstMeasure();
       if (!m)
             return;
 
-      //---------------------------------------------------------
-      //    lambda: connectTiesForChord
-      //---------------------------------------------------------
-      auto connectTiesForChord = [silent](Chord* c, Segment* s, int track) -> void {
-            for (Note* n : c->notes()) {
-                  // Laissez Vibre not implemented
-                  // if (n->laissezVib()) {
-                  //       continue;
-                  //       }
-
-                  // connect a tie without end note
-                  Tie* tie = n->tieFor();
-
-                  // Unimplemented:
-                  // if (tie) {
-                  //       tie->updatePossibleJumpPoints();
-                  //       }
-
-                  if (tie && /*!tie->isPartialTie() && */ !tie->endNote()) {
-                        Note* nnote;
-                        nnote = searchTieNote(n);
-                        if (!nnote) {
-                              if (!silent) {
-                                    qDebug("next note at %d track %d for tie not found", s->tick().ticks(), track);
-                                    delete tie;
-                                    n->setTieFor(nullptr);
-                                    }
-                              }
-                        else {
-                              tie->setEndNote(nnote);
-                              nnote->setTieBack(tie);
-                              }
-                        }
-                  // connect a glissando without initial note (old glissando format)
-                  for (Spanner* spanner : n->spannerBack()) {
-                        if (spanner->isGlissando() && !spanner->startElement()) {
-                              Note* initialNote = Glissando::guessInitialNote(n->chord());
-                              n->removeSpannerBack(spanner);
-                              if (initialNote) {
-                                    spanner->setStartElement(initialNote);
-                                    spanner->setEndElement(n);
-                                    spanner->setTick(initialNote->chord()->tick());
-                                    spanner->setTick2(n->chord()->tick());
-                                    spanner->setTrack(n->track());
-                                    spanner->setTrack2(n->track());
-                                    spanner->setParent(initialNote);
-                                    initialNote->add(spanner);
+      SegmentType st = SegmentType::ChordRest;
+      for (Segment* s = m->first(st); s; s = s->next1(st)) {
+            for (int i = 0; i < tracks; ++i) {
+                  Element* e = s->element(i);
+                  if (e == 0 || !e->isChord())
+                        continue;
+                  Chord* c = toChord(e);
+                  for (Note* n : c->notes()) {
+                        // connect a tie without end note
+                        Tie* tie = n->tieFor();
+                        if (tie && !tie->endNote()) {
+                              Note* nnote;
+                              if (_mscVersion <= 114)
+                                    nnote = searchTieNote114(n);
+                              else
+                                    nnote = searchTieNote(n);
+                              if (nnote == 0) {
+                                    if (!silent) {
+                                          qDebug("next note at %d track %d for tie not found (version %d)", s->tick().ticks(), i, _mscVersion);
+                                          delete tie;
+                                          n->setTieFor(0);
+                                          }
                                     }
                               else {
+                                    tie->setEndNote(nnote);
+                                    nnote->setTieBack(tie);
+                                    }
+                              }
+                        // connect a glissando without initial note (old glissando format)
+                        for (Spanner* spanner : n->spannerBack()) {
+                              if (spanner->isGlissando() && !spanner->startElement()) {
+                                    Note* initialNote = Glissando::guessInitialNote(n->chord());
+                                    n->removeSpannerBack(spanner);
+                                    if (initialNote) {
+                                          spanner->setStartElement(initialNote);
+                                          spanner->setEndElement(n);
+                                          spanner->setTick(initialNote->chord()->tick());
+                                          spanner->setTick2(n->chord()->tick());
+                                          spanner->setTrack(n->track());
+                                          spanner->setTrack2(n->track());
+                                          spanner->setParent(initialNote);
+                                          initialNote->add(spanner);
+                                          }
+                                    else {
+                                          delete spanner;
+                                          }
+                                    }
+                              }
+                        // spanner with no end element can happen during copy/paste
+                        for (Spanner* spanner : n->spannerFor()) {
+                              if (spanner->endElement() == nullptr) {
+                                    n->removeSpannerFor(spanner);
                                     delete spanner;
                                     }
                               }
                         }
-
-                  // spanner with no end element can happen during copy/paste
-                  for (Spanner* spanner : n->spannerFor()) {
-                        if (spanner->endElement() == nullptr) {
-                              n->removeSpannerFor(spanner);
-                              delete spanner;
+#if 0    // chords are set in tremolo->layout()
+                  // connect two note tremolos
+                  Tremolo* tremolo = c->tremolo();
+                  if (tremolo && tremolo->twoNotes() && !tremolo->chord2()) {
+                        for (Segment* ls = s->next1(st); ls; ls = ls->next1(st)) {
+                              Element* element = ls->element(i);
+                              if (!element)
+                                    continue;
+                              if (!element->isChord())
+                                    qDebug("cannot connect tremolo");
+                              else {
+                                    Chord* nc = toChord(element);
+                                    nc->setTremolo(tremolo);
+                                    tremolo->setChords(c, nc);
+                                    // cross-measure tremolos are not supported
+                                    // but can accidentally result from copy & paste
+                                    // remove them now
+                                    if (c->measure() != nc->measure())
+                                          c->remove(tremolo);
+                                    }
+                              break;
                               }
                         }
-                  }
-            };
-
-      SegmentType st = SegmentType::ChordRest;
-      for (Segment* s = m->first(st); s; s = s->next1(st)) {
-            for (int track = 0; track < tracks; ++track) {
-                  Element* e = s->element(track);
-                  if (e == 0 || !e->isChord()) {
-                        continue;
-                        }
-                  Chord* c = toChord(e);
-                  connectTiesForChord(c, s, track);
-                  for (Chord* gc : c->graceNotes()) {
-                        connectTiesForChord(gc, s, track);
+#endif
+                  for (Chord* gc : qAsConst(c->graceNotes())) {
                         for (Note* n : gc->notes()) {
                               // spanner with no end element apparently happens when reading some 206 files
                               // (and possibly in other situations too)
                               for (Spanner* spanner : n->spannerFor()) {
-                                    if (spanner->endElement() == nullptr) {
-                                          n->removeSpannerFor(spanner);
-                                          delete spanner;
-                                          }
+                                   if (spanner->endElement() == nullptr) {
+                                         n->removeSpannerFor(spanner);
+                                         delete spanner;
+                                         }
                                     }
                               }
                         }

--- a/libmscore/mscore.cpp
+++ b/libmscore/mscore.cpp
@@ -128,6 +128,8 @@ bool    MScore::retainAugmentationInRhythmEntry;
 
 bool    MScore::fingerTextAutoForwardAlphaNumeric;
 
+bool    MScore::noteEntryAutoSwitchModes;
+
 bool    MScore::disableVerticalMouseDragOfNotes;
 bool    MScore::lassoWithoutShift;
 bool    MScore::lassoAnnotations;

--- a/libmscore/mscore.h
+++ b/libmscore/mscore.h
@@ -388,6 +388,8 @@ class MScore {
       static bool noteInputForceVoice2BeneathVoice1;
       static bool retainAugmentationInRhythmEntry;
 
+      static bool noteEntryAutoSwitchModes;
+
       static bool fingerTextAutoForwardAlphaNumeric;
 
       static bool disableVerticalMouseDragOfNotes;

--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -2720,12 +2720,14 @@ void Note::verticalDrag(EditData &ed)
             int newTpc1 = pitch2tpc(newPitch, key, Prefer::NEAREST);
             int newTpc2 = pitch2tpc(newPitch - transposition(), key, Prefer::NEAREST);
             for (Note* nn : tiedNotes()) {
-                  nn->setAccidentalType(AccidentalType::NONE);
                   nn->setPitch(newPitch, newTpc1, newTpc2);
                   nn->triggerLayout();
+                  for (ScoreElement* se : nn->linkList()) {
+                        Note* ln = toNote(se);
+                        ln->setPitch(newPitch, newTpc1, newTpc2);
+                        }
                   }
             }
-      score()->inputState().setAccidentalType(AccidentalType::NONE);
       }
 
 //---------------------------------------------------------

--- a/libmscore/noteentry.cpp
+++ b/libmscore/noteentry.cpp
@@ -689,8 +689,9 @@ void Score::repitchNote(const Position& p, bool replace)
             tie->setTick2(tie->endNote()->tick());
             tie->setTrack(note->track());
             undoAddElement(tie);
+            firstTiedNote = note;
             }
-      select(lastTiedNote);
+      select(firstTiedNote ? firstTiedNote : lastTiedNote);
       // move to next Chord
       ChordRest* next = nextChordRest(lastTiedNote->chord());
       while (next && !next->isChord())

--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -1445,6 +1445,7 @@ void Score::addElement(Element* element)
       bool skipLayout = false;
 
       if (element->isBarLine()) {
+            // Testing: may be a time-saver to skip this in large scores
             skipLayout = true;
             }
       if (element->isSegment()) {

--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -3131,6 +3131,13 @@ void Score::addAudioTrack()
 
 void Score::padToggle(Pad p, const EditData& ed)
       {
+      const bool repitchMode = usingNoteEntryMethod(NoteEntryMethod::REPITCH);
+      if (MScore::noteEntryAutoSwitchModes) {
+            if (repitchMode) {
+                  _is.setNoteEntryMethod(NoteEntryMethod::RHYTHM);
+                  }
+            }
+
       int oldDots = _is.duration().dots();
       switch (p) {
             case Pad::NOTE00:

--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -1894,12 +1894,12 @@ void Score::scanElementsInRange(void* data, void (*func)(void*, Element*), bool 
                         mmr->scanElements(data, func, all);
                   }
             }
-      for (Element* e : _selection.elements()) {
-            if (e->isSpanner()) {
-                  Spanner* spanner = toSpanner(e);
-                  for (SpannerSegment* ss : spanner->spannerSegments()) {
-                        ss->scanElements(data, func, all);
-                        }
+      for (const Element* e : _selection.elements()) {
+            if (!e->isSpannerSegment())
+                  continue;
+            Spanner* spanner = toSpannerSegment(e)->spanner();
+            for (SpannerSegment* ss : spanner->spannerSegments()) {
+                  ss->scanElements(data, func, all);
                   }
             }
       }

--- a/libmscore/undo.cpp
+++ b/libmscore/undo.cpp
@@ -1937,6 +1937,27 @@ void InsertRemoveMeasures::removeMeasures()
       Fraction tick1 = fm->tick();
       Fraction tick2 = lm->endTick();
 
+      if (fm->isMeasure() && lm->isMeasure()) {
+            // remove beams from chordrests in affected area, they will be rebuilt later but we need
+            // to avoid situations where notes from deleted measures remain in beams
+            // when undoing, we need to check the previous measure as well as there could be notes in there
+            // that need to have their beams recalculated (esp. when adding time signature)
+            MeasureBase* prev = fm->prev();
+            Segment* first = toMeasure(prev && prev->isMeasure() ? prev : fm)->first();
+            for (Segment* s = first; s && s != toMeasure(lm)->last(); s = s->next1()) {
+                  if (!s)
+                        break;
+                  if (!s->isChordRestType())
+                        continue;
+
+                  for (int track = 0; track < score->ntracks(); ++track) {
+                        Element* e = s->element(track);
+                        if (e && e->isChordRest())
+                              toChordRest(e)->removeDeleteBeam(false);
+                        }
+                  }
+            }
+
       QList<System*> systemList;
       for (MeasureBase* mb = lm;; mb = mb->prev()) {
             System* system = mb->system();
@@ -1949,10 +1970,54 @@ void InsertRemoveMeasures::removeMeasures()
             if (mb == fm)
                   break;
             }
+
+      // move subsequent StaffTypeChanges
+      #if 0 // unimplemented
+      if (moveStc) {
+            for (Staff* staff : score->staves()) {
+                  Fraction tickStart = tick1;
+                  Fraction tickEnd = tick2;
+
+                  // loop trhu, until the last one
+                  auto stRange = staff->staffTypeRange(tickEnd);
+                  int moveTick = stRange.first == tickEnd.ticks() ? stRange.first : stRange.second;
+
+                  while (moveTick != -1) {
+                        Fraction tick = Fraction::fromTicks(moveTick);
+                        Fraction newTick = tick + tickStart - tickEnd;
+
+                        Measure* measure = score->tick2measure(tick);
+                        bool stIcon = false;
+
+                        staff->moveStaffType(tick, newTick);
+
+                        for (EngravingItem* el : measure->el()) {
+                              if (el && el->isStaffTypeChange() && el->track() == staff->idx() * VOICES) {
+                                    StaffTypeChange* stc = toStaffTypeChange(el);
+                                    stc->setStaffType(staff->staffType(newTick), false);
+                                    stIcon = true;
+                                    break;
+                                    }
+                              }
+
+                        if (!stIcon) {
+                              LOG_UNDO() << "StaffTypeChange icon is missing in measure " << measure->no();
+                              }
+
+                        stRange = staff->staffTypeRange(tick);
+                        moveTick = stRange.second;
+                        }
+                  }
+            }
+      #endif
+
       score->measures()->remove(fm, lm);
 
-      score->fixTicks();
       if (fm->isMeasure()) {
+            #if 0 // unimplemented
+            score->setUpTempoMap();
+            score->rebuildTempoAndTimeSigMaps(fm); // alternative?
+            #endif
             score->setPlaylistDirty();
 
             // check if there is a clef at the end of last measure
@@ -1973,19 +2038,19 @@ void InsertRemoveMeasures::removeMeasures()
             // remember clefs at the end of previous measure
             const auto clefs = getCourtesyClefs(toMeasure(fm));
 
-            if (score->firstMeasure())
-                  score->insertTime(tick1, -(tick2 - tick1));
+            score->insertTime(tick1, -(tick2 - tick1));
 
             // Restore clefs that were backed up. Events for them could be lost
             // as a result of the recent insertTime() call.
             for (Clef* clef : clefs)
                   clef->staff()->setClef(clef);
 
-            for (Spanner* sp : score->unmanagedSpanners()) {
-                  if ((sp->tick() >= tick1 && sp->tick() < tick2) || (sp->tick2() >= tick1 && sp->tick2() < tick2))
+            std::set<Spanner*> spannersCopy = score->unmanagedSpanners();
+            for (Spanner* sp : spannersCopy) {
+                  if ((sp->tick() >= tick1 && sp->tick() < tick2) || (sp->tick2() >= tick1 && sp->tick2() < tick2)) {
                         sp->removeUnmanaged();
+                        }
                   }
-            score->connectTies(true);   // ??
             }
 
       // remove empty systems

--- a/libmscore/undo.cpp
+++ b/libmscore/undo.cpp
@@ -1937,27 +1937,6 @@ void InsertRemoveMeasures::removeMeasures()
       Fraction tick1 = fm->tick();
       Fraction tick2 = lm->endTick();
 
-      if (fm->isMeasure() && lm->isMeasure()) {
-            // remove beams from chordrests in affected area, they will be rebuilt later but we need
-            // to avoid situations where notes from deleted measures remain in beams
-            // when undoing, we need to check the previous measure as well as there could be notes in there
-            // that need to have their beams recalculated (esp. when adding time signature)
-            MeasureBase* prev = fm->prev();
-            Segment* first = toMeasure(prev && prev->isMeasure() ? prev : fm)->first();
-            for (Segment* s = first; s && s != toMeasure(lm)->last(); s = s->next1()) {
-                  if (!s)
-                        break;
-                  if (!s->isChordRestType())
-                        continue;
-
-                  for (int track = 0; track < score->ntracks(); ++track) {
-                        Element* e = s->element(track);
-                        if (e && e->isChordRest())
-                              toChordRest(e)->removeDeleteBeam(false);
-                        }
-                  }
-            }
-
       QList<System*> systemList;
       for (MeasureBase* mb = lm;; mb = mb->prev()) {
             System* system = mb->system();
@@ -1970,54 +1949,10 @@ void InsertRemoveMeasures::removeMeasures()
             if (mb == fm)
                   break;
             }
-
-      // move subsequent StaffTypeChanges
-      #if 0 // unimplemented
-      if (moveStc) {
-            for (Staff* staff : score->staves()) {
-                  Fraction tickStart = tick1;
-                  Fraction tickEnd = tick2;
-
-                  // loop trhu, until the last one
-                  auto stRange = staff->staffTypeRange(tickEnd);
-                  int moveTick = stRange.first == tickEnd.ticks() ? stRange.first : stRange.second;
-
-                  while (moveTick != -1) {
-                        Fraction tick = Fraction::fromTicks(moveTick);
-                        Fraction newTick = tick + tickStart - tickEnd;
-
-                        Measure* measure = score->tick2measure(tick);
-                        bool stIcon = false;
-
-                        staff->moveStaffType(tick, newTick);
-
-                        for (EngravingItem* el : measure->el()) {
-                              if (el && el->isStaffTypeChange() && el->track() == staff->idx() * VOICES) {
-                                    StaffTypeChange* stc = toStaffTypeChange(el);
-                                    stc->setStaffType(staff->staffType(newTick), false);
-                                    stIcon = true;
-                                    break;
-                                    }
-                              }
-
-                        if (!stIcon) {
-                              LOG_UNDO() << "StaffTypeChange icon is missing in measure " << measure->no();
-                              }
-
-                        stRange = staff->staffTypeRange(tick);
-                        moveTick = stRange.second;
-                        }
-                  }
-            }
-      #endif
-
       score->measures()->remove(fm, lm);
 
+      score->fixTicks();
       if (fm->isMeasure()) {
-            #if 0 // unimplemented
-            score->setUpTempoMap();
-            score->rebuildTempoAndTimeSigMaps(fm); // alternative?
-            #endif
             score->setPlaylistDirty();
 
             // check if there is a clef at the end of last measure
@@ -2038,19 +1973,19 @@ void InsertRemoveMeasures::removeMeasures()
             // remember clefs at the end of previous measure
             const auto clefs = getCourtesyClefs(toMeasure(fm));
 
-            score->insertTime(tick1, -(tick2 - tick1));
+            if (score->firstMeasure())
+                  score->insertTime(tick1, -(tick2 - tick1));
 
             // Restore clefs that were backed up. Events for them could be lost
             // as a result of the recent insertTime() call.
             for (Clef* clef : clefs)
                   clef->staff()->setClef(clef);
 
-            std::set<Spanner*> spannersCopy = score->unmanagedSpanners();
-            for (Spanner* sp : spannersCopy) {
-                  if ((sp->tick() >= tick1 && sp->tick() < tick2) || (sp->tick2() >= tick1 && sp->tick2() < tick2)) {
+            for (Spanner* sp : score->unmanagedSpanners()) {
+                  if ((sp->tick() >= tick1 && sp->tick() < tick2) || (sp->tick2() >= tick1 && sp->tick2() < tick2))
                         sp->removeUnmanaged();
-                        }
                   }
+            score->connectTies(true);   // ??
             }
 
       // remove empty systems

--- a/libmscore/undo.cpp
+++ b/libmscore/undo.cpp
@@ -1985,7 +1985,6 @@ void InsertRemoveMeasures::removeMeasures()
                   if ((sp->tick() >= tick1 && sp->tick() < tick2) || (sp->tick2() >= tick1 && sp->tick2() < tick2))
                         sp->removeUnmanaged();
                   }
-            score->connectTies(true);   // ??
             }
 
       // remove empty systems

--- a/mscore/events.cpp
+++ b/mscore/events.cpp
@@ -682,9 +682,10 @@ void ScoreView::mousePressEvent(QMouseEvent* ev)
                                     else changeState(ViewState::NORMAL);
                                     //adjustCanvasPosition(el, true);
                                     }
-                              else if (auto m = toStaffLines(el)->measure()) {
-                                    if (auto f = m->first()) {
-                                          if (auto cr = f->nextChordRest(el->track())) {
+                              else if (auto sl = toStaffLines(el)) {
+                                    if (auto m = sl->measure()) {
+                                          int firstTrack = staff2track(sl->staffIdx());
+                                          if (auto cr = m->findChordRest(m->tick(), firstTrack)) {
                                                 if (!shift) {
                                                       _score->deselectAll();
                                                       _score->select(m, SelectType::RANGE, cr->staffIdx());
@@ -693,6 +694,7 @@ void ScoreView::mousePressEvent(QMouseEvent* ev)
                                                       }
                                                 else _score->select(cr, SelectType::RANGE);
 
+                                                _score->inputState().setTrack(firstTrack);
                                                 _score->inputState().moveInputPos(cr);
                                                 }
                                           }

--- a/mscore/keyb.cpp
+++ b/mscore/keyb.cpp
@@ -68,8 +68,7 @@ void MuseScore::updateInputState(Score* score)
       {
       InputState& is = score->inputState();
       if (is.noteEntryMode()) {
-            bool repitching = is.usingNoteEntryMethod(NoteEntryMethod::REPITCH) ||
-                              (is.usingNoteEntryMethod(NoteEntryMethod::RHYTHM) && MScore::noteEntryAutoSwitchModes);
+            bool repitching = is.usingNoteEntryMethod(NoteEntryMethod::REPITCH);
             if (repitching) {
                   TDuration d = is.cr() ? is.cr()->durationType() : TDuration::DurationType::V_QUARTER;
                   if (!d.isValid() || d.isZero() || d.isMeasure())

--- a/mscore/keyb.cpp
+++ b/mscore/keyb.cpp
@@ -68,7 +68,9 @@ void MuseScore::updateInputState(Score* score)
       {
       InputState& is = score->inputState();
       if (is.noteEntryMode()) {
-            if (is.usingNoteEntryMethod(NoteEntryMethod::REPITCH)) {
+            bool repitching = is.usingNoteEntryMethod(NoteEntryMethod::REPITCH) ||
+                              (is.usingNoteEntryMethod(NoteEntryMethod::RHYTHM) && MScore::noteEntryAutoSwitchModes);
+            if (repitching) {
                   TDuration d = is.cr() ? is.cr()->durationType() : TDuration::DurationType::V_QUARTER;
                   if (!d.isValid() || d.isZero() || d.isMeasure())
                         d = TDuration::DurationType::V_QUARTER;

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -540,6 +540,7 @@ void updateExternalValuesFromPreferences() {
       MScore::fingerTextAutoForwardAlphaNumeric = preferences.getBool(PREF_SCORE_FINGERING_ALPHANUMERIC_AUTOFORWARD);
       MScore::noteEntryInformationColor = preferences.getColor(PREF_SCORE_NOTE_INPUT_ENTRY_STATUS_COLOR);
       MScore::noteEntryInformationEnabled = preferences.getBool(PREF_SCORE_NOTE_INPUT_ENTRY_STATUS_ENABLE);
+      MScore::noteEntryAutoSwitchModes = preferences.getBool(PREF_SCORE_NOTE_INPUT_ENTRY_AUTO_SWITCH_MODE);
 
       MScore::defaultPlayDuration = preferences.getInt(PREF_SCORE_NOTE_DEFAULTPLAYDURATION);
       MScore::panPlayback = preferences.getBool(PREF_APP_PLAYBACK_PANPLAYBACK);
@@ -4859,6 +4860,8 @@ void MuseScore::changeState(ScoreState val)
                         cv->cmd("note-input");
                   // fall through
             case STATE_NOTE_ENTRY_STAFF_PITCHED:
+            case STATE_NOTE_ENTRY_METHOD_REPITCH:
+            case STATE_NOTE_ENTRY_METHOD_RHYTHM:
                   if (getAction("note-input-repitch")->isChecked()) {
                         showModeText(tr("Repitch input mode"));
                         cs->setNoteEntryMethod(NoteEntryMethod::REPITCH);

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -1424,6 +1424,15 @@ MuseScore::MuseScore()
       _positionLabel = new QLabel;
       _positionLabel->setObjectName("decoration widget");  // this prevents animations
 
+      _timerLabel = new QLabel;
+      _timerLabel->setObjectName("timerLabel");
+
+      _time.setHMS(0,0,1);
+      _timer = new QTimer(this);
+      connect(_timer, &QTimer::timeout, this, QOverload<>::of(&MuseScore::updateTimer));
+      int perSecond = 1000/*ms*/;
+      _timer->start(perSecond);
+
       _modeText = new QLabel;
       _modeText->setAutoFillBackground(false);
       _modeText->setObjectName("modeLabel");
@@ -1469,6 +1478,7 @@ MuseScore::MuseScore()
                   _statusBar->addPermanentWidget(layerSwitch);
                   }
 
+            _statusBar->addPermanentWidget(_timerLabel, 0);
             _statusBar->addPermanentWidget(_positionLabel, 0);
 
       setStatusBar(_statusBar);
@@ -2469,6 +2479,7 @@ void MuseScore::retranslate()
       {
       setMenuTitles();
       _positionLabel->setToolTip(tr("Measure:Beat:Tick"));
+      _timerLabel->setToolTip(tr("HH:MM:SS Timer"));
       pref->setText(tr("&Preferences…"));
       aboutAction->setText(tr("&About…"));
       aboutQtAction->setText(tr("About &Qt…"));
@@ -4455,6 +4466,17 @@ bool MuseScore::eventFilter(QObject *obj, QEvent *event)
                   globalY = me->globalY();
                   return QMainWindow::eventFilter(obj, event);
                   }
+            case QEvent::MouseButtonPress: {
+                  QMouseEvent* me = static_cast<QMouseEvent*>(event);
+                  // HACK - Would be better to overload QLabel to handle mouse event
+                  if (obj->objectName()=="timerLabel") {
+                        if (me->button() == Qt::LeftButton)
+                              stopStartTime();
+                        if (me->button() == Qt::RightButton)
+                              clearTime();
+                        }
+                  return QMainWindow::eventFilter(obj, event);
+                  }
             case QEvent::StatusTip:
                   return true; // prevent updates to the status bar
             case QEvent::KeyRelease:
@@ -5486,6 +5508,27 @@ void MuseScore::setPos(const Fraction& t)
       }
 
 //---------------------------------------------------------
+//   timer functions
+//---------------------------------------------------------
+
+void MuseScore::stopStartTime()
+      {
+      _timeStopped = !_timeStopped;
+      }
+
+void MuseScore::clearTime()
+      {
+      _time.setHMS(0,0,0);
+      _timerLabel->setText(_time.toString());
+      }
+
+void MuseScore::storeTime()
+      {
+      // TODO: store cumulation of timer into mscz file
+      //
+      }
+
+//---------------------------------------------------------
 //   undoRedo
 //---------------------------------------------------------
 
@@ -5543,6 +5586,16 @@ void MuseScore::handleMessage(const QString& message)
       ((QtSingleApplication*)(qApp))->activateWindow();
       openScore(message);
       }
+
+void MuseScore::updateTimer()
+      {
+      if (!_timeStopped) {
+            _time = _time.addSecs(1);       // +1 second
+            QString str = _time.toString(); // HH:MM:SS
+            _timerLabel->setText(str);
+            }
+      }
+
 
 //---------------------------------------------------------
 //   editInPianoroll

--- a/mscore/musescore.h
+++ b/mscore/musescore.h
@@ -333,6 +333,7 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
       QStatusBar* _statusBar;
       QLabel* _modeText;
       QLabel* _positionLabel;
+      QLabel* _timerLabel;
       NewWizard* newWizard           { 0 };
       HelpBrowser* helpBrowser       { 0 };
       QDockWidget* manualDock        { 0 };
@@ -362,6 +363,10 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
       bool _horizontalSplit              { true  };
 
       QString rev;
+
+      QTime _time;
+      bool _timeStopped                 { false };
+      QTimer* _timer{0};
 
       int _midiRecordId                  { -1 };
 
@@ -616,6 +621,7 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
       void checkForUpdates();
       void startPreferenceDialog();
       void restartAudioEngine();
+      void updateTimer();
 
    public:
       MuseScore();
@@ -631,6 +637,10 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
       void showElementContext(Element* el);
       void cmdAppendMeasures(int);
       bool isMidiInEnabled() const;
+
+      void stopStartTime();
+      void clearTime();
+      void storeTime();
 
       void readSettings();
       void writeSettings();

--- a/mscore/preferences.cpp
+++ b/mscore/preferences.cpp
@@ -241,6 +241,7 @@ void Preferences::init(bool storeInMemoryOnly)
             {PREF_SCORE_FINGERING_ALPHANUMERIC_AUTOFORWARD,        new BoolPreference(false)},
             {PREF_SCORE_NOTE_INPUT_ENTRY_STATUS_COLOR,             new ColorPreference(QColor(255,0,0), true)},
             {PREF_SCORE_NOTE_INPUT_ENTRY_STATUS_ENABLE,            new BoolPreference(false)},
+            {PREF_SCORE_NOTE_INPUT_ENTRY_AUTO_SWITCH_MODE,         new BoolPreference(false)},
             {PREF_UI_SCORE_DISABLE_NOTE_DRAG_VERTICAL,             new BoolPreference(false)},
             {PREF_UI_SCORE_LASSO_WITHOUT_SHIFT,                    new BoolPreference(true)},
             {PREF_UI_SCORE_LASSO_ANNOTATIONS,                      new BoolPreference(true)},

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -4618,8 +4618,16 @@ void ScoreView::startNoteEntry()
             }
       TDuration d(is.duration());
 
-      if (!d.isValid() || d.isZero() || d.type() == TDuration::DurationType::V_MEASURE)
-            is.setDuration(defaultDuration);
+      const bool rhythmMode = is.usingNoteEntryMethod(NoteEntryMethod::RHYTHM);
+      if (MScore::noteEntryAutoSwitchModes && rhythmMode) {
+            if (auto icr = is.cr())
+                  d = icr->durationType();
+            }
+
+      if (!d.isValid() || d.isZero() || d.isMeasure())
+            d = defaultDuration;
+
+      is.setDuration(d);
       is.setAccidentalType(AccidentalType::NONE);
 
       _score->select(el, SelectType::SINGLE, 0);

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -5485,8 +5485,24 @@ void ScoreView::cmdEnterRest()
       InputState& is = _score->inputState();
       if (is.track() == -1 || is.segment() == 0)          // invalid state
             return;
-      if (!is.duration().isValid() || is.duration().isZero() || is.duration().isMeasure())
+
+      bool invalid = false;
+      const bool rhythmMode = _score->usingNoteEntryMethod(NoteEntryMethod::RHYTHM);
+      if (MScore::noteEntryAutoSwitchModes) {
+            if (rhythmMode) {
+                  _score->setNoteEntryMethod(NoteEntryMethod::REPITCH);
+                  if (auto cr = is.cr())
+                        is.setDuration(cr->durationType());
+
+                  invalid = !is.duration().isValid() || is.duration().isZero() || is.duration().isMeasure();
+                  if (invalid)
+                        return;
+                  }
+            }
+
+      if (invalid)
             is.setDuration(TDuration::DurationType::V_QUARTER);
+
       cmdEnterRest(is.duration());
       }
 
@@ -5498,9 +5514,6 @@ void ScoreView::cmdEnterRest(const TDuration& d)
       {
       if (!noteEntryMode())
             cmd("note-input");
-
-      if (MScore::noteEntryAutoSwitchModes && _score->usingNoteEntryMethod(NoteEntryMethod::RHYTHM))
-            _score->setNoteEntryMethod(NoteEntryMethod::REPITCH);
 
       if (_score->usingNoteEntryMethod(NoteEntryMethod::RHYTHM))
             _score->cmd(getAction("pad-rest"), editData);

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -5924,10 +5924,12 @@ void ScoreView::cmdAddPedal(HookType beginHook, HookType endHook)
             activePedal = nullptr;
             }
 
+      bool editElementIsPedalSeg = (editData.element && editData.element->type() == ElementType::PEDAL_SEGMENT);
+      bool selIsPedalSeg = selection.element() && selection.element()->type() == ElementType::PEDAL_SEGMENT;
+      bool havePedal = selIsPedalSeg || editElementIsPedalSeg;
       // Pedal Style Cycling
       // -------------------
-      bool editElementIsPedalSeg = (editData.element && editData.element->type() == ElementType::PEDAL_SEGMENT);
-      if (selection.isSingle() && (selection.element()->isPedalSegment() || editElementIsPedalSeg)) {
+      if (havePedal) {
             auto pseg = editElementIsPedalSeg ? toPedalSegment(editData.element)
                                               : toPedalSegment(selection.element());
             if (!pseg) return;
@@ -5937,9 +5939,13 @@ void ScoreView::cmdAddPedal(HookType beginHook, HookType endHook)
             auto middleGripSelected = editData.curGrip == Grip::MIDDLE;
             auto nothingSelected = !endGripSelected && !startGripSelected && !middleGripSelected;
 
+            if (!activePedal && endGripSelected) {
+                  activePedal = pedal;
+                  }
+
             // [Cycle End Hook] - [If active pedal], will apply additional pedal-line
             // Alt: If mid-grip is active, allow end-style cycling while [active pedal].
-            if ((endGripSelected && !activePedal) || (middleGripSelected && activePedal)) {
+            if (middleGripSelected) {
                   auto height = pedal->endHookHeight();
                   // Cycle through hook types, then change height +/-
                   if (pedal->endHookType() == HookType::HOOK_90)

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -5997,7 +5997,6 @@ void ScoreView::cmdAddPedal(HookType beginHook, HookType endHook)
                pedal->layout();
                mscore->currentScoreView()->updateGrips();
             score()->endCmd();
-            score()->doLayout();
 
             // When altering start-style only, finalize function
             // Or when altering end-style during middle-selection

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -6006,9 +6006,6 @@ void ScoreView::cmdAddPedal(HookType beginHook, HookType endHook)
 
             } // End "style" cycle
 
-      if (!selection.firstChordRest())
-            return;
-
       // Initialize Pedal
       auto newPedal = new Pedal(_score);
 
@@ -6040,6 +6037,7 @@ void ScoreView::cmdAddPedal(HookType beginHook, HookType endHook)
       // Retrieve two chord rests from score selection:
       auto cr1 = selection.firstChordRest();
       auto cr2 = selection.lastChordRest();
+
       if (!cr1 && !activePedal)
             return;
 
@@ -6048,11 +6046,12 @@ void ScoreView::cmdAddPedal(HookType beginHook, HookType endHook)
             onlyOne = true;
             cr2 = cr1;
             }
-      auto startSegment = cr1->segment();
-      auto endSegment   = cr2->segment();
-      auto track        = cr1->track();
-      auto nextSegment  = endSegment->nextCR(track, true);
-      auto staffIdx     = cr1->staffIdx();
+      // Reminder that this whole set of code could be redone:
+      auto startSegment = cr1 ? cr1->segment() : nullptr;
+      auto endSegment   = cr2 ? cr2->segment() : nullptr;
+      auto track        = cr1 ? cr1->track() : 0;
+      auto nextSegment  = endSegment ? endSegment->nextCR(track, true) : nullptr;
+      auto staffIdx     = cr1 ? cr1->staffIdx() : 0;
 
       if (nextSegment) {
             // Will be jumping to next measure later, so pull back if already ahead of beginning measure:

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -5488,6 +5488,10 @@ void ScoreView::cmdEnterRest(const TDuration& d)
       {
       if (!noteEntryMode())
             cmd("note-input");
+
+      if (MScore::noteEntryAutoSwitchModes && _score->usingNoteEntryMethod(NoteEntryMethod::RHYTHM))
+            _score->setNoteEntryMethod(NoteEntryMethod::REPITCH);
+
       if (_score->usingNoteEntryMethod(NoteEntryMethod::RHYTHM))
             _score->cmd(getAction("pad-rest"), editData);
       else

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -3794,6 +3794,8 @@ void ScoreView::cmd(const char* s)
                   }},
             {{"tie"}, [](ScoreView* cv, const QByteArray&) {
                   if (cv->noteEntryMode()) {
+                        if (MScore::noteEntryAutoSwitchModes && cv->score()->usingNoteEntryMethod(NoteEntryMethod::RHYTHM))
+                              cv->score()->setNoteEntryMethod(NoteEntryMethod::REPITCH);
                         cv->score()->cmdAddTie();
                         cv->moveCursor();
                         }

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -1996,6 +1996,8 @@ void ScoreView::paint(const QRect& r, QPainter& p)
             p.fillRect(dropRectangle, QColor(80, 0, 0, 80));
 
       const Selection& sel = _score->selection();
+
+      // RANGE SELECTION
       if (sel.isRange()) {
             Segment* ss = sel.startSegment();
             Segment* es = sel.endSegment();
@@ -2026,8 +2028,10 @@ void ScoreView::paint(const QRect& r, QPainter& p)
             p.setBrush(Qt::NoBrush);
 
             QPen pen;
-            pen.setColor(MScore::selectColor[0]);
-            pen.setWidthF(2.0 / p.worldTransform().m11());
+            QColor rangeColor = MScore::lassoColor; // MScore::selectColor[0];
+            qreal rangeWidth = 5.0; // 2.0
+            pen.setColor(rangeColor);
+            pen.setWidthF(rangeWidth / p.worldTransform().m11());
 
             pen.setStyle(Qt::SolidLine);
 

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -6839,7 +6839,9 @@ void ScoreView::cmdTuplet(int n)
                               : _score->inputState().cr();
 
             if (cr) {
-                  _score->changeCRlen(cr, _score->inputState().duration());
+                  InputState& is = _score->inputState();
+                  const auto duration = rhythmEntry ? cr->durationType() : is.duration();
+                  _score->changeCRlen(cr, duration);
                   cmdTuplet(n, cr);
                   }
             }

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -3020,6 +3020,10 @@ void ScoreView::cmd(const char* s)
                   el = score.moveAlt(el, dir);
                   cv->cmdGotoElement(el);
                   }
+            if (score.noteEntryMode()) {
+                  auto& is = score.inputState();
+                  is.moveToNextInputPos();
+                  }
             };
 
       static const std::vector<ScoreViewCmd> cmdList {

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -2970,10 +2970,13 @@ void ScoreView::cmd(const char* s)
             auto& selection = score.selection();
             auto el = selection.element();
             auto oel = el;
-            bool isRange = selection.isRange();
+            const bool isRange = selection.isRange();
+            bool cursorHasSamePosition = false;
             std::vector<Element*> notes;
 
             if (el && (el->isNote() || el->isRest())) {
+                  if (score.inputState().tick() == el->tick())
+                        cursorHasSamePosition = true;
                   cv->cmdGotoElement(score.moveAlt(el, dir));
                   }
             else for (auto e : selection.elements()) {
@@ -3020,7 +3023,7 @@ void ScoreView::cmd(const char* s)
                   el = score.moveAlt(el, dir);
                   cv->cmdGotoElement(el);
                   }
-            if (score.noteEntryMode()) {
+            if (score.noteEntryMode() && !cursorHasSamePosition) {
                   auto& is = score.inputState();
                   is.moveToNextInputPos();
                   }

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -6708,6 +6708,7 @@ void ScoreView::cmdCreateTuplet(ChordRest* cr, Tuplet* tuplet)
 
 void ScoreView::changeVoice(int voice)
       {
+      ///
       InputState* is = &score()->inputState();
       bool isRange = score()->selection().isRange();
       int track = (is->track() / VOICES) * VOICES + voice;
@@ -6771,6 +6772,20 @@ void ScoreView::changeVoice(int voice)
                         is->setTrack(track);
                         break;
                         }
+            }
+
+      if (MScore::noteEntryAutoSwitchModes) {
+            const bool rhythmMode = is->usingNoteEntryMethod(NoteEntryMethod::RHYTHM);
+            if (!rhythmMode)
+                  return;
+
+            // Duration mustn't linger with auto switching
+            TDuration defaultDuration = TDuration::DurationType::V_QUARTER;
+            TDuration d = is->cr() ? is->cr()->durationType() : defaultDuration;
+            if (!d.isValid() || d.isZero() || d.isMeasure()) {
+                  d = defaultDuration;
+                  }
+            is->setDuration(d);
             }
       }
 

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -7423,6 +7423,9 @@ void ScoreView::cmdRepeatSelection(bool silent)
       if (MScore::noteEntryAutoSwitchModes && rhythm) {
             _score->setNoteEntryMethod(NoteEntryMethod::REPITCH);
             repitch = true;
+            bool invalid = !is.duration().isValid() || is.duration().isZero() || is.duration().isMeasure();
+            if (invalid)
+                  return;
             }
 
       if (noteEntryMode() && selection.isSingle()) {

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -3501,14 +3501,27 @@ void ScoreView::cmd(const char* s)
                                     }
                               }
 
-                        // Active slur will de-activate if move command is larger than per-chord:
-                        if (score->noteEntryMode() && cmd != "next-chord" && cmd != "prev-chord") {
-                              if (auto slur = score->inputState().slur()) {
-                                    auto& ss = slur->spannerSegments();
-                                    if (!ss.empty())
-                                          ss.front()->setSelected(false);
-                                    
-                                    score->inputState().setSlur(nullptr);
+                        if (score->noteEntryMode()) {
+                              auto& is = score->inputState();
+                              bool repitching = is.usingNoteEntryMethod(NoteEntryMethod::RHYTHM) && MScore::noteEntryAutoSwitchModes;
+                              if (repitching) {
+                                    // Combined Rhythm+Repitch needs duration state to be not lingering from a
+                                    // non note-entry selection
+                                    TDuration d = is.cr() ? is.cr()->durationType() : TDuration::DurationType::V_QUARTER;
+                                    if (!d.isValid() || d.isZero() || d.isMeasure())
+                                          d = TDuration::DurationType::V_QUARTER;
+                                    is.setDuration(d);
+                                    }
+
+                              if (auto slur = is.slur()) {
+                                    // Active slur will de-activate if move command is larger than per-chord:
+                                    if (cmd != "next-chord" && cmd != "prev-chord") {
+                                          auto& ss = slur->spannerSegments();
+                                          if (!ss.empty())
+                                                ss.front()->setSelected(false);
+
+                                          is.setSlur(nullptr);
+                                          }
                                     }
                               }
                         if (ele)
@@ -3797,10 +3810,39 @@ void ScoreView::cmd(const char* s)
                   }},
             {{"tie"}, [](ScoreView* cv, const QByteArray&) {
                   if (cv->noteEntryMode()) {
-                        if (MScore::noteEntryAutoSwitchModes && cv->score()->usingNoteEntryMethod(NoteEntryMethod::RHYTHM))
+                        auto& is = cv->score()->inputState();
+                        const bool rhythmMode = is.usingNoteEntryMethod(NoteEntryMethod::RHYTHM);
+
+                        if (MScore::noteEntryAutoSwitchModes && rhythmMode) {
                               cv->score()->setNoteEntryMethod(NoteEntryMethod::REPITCH);
+                              }
+
+                        // Switch to step-time temporarily if no immediate note to tie to:
+                        bool farOut = false;
+                        auto se = cv->score()->selection().element();
+                        if (rhythmMode && se && se->isNote()) {
+                              const auto note = toNote(se);
+                              const auto chord = note->chord();
+                              const auto nnote = searchTieNote(note);
+                              if (!nnote) {
+                                    if (auto nseg = chord->segment()->next1(SegmentType::ChordRest)) {
+                                          auto e = nseg->element(chord->track());
+                                          if (!e || !e->isChord()) {
+                                                farOut = true;
+                                                }
+                                          }
+                                    }
+
+                              if (farOut && MScore::noteEntryAutoSwitchModes && rhythmMode) {
+                                    is.setNoteEntryMethod(NoteEntryMethod::STEPTIME);
+                                    }
+                              }
+
                         cv->score()->cmdAddTie();
                         cv->moveCursor();
+                        if (farOut) {
+                              is.setNoteEntryMethod(NoteEntryMethod::RHYTHM);
+                              }
                         }
                   else
                         cv->score()->cmdToggleTie();
@@ -7426,6 +7468,7 @@ MeasureBase* ScoreView::checkSelectionStateForInsertMeasure()
 void ScoreView::cmdRepeatSelection(bool silent)
       {
       const Selection& selection = _score->selection();
+      auto scr = selection.cr();
       bool resetToRepitch = false;
       bool isRange = selection.isRange();
       auto& is = _score->inputState();
@@ -7433,16 +7476,20 @@ void ScoreView::cmdRepeatSelection(bool silent)
       const bool stepTime = _score->usingNoteEntryMethod(NoteEntryMethod::STEPTIME);
       const bool rhythm = _score->usingNoteEntryMethod(NoteEntryMethod::RHYTHM);
       bool repitch = _score->usingNoteEntryMethod(NoteEntryMethod::REPITCH);
+      bool invalid = false;
 
-      if (!stepTime && iCR)
-            is.setDuration(iCR->durationType());
+      if (!stepTime) {
+            if (iCR) {
+                  is.setDuration(iCR->durationType());
+                  }
+            else if (scr) {
+                  is.setDuration(scr->durationType());
+                  }
+            }
 
       if (MScore::noteEntryAutoSwitchModes && rhythm) {
             _score->setNoteEntryMethod(NoteEntryMethod::REPITCH);
             repitch = true;
-            bool invalid = !is.duration().isValid() || is.duration().isZero() || is.duration().isMeasure();
-            if (invalid)
-                  return;
             }
 
       if (noteEntryMode() && selection.isSingle()) {
@@ -7450,6 +7497,8 @@ void ScoreView::cmdRepeatSelection(bool silent)
                   resetToRepitch = true;
                   _score->setNoteEntryMethod(NoteEntryMethod::STEPTIME);
                   }
+
+            invalid = !is.duration().isValid() || is.duration().isZero() || is.duration().isMeasure();
 
             if (auto el = selection.element()) {
                   bool isRest = el->type() == ElementType::REST;
@@ -7467,8 +7516,15 @@ void ScoreView::cmdRepeatSelection(bool silent)
                   if (usePrevChord) {
                         prevCR = prevChordRest(prevCR);
                         while (el) {
-                              if (!prevCR || prevCR == prevChordRest(prevCR))
-                                    return;
+                              if (!prevCR) {
+                                    el = prevCR = iCR;
+                                    break;
+                                    }
+
+                              if (prevCR == prevChordRest(prevCR)) {
+                                    el = prevCR;
+                                    break;
+                                    }
 
                               if (!prevCR->isRest()) {
                                     el = prevCR;
@@ -7477,6 +7533,17 @@ void ScoreView::cmdRepeatSelection(bool silent)
 
                               prevCR = prevChordRest(prevCR);
                               }
+                        }
+
+                  if (invalid) {
+                        if (usePrevChord) {
+                              is.setDuration(prevCR->durationType());
+                              }
+                        else if (scr) {
+                              is.setDuration(scr->durationType());
+                              }
+                        else
+                              return;
                         }
 
                   _score->startCmd();

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -7396,9 +7396,22 @@ void ScoreView::cmdRepeatSelection(bool silent)
       const Selection& selection = _score->selection();
       bool resetToRepitch = false;
       bool isRange = selection.isRange();
-      auto iCR = _score->inputState().cr();
+      auto& is = _score->inputState();
+      auto iCR = is.cr();
+      const bool stepTime = _score->usingNoteEntryMethod(NoteEntryMethod::STEPTIME);
+      const bool rhythm = _score->usingNoteEntryMethod(NoteEntryMethod::RHYTHM);
+      bool repitch = _score->usingNoteEntryMethod(NoteEntryMethod::REPITCH);
+
+      if (!stepTime && iCR)
+            is.setDuration(iCR->durationType());
+
+      if (MScore::noteEntryAutoSwitchModes && rhythm) {
+            _score->setNoteEntryMethod(NoteEntryMethod::REPITCH);
+            repitch = true;
+            }
+
       if (noteEntryMode() && selection.isSingle()) {
-            if (_score->noteEntryMethod() == NoteEntryMethod::REPITCH) {
+            if (repitch) {
                   resetToRepitch = true;
                   _score->setNoteEntryMethod(NoteEntryMethod::STEPTIME);
                   }
@@ -7411,7 +7424,7 @@ void ScoreView::cmdRepeatSelection(bool silent)
                         return;
 
                   auto startTick = selection.tickStart();
-                  auto inputTick = _score->inputState().tick();
+                  auto inputTick = is.tick();
 
                   bool selectionAndInputAreSamePos = startTick == inputTick;
                   bool usePrevChord = (isRest || (isNote && selectionAndInputAreSamePos));
@@ -7450,12 +7463,12 @@ void ScoreView::cmdRepeatSelection(bool silent)
                         bool end = false;
                         while (nCR && !nCR->isChord()) {
                               if ((nCR = nextChordRest(nCR))) {
-                                    _score->inputState().setSegment(nCR->segment());
+                                    is.setSegment(nCR->segment());
                                     }
                               else end = true;
                               }
                         if (end) {
-                              _score->inputState().setSegment(oCR->segment());
+                              is.setSegment(oCR->segment());
                               }
                         }
                   moveCursor();
@@ -7521,11 +7534,10 @@ void ScoreView::cmdRepeatSelection(bool silent)
             } else qDebug("cmdRepeatSelection: cannot paste: endSegment: %p dStaff %d", endSegment, dStaff);
 
       if (isRange && noteEntryMode()) {
-            auto& _is = _score->inputState();
-            auto track = _is.track();
+            auto track = is.track();
             auto ncr  = selection.endSegment()->nextChordRest(track);
-            _is.moveInputPos(ncr);
-            _is.setTrack(track);
+            is.moveInputPos(ncr);
+            is.setTrack(track);
             }
 
       }

--- a/mscore/shortcut.cpp
+++ b/mscore/shortcut.cpp
@@ -924,7 +924,8 @@ Shortcut Shortcut::_sc[] = {
          QT_TRANSLATE_NOOP("action","Go to higher pitched note in chord"),
          0,
          Icons::Invalid_ICON,
-         Qt::WindowShortcut
+         Qt::WindowShortcut,
+         ShortcutFlags::A_CMD
          },
       {
          MsWidget::SCORE_TAB,

--- a/mscore/textcursor.cpp
+++ b/mscore/textcursor.cpp
@@ -88,6 +88,14 @@ void PositionCursor::paint(QPainter* p)
                   break;
             default:                            // fill the rectangle and add TAB string marks, if required
                   p->fillRect(_rect, color());
+                  if (_sv && _sv->score() && _sv->score()->selection().isRange()) {
+                        // Signify the presence of range selection on Note Entry Cursor:
+                        QColor rangeColor = MScore::lassoColor;
+                        qreal rangeWidth = 5.0 / p->worldTransform().m11();
+                        p->setBrush(Qt::NoBrush);
+                        p->setPen(QPen(rangeColor, rangeWidth, Qt::SolidLine));
+                        p->drawRect(_rect);
+                        }
                   if (s->noteEntryMode()) {
                         int track = s->inputTrack();
                         if (track >= 0) {


### PR DESCRIPTION
Lazy conglomeration of recent commits, but mainly consists of Fixes and two main features:

**New Feature**: Stopwatch at bottom right of program. Sounds kind of cheesy, but you can press one mouse button to stop/start and another for resetting to 00:00:00 (HH:MM:SS). Can be useful to do a test having to do with how long it's taking to put in a particular score or system of music or whatever. I was thinking maybe it'd be interesting to be able to accumulate it and store that data in the score's metadata properties to sum up how long the score took to notate, but haven't thought that out yet.

https://github.com/user-attachments/assets/834db531-6f97-4992-900e-0285ca06dc90


**New Feature**: **_Auto switching between rhythm mode and repitch mode._** For not doing regular Step Time Entry, this is actually really slick feeling not having to deal with going back and forth between the two modes, but there were a lot of "kinks" I had to fix in the process of attempting it. If user chooses "Rhythm Entry" mode and enables an advanced preference: `ui/score/noteEntry/autoSwitchRhythmRepitch`, entry will allow to use duration shortcuts for rhythm entry and pitch shortcuts for repitch entry without needing to switch back and forth. Tying/Repeat/Voice-Switching/Special attention to duration updates needed to be updated to work well for this. It 
probably still has something that will need some updating to fix later, but this will do for now: but I have tested it and at the moment not having any problems.


Other Changes
- **Repitching:** now keeps first note of tied notes selected to easily build from the beginning of that chord
- **Note Entry with Range Selection** will draw a lasso also around the note-entry position. Helps mainly when note-entry is in another system from a range selection to reiterate that there indeed is a range selection still present
- **Delete** will not "bring back" the note entry position to the score-selection but stay where it was so as to help streamline the note-entry process
- **Traverse chord up/down** commands also will not "bring back" the note entry position. User can, while in Note-Entry traverse a chord, delete a note, and continue typing in note entry after that without having to move forward manually.
- **Repeat Command & Tying** is updated to flow well with Repitch mode and Rhythm mode when auto switching. 

**Command: Add Pedal Line** now allows to add a new line and cycle styles even if not active. First node for start, Middle node for ending style, and End node to now attach a new line. Before, user had to have an active pedal line to add a new attach pedal line. (Commit message is wrong saying this for hairpins... being sloppy)

- Deleting a chord will delete its start slur also (MSS4 style)
