### PR TITLE
Crossbeam/chord articulations + fingerings

### DIFF
--- a/libmscore/articulation.cpp
+++ b/libmscore/articulation.cpp
@@ -840,9 +840,13 @@ void Articulation::doAutoplace(bool above)
                   if (above)
                         yd *= -1.0;
 
-                  // Rebasing without checking if offsetChanged() fixes "accumulated skylines" for articulation
-                  if (rebaseMinDistance(md, yd, sp, rebase, above, true))
-                        r.translate(0.0, rebase);
+                  if (offsetChanged() != OffsetChange::NONE) {
+                        // user moved element within the skyline
+                        // we may need to adjust minDistance, yd, and/or offset
+                        //bool inStaff = placeAbove() ? r.bottom() + rebase > 0.0 : r.top() + rebase < staff()->height();
+                        if (rebaseMinDistance(md, yd, sp, rebase, above, true))
+                              r.translate(0.0, rebase);
+                        }
 
                   rypos() += yd;
                   r.translate(QPointF(0.0, yd));

--- a/libmscore/articulation.cpp
+++ b/libmscore/articulation.cpp
@@ -736,6 +736,63 @@ bool Articulation::isOrnament() const
       }
 
 //---------------------------------------------------------
+//   isBasicArticulation
+//---------------------------------------------------------
+
+bool Articulation::isBasicArticulation() const
+      {
+      static const std::set<SymId> articulations {
+            SymId::articAccentAbove, SymId::articAccentBelow,
+            SymId::articStaccatoAbove, SymId::articStaccatoBelow,
+            SymId::articTenutoAbove, SymId::articTenutoBelow,
+            SymId::articMarcatoAbove, SymId::articMarcatoBelow,
+
+            SymId::articAccentStaccatoAbove, SymId::articAccentStaccatoBelow,
+            SymId::articMarcatoStaccatoAbove, SymId::articMarcatoStaccatoBelow,
+            SymId::articMarcatoTenutoAbove, SymId::articMarcatoTenutoBelow,
+            SymId::articTenutoStaccatoAbove, SymId::articTenutoStaccatoBelow,
+            SymId::articTenutoAccentAbove, SymId::articTenutoAccentBelow,
+            SymId::articStaccatissimoAbove, SymId::articStaccatissimoBelow,
+            SymId::articStaccatissimoStrokeAbove, SymId::articStaccatissimoStrokeBelow,
+            SymId::articStaccatissimoWedgeAbove, SymId::articStaccatissimoWedgeBelow,
+            SymId::articStressAbove, SymId::articStressBelow
+            };
+      SymId symId = static_cast<SymId>(subtype());
+      return articulations.find(symId) != articulations.end();
+      }
+
+//---------------------------------------------------------
+//   isOnCrossBeamSide
+//---------------------------------------------------------
+
+bool Articulation::isOnCrossBeamSide() const
+      {
+      ChordRest* cr = chordRest();
+      if (!cr || !cr->isChord())
+            return false;
+      Chord* chord = toChord(cr);
+      return chord->beam() && (chord->beam()->cross() || chord->staffMove() != 0) && (up() == chord->up());
+      }
+
+//---------------------------------------------------------
+//   opticalCenter
+//---------------------------------------------------------
+
+double Articulation::opticalCenter() const
+      {
+      switch (symId()) {
+            case SymId::handbellsMartellatoLift:
+                  return 0.5 * symWidth(SymId::handbellsMartellato);
+            case SymId::handbellsMalletLft:
+                  return 0.5 * symWidth(SymId::handbellsMalletBellOnTable);
+            case SymId::handbellsPluckLift:
+                  return 0.5 * symWidth(SymId::articStaccatoAbove);
+            default:
+                  return 0.5 * bbox().width();
+            }
+      }
+
+//---------------------------------------------------------
 //   accessibleInfo
 //---------------------------------------------------------
 
@@ -749,7 +806,7 @@ QString Articulation::accessibleInfo() const
 //    check for collisions
 //---------------------------------------------------------
 
-void Articulation::doAutoplace()
+void Articulation::doAutoplace(bool above)
       {
       // rebase vertical offset on drag
       qreal rebase = 0.0;
@@ -768,7 +825,6 @@ void Articulation::doAutoplace()
             QRectF r = bbox().translated(chordRest()->pos() + m->pos() + s->pos() + pos());
 
             qreal d;
-            bool above = up(); // (anchor() == ArticulationAnchor::TOP_STAFF || anchor() == ArticulationAnchor::TOP_CHORD);
             SkylineLine sk(!above);
             if (above) {
                   sk.add(r.x(), r.bottom(), r.width());
@@ -783,13 +839,11 @@ void Articulation::doAutoplace()
                   qreal yd = d + md;
                   if (above)
                         yd *= -1.0;
-                  if (offsetChanged() != OffsetChange::NONE) {
-                        // user moved element within the skyline
-                        // we may need to adjust minDistance, yd, and/or offset
-                        //bool inStaff = placeAbove() ? r.bottom() + rebase > 0.0 : r.top() + rebase < staff()->height();
-                        if (rebaseMinDistance(md, yd, sp, rebase, above, true))
-                              r.translate(0.0, rebase);
-                        }
+
+                  // Rebasing without checking if offsetChanged() fixes "accumulated skylines" for articulation
+                  if (rebaseMinDistance(md, yd, sp, rebase, above, true))
+                        r.translate(0.0, rebase);
+
                   rypos() += yd;
                   r.translate(QPointF(0.0, yd));
                   }

--- a/libmscore/articulation.h
+++ b/libmscore/articulation.h
@@ -172,8 +172,12 @@ class Articulation final : public Element {
       bool isMarcato() const;
       bool isLuteFingering() const;
       bool isOrnament() const;
+      bool isBasicArticulation() const;
+      bool isOnCrossBeamSide() const;
 
-      void doAutoplace();
+      double opticalCenter() const;
+
+      void doAutoplace(bool above);
       int vStaffIdx() const override { return chordRest()->vStaffIdx(); }
       };
 

--- a/libmscore/chord.cpp
+++ b/libmscore/chord.cpp
@@ -3173,6 +3173,42 @@ QVector<Chord*> Chord::graceNotesAfter() const
       }
 
 //---------------------------------------------------------
+//   getFingerings
+//    Direction:: dictates either
+//          AUTO : indiscriminate
+//          UP   : placeAbove
+//          DOWN : placeBelow
+//---------------------------------------------------------
+
+std::vector<Fingering*> Chord::getFingerings(Direction dir) const
+      {
+      std::vector<Note*> nn;
+      for (const auto gc : graceNotes()) {
+            for (const auto n : gc->notes()) {
+                  nn.push_back(n);
+                  }
+            }
+      for (auto n : this->notes())
+            nn.push_back(n);
+
+      std::vector<Fingering*> fingerings;
+      const bool either = (dir == Direction::AUTO);
+      for (auto n : nn) {
+            for (auto el : n->el()) {
+                  if (el->isFingering()) {
+                        Fingering* f = toFingering(el);
+                        const bool below = (dir == Direction::DOWN) && f->placeBelow();
+                        const bool above = (dir == Direction::UP) && f->placeAbove();
+                        if (below || above || either) {
+                              fingerings.push_back(f);
+                              }
+                        }
+                  }
+            }
+      return fingerings;
+      }
+
+//---------------------------------------------------------
 //   sortNotes
 //---------------------------------------------------------
 

--- a/libmscore/chord.cpp
+++ b/libmscore/chord.cpp
@@ -10,6 +10,8 @@
 //  the file LICENCE.GPL
 //=============================================================================
 
+#include "global/log.h"
+
 #include "accidental.h"
 #include "arpeggio.h"
 #include "articulation.h"
@@ -3704,128 +3706,188 @@ void Chord::layoutArticulations()
 //    To be finished after laying out slurs
 //---------------------------------------------------------
 
-void Chord::layoutArticulations2()
+void Chord::layoutArticulations2(bool layoutOnCrossBeamSide)
       {
+      auto isFuzzyLessThanOrEqual = [](double a, double b) -> bool {
+            return a < b || qFuzzyCompare(a, b);
+            };
+      auto isFuzzyGreaterThanOrEqual = [](double a, double b) -> bool {
+            return a > b || qFuzzyCompare(a, b);
+            };
+
       for (Chord*& gc : graceNotes())
             gc->layoutArticulations2();
 
       if (_articulations.empty())
             return;
-      qreal _spatium  = spatium();
-      qreal x = centerX();
-      const Note* note = up() ? upNote(true) : downNote(true);
-      qreal overlapMirror = 0.0;
-      if (stem())
-            overlapMirror = stem()->lineWidth();
-      else if (durationType().headType() == NoteHead::Type::HEAD_WHOLE)
-            overlapMirror = styleP(Sid::stemWidth) * this->mag();
-      qreal dx = up() ? overlapMirror : -overlapMirror;
-      // Counter mirror from layoutChords3()
-      if (note->mirror()) {
-            x += dx;
+
+      auto headSideX = centerX();
+      auto stemSideX = headSideX;
+
+      if (stem()) {
+            if (up()) {
+                  stemSideX = downNote()->pos().x() + downNote()->bboxRightPos() - stemSideX;
+                  }
             }
 
-      qreal distance0 = score()->styleP(Sid::propertyDistance);
-      qreal distance2 = score()->styleP(Sid::propertyDistanceStem);
+      auto stacAccentKern = 0.5 * spatium();
+      auto minDist = score()->styleS(Sid::articulationMinDistance).val() * spatium();
+      auto staffDist = score()->styleS(Sid::propertyDistance).val() * spatium();
+      auto stemDist = score()->styleS(Sid::propertyDistanceStem).val() * spatium();
+      auto noteDist = score()->styleS(Sid::propertyDistanceHead).val() * spatium();
 
-      qreal chordTopY = upPos();    // note position of highest note
-      qreal chordBotY = downPos();  // note position of lowest note
+      auto yOffset = staffOffset().y();
 
-      qreal staffTopY = -distance2;
-      qreal staffBotY = staff()->height() + distance2;
+
+      auto chordTopY = upPos() - 0.5 * upNote()->headHeight() + yOffset;       // note position of highest note
+      auto chordBotY = downPos() + 0.5 * upNote()->headHeight() + yOffset;     // note position of lowest note
+
+      auto staffTopY = -staffDist + yOffset;
+      auto staffBotY = staff()->height() + staffDist + yOffset;
 
       // avoid collisions of staff articulations with chord notes:
       // gap between note and staff articulation is distance0 + 0.5 spatium
 
       if (stem()) {
-            qreal y = stem()->pos().y() + pos().y() + stem()->stemLen();
-            if (beam()) {
-                  qreal bw = score()->styleS(Sid::beamWidth).val() * _spatium;
-                  y += up() ? -bw : bw;
+            // Check if there's a hook, because the tip of the hook always extends slightly past the end of the stem
+            // Observation:
+            //   MSS4 has 3 different positions for beams: up/down, and then the "centered" beam
+            //   MS3 has nothing of the sort except by manually draggin a beam to attain UP/DOWN appearance
+            //   TODO: Backport that hopefully
+            //   Because of that, there's going to be miscalculations with this code since it relies on that,
+            //   so user will need to perform manual direction shift ('x' command) of the beam to fix.
+            if (up()) {
+                  double tip = hook()
+                        ? hook()->bbox().translated(hook()->pos()).top()
+                        : stem()->bbox().translated(stem()->pos()).top();
+
+                  chordTopY = tip + yOffset;
                   }
-            if (up())
-                  chordTopY = y;
-            else
-                  chordBotY = y;
+            else {
+                  double tip = hook()
+                        ? hook()->bbox().translated(hook()->pos()).bottom()
+                        : stem()->bbox().translated(stem()->pos()).bottom();
+
+                  chordBotY = tip + yOffset;
+                  }
             }
 
       //
       //    place all articulations with anchor at chord/rest
       //
-      qreal distance1 = score()->styleP(Sid::propertyDistanceHead);
-      chordTopY -= up() ? 0.5 * _spatium : distance1;
-      chordBotY += up() ? distance1 : 0.5 * _spatium;
-      for (Articulation* a : qAsConst(_articulations)) {
+      chordTopY -= up() ? stemDist : noteDist;
+      chordBotY += up() ? noteDist : stemDist;
+      // add space for staccato and tenuto marks which may have been previously laid out
+      for (Articulation* a : articulations()) {
             ArticulationAnchor aa = a->anchor();
-            if (aa != ArticulationAnchor::CHORD && aa != ArticulationAnchor::TOP_CHORD && aa != ArticulationAnchor::BOTTOM_CHORD)
+            if (a->layoutCloseToNote() && a->visible() && aa == ArticulationAnchor::CHORD) {
+                  if (a->up())
+                        chordTopY = a->y() - a->height() - minDist + yOffset;
+                  else
+                        chordBotY = a->y() + a->height() + minDist + yOffset;
+                  }
+            }
+
+      for (Articulation* a : articulations()) {
+            if (layoutOnCrossBeamSide && !a->isOnCrossBeamSide())
+                  continue;
+            if (!a->layoutCloseToNote())
+                  continue;
+            if (a->visible()) {
+                  if (a->up())
+                        chordTopY = a->y() - a->height() - minDist + yOffset;
+                  else
+                        chordBotY = a->y() + a->height() + minDist + yOffset;
+                  }
+            }
+      //
+      //    now place all articulations with staff top or bottom anchor, or chord anchor for artics that don't layout close to note
+      //
+      staffTopY = std::min(staffTopY, chordTopY);
+      staffBotY = std::max(staffBotY, chordBotY);
+      Articulation* stacc = nullptr;
+      for (Articulation* a : articulations()) {
+            double kearnHeight = 0.0;
+            if ((layoutOnCrossBeamSide && !a->isOnCrossBeamSide()) /*|| a->isLaissezVib()*/)
                   continue;
 
-            qreal counter = a->isAccent() ? 0.5 * _spatium : 0.0;
-            if (a->up()) {
-                  if (!a->layoutCloseToNote()) {
-                        a->layout();
-                        chordTopY += counter;
-                        a->setPos(x, chordTopY);
-                        a->doAutoplace();
-                        }
-                  if (a->visible())
-                        chordTopY = a->y() - a->height() - 0.5 * _spatium - counter;
+            if (a->isStaccato())
+                  stacc = a;
+            else if (stacc && a->isAccent() && stacc->up() == a->up()
+                     && (isFuzzyLessThanOrEqual(stacc->pos().y(), 0.0) || isFuzzyGreaterThanOrEqual(stacc->pos().y(), staff()->height()))) {
+                  // obviously, the accent doesn't have a cutout, so this value just artificially moves the stacc
+                  // and accent closer to each other to simulate some kind of kerning. Looks great using all musescore fonts,
+                  // though there is a possibility that a different font which has vertically-asymmetrical accents
+                  // could make this look bad.
+                  // MS3: Omitting for now
+                  kearnHeight = stacAccentKern;
+                  stacc = nullptr;
                   }
-            else {
-                  if (!a->layoutCloseToNote()) {
-                        a->layout();
-                        chordBotY -= counter;
-                        a->setPos(x, chordBotY);
-                        a->doAutoplace();
-                        }
-                  if (a->visible())
-                        chordBotY = a->y() + a->height() + 0.5 * _spatium + counter ;
-                  }
-            }
-      //
-      //    now place all articulations with staff top or bottom anchor
-      //
+            else
+                  stacc = nullptr;
 
-      staffTopY = qMin(staffTopY, chordTopY - distance0 - 0.5 * _spatium);
-      staffBotY = qMax(staffBotY, chordBotY + distance0 + 0.5 * _spatium);
-      for (Articulation* a : qAsConst(_articulations)) {
-            ArticulationAnchor aa = a->anchor();
-            if (aa == ArticulationAnchor::TOP_STAFF || aa == ArticulationAnchor::BOTTOM_STAFF) {
+            if (!a->layoutCloseToNote()) {
                   a->layout();
+                  stemSideX = headSideX; // TODO: stemSideX implementation via ArticulationStemSideAlign
                   if (a->up()) {
-                        a->setPos(x, staffTopY);
+                        a->setPos(!up() || !a->isBasicArticulation() ? headSideX : stemSideX, staffTopY + kearnHeight - yOffset);
                         if (a->visible())
-                              staffTopY -= distance0;
+                              staffTopY = a->y() - a->height() - minDist + yOffset;
                         }
                   else {
-                        a->setPos(x, staffBotY);
+                        a->setPos(up() || !a->isBasicArticulation() ? headSideX : stemSideX, staffBotY - kearnHeight - yOffset);
                         if (a->visible())
-                              staffBotY += distance0;
+                              staffBotY = a->y() + a->height() + minDist + yOffset;
                         }
-                  a->doAutoplace();
+                  }
+
+            // Conforms to eda47665ee ("Include Articulations and Fermatas in horizontal spacing calculations", 2025-05-12):
+            if (!a->isOnCrossBeamSide()) {
+                  if (a->layoutCloseToNote()) {
+                        if (auto sys = a->measure()->system()) {
+                              auto point   = a->systemPos() + staffOffset();
+                              auto staff   = sys->staff(a->vStaffIdx());
+                              auto skyline = staff->skyline();
+                              auto shape   = a->shape().translated(point);
+
+                              skyline.add(shape);
+                              }
+                        }
+                  else {
+                        a->doAutoplace(a->up());
+                        }
+
+                  if (a->addToSkyline()) {
+                        auto staff  = a->vStaffIdx();
+                        auto point  = a->pos() + pos() + staffOffset();
+                        auto shape  = a->shape().translated(point);
+                        a->segment()->staffShape(staff).add(shape);
+                        }
                   }
             }
-      for (Articulation* a : qAsConst(_articulations)) {
-            if (a->addToSkyline()) {
+
+      for (Articulation* a : articulations()) {
+            if (a->addToSkyline() && !a->isOnCrossBeamSide()) {
                   // the segment shape has already been calculated
                   // so measure width and spacing is already determined
                   // in line mode, we cannot add to segment shape without throwing this off
                   // but adding to skyline is always good
                   Segment* s = segment();
                   Measure* m = s->measure();
-                  QRectF r = a->bbox().translated(a->pos() + pos());
+                  Shape sh = a->shape().translated(a->pos() + pos());
                   // TODO: limit to width of chord
                   // this avoids "staircase" effect due to space not having been allocated already
                   // ANOTHER alternative is to allocate the space in layoutPitched() / layoutTablature()
-                  //qreal w = qMin(r.width(), width());
+                  //double w = std::min(r.width(), width());
                   //r.translate((r.width() - w) * 0.5, 0.0);
                   //r.setWidth(w);
-                  if (!score()->lineMode())
-                        s->staffShape(staffIdx()).add(r);
-                  r.translate(s->pos() + m->pos());
-                  m->system()->staff(vStaffIdx())->skyline().add(r);
+                  if (score()->lineMode())
+                        s->staffShape(staffIdx()).add(sh);
+                  sh.translate(s->pos() + m->pos());
+                  m->system()->staff(vStaffIdx())->skyline().add(sh);
                   }
             }
+
       }
 
 //---------------------------------------------------------

--- a/libmscore/chord.cpp
+++ b/libmscore/chord.cpp
@@ -3903,7 +3903,10 @@ void Chord::layoutArticulations2(bool layoutOnCrossBeamSide)
             }
 
       for (Articulation* a : articulations()) {
-            if (a->addToSkyline() && !a->isOnCrossBeamSide()) {
+            if (a->addToSkyline()) {
+                  // As of 2026.05--MSS4 checks  [&& !a->isOnCrossBeamSide()], but seems to be okay here
+                  // and allows for fingering on beam-side to apply ontop of articulations
+
                   // the segment shape has already been calculated
                   // so measure width and spacing is already determined
                   // in line mode, we cannot add to segment shape without throwing this off

--- a/libmscore/chord.h
+++ b/libmscore/chord.h
@@ -155,6 +155,8 @@ class Chord final : public ChordRest {
       int graceIndex() const                        { return _graceIndex; }
       void setGraceIndex(int val)                   { _graceIndex = val;  }
 
+      std::vector<Fingering*> getFingerings(Direction) const;
+
       int upLine() const override;
       int downLine() const override;
       int upLine(bool omitInvisible) const;

--- a/libmscore/chord.h
+++ b/libmscore/chord.h
@@ -204,7 +204,7 @@ class Chord final : public ChordRest {
       TremoloChordType tremoloChordType() const;
 
       void layoutArticulations();
-      void layoutArticulations2();
+      void layoutArticulations2(bool layoutOnCrossBeamSide = false);
       void layoutArticulations3(Slur* s);
 
       QVector<Articulation*>& articulations()             { return _articulations; }

--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -320,8 +320,26 @@ void Score::update(bool resetCmdState)
             ms->deletePostponed();
             if (!printing()) {
                   if (cs.layoutRange()) {
-                        for (Score*& s : ms->scoreList())
-                              s->doLayoutRange(cs.startTick(), cs.endTick());
+                        for (Score*& s : ms->scoreList()) {
+                              auto layoutStart = cs.startTick();
+                              auto layoutEnd = cs.endTick();
+                              const bool fullPageLayout = true;
+                              if (fullPageLayout) {
+                                    for (auto page : s->pages()) {
+                                          if (page->startTick() > cs.startTick())
+                                                continue;
+                                          layoutStart = page->startTick();
+                                          break;
+                                          }
+                                    for (auto page : s->pages()) {
+                                          if (page->endTick() < cs.endTick())
+                                                continue;
+                                          layoutEnd = page->endTick();
+                                          break;
+                                          }
+                                    }
+                              s->doLayoutRange(layoutStart, layoutEnd);
+                              }
                         updateAll = true;
                         }
                   }

--- a/libmscore/element.cpp
+++ b/libmscore/element.cpp
@@ -15,6 +15,8 @@
  Implementation of Element, ElementList
 */
 
+#include "global/log.h"
+
 #include "accidental.h"
 #include "ambitus.h"
 #include "arpeggio.h"
@@ -385,6 +387,35 @@ Part* Element::part() const
       {
       Staff* s = staff();
       return s ? s->part() : 0;
+      }
+
+//---------------------------------------------------------
+//   staffOffset
+//---------------------------------------------------------
+
+QPointF Element::staffOffset() const
+      {
+      const StaffType* st = staffType();
+      const double yOffset = st ? st->yoffset().val() * spatium() : 0.0;
+      return QPointF{0.0, yOffset};
+      }
+
+//---------------------------------------------------------
+//   systemPos
+//---------------------------------------------------------
+
+QPointF Element::systemPos() const
+      {
+      IF_ASSERT_FAILED(findAncestor(ElementType::SYSTEM))
+            return QPointF{};
+      QPointF result = pos();
+      Element* ancestor = parent();
+      while (ancestor && !ancestor->isSystem()) {
+            result += ancestor->pos();
+            ancestor = ancestor->parent();
+            }
+
+      return result;
       }
 
 //---------------------------------------------------------

--- a/libmscore/element.h
+++ b/libmscore/element.h
@@ -367,6 +367,9 @@ class Element : public ScoreElement {
       bool onTabStaff() const;
       Part* part() const;
 
+      QPointF staffOffset() const;
+      QPointF systemPos() const;
+
       virtual void add(Element*);
       virtual void remove(Element*);
       virtual void change(Element* o, Element* n);

--- a/libmscore/fingering.cpp
+++ b/libmscore/fingering.cpp
@@ -168,12 +168,13 @@ void Fingering::layout()
                               top -= md;
                               qreal diff = (bbox().bottom() + ipos().y() + yd + n->y()) - top;
                               if (diff > 0.0) {
-                                    if (auto beam = chord->beam())
-                                          if (beam->up()) {
+                                    if (auto beam = chord->beam()) {
+                                          if (beam->up() || stem->up()) {
                                                 yd -= diff;
                                                 qreal beamLineProp = 0.33 * point(score()->styleS(Sid::beamWidth)) * chord->chordMag();
                                                 yd += beamLineProp;
                                                 }
+                                          }
                                     }
                               if (offsetChanged() != OffsetChange::NONE) {
                                     // user moved element within the skyline
@@ -210,12 +211,13 @@ void Fingering::layout()
                               bottom += md;
                               qreal diff = bottom - (bbox().top() + ipos().y() + yd + n->y());
                               if (diff > 0.0) {
-                                    if (auto beam = chord->beam())
-                                          if (!beam->up()) {
+                                    if (auto beam = chord->beam()) {
+                                          if (!beam->up() && !stem->up()) {
                                                 yd += diff;
                                                 qreal beamLineProp = 0.33 * point(score()->styleS(Sid::beamWidth)) * chord->chordMag();
                                                 yd -= beamLineProp;
                                                 }
+                                          }
                                     }
                               if (offsetChanged() != OffsetChange::NONE) {
                                     // user moved element within the skyline

--- a/libmscore/fingering.cpp
+++ b/libmscore/fingering.cpp
@@ -56,7 +56,7 @@ Fingering::Fingering(Score* s, ElementFlags ef)
 //   layoutType
 //---------------------------------------------------------
 
-ElementType Fingering::layoutType()
+ElementType Fingering::layoutType() const
       {
       switch (tid()) {
             case Tid::FINGERING:
@@ -149,6 +149,7 @@ void Fingering::layout()
                               }
                         else {
                               QRectF r = bbox().translated(m->pos() + s->pos() + chord->pos() + n->pos() + pos());
+
                               SkylineLine sk(false);
                               sk.add(r.x(), r.bottom(), r.width());
                               qreal d = sk.minDistance(ss->skyline().north());
@@ -166,9 +167,14 @@ void Fingering::layout()
                                     }
                               top -= md;
                               qreal diff = (bbox().bottom() + ipos().y() + yd + n->y()) - top;
-                              if (diff > 0.0)
-                                    if (chord->beam())
-                                          yd -= diff;
+                              if (diff > 0.0) {
+                                    if (auto beam = chord->beam())
+                                          if (beam->up()) {
+                                                yd -= diff;
+                                                qreal beamLineProp = 0.33 * point(score()->styleS(Sid::beamWidth)) * chord->chordMag();
+                                                yd += beamLineProp;
+                                                }
+                                    }
                               if (offsetChanged() != OffsetChange::NONE) {
                                     // user moved element within the skyline
                                     // we may need to adjust minDistance, yd, and/or offset
@@ -203,9 +209,14 @@ void Fingering::layout()
                                     }
                               bottom += md;
                               qreal diff = bottom - (bbox().top() + ipos().y() + yd + n->y());
-                              if (diff > 0.0)
-                                    if (chord->beam())
-                                          yd += diff;
+                              if (diff > 0.0) {
+                                    if (auto beam = chord->beam())
+                                          if (!beam->up()) {
+                                                yd += diff;
+                                                qreal beamLineProp = 0.33 * point(score()->styleS(Sid::beamWidth)) * chord->chordMag();
+                                                yd -= beamLineProp;
+                                                }
+                                    }
                               if (offsetChanged() != OffsetChange::NONE) {
                                     // user moved element within the skyline
                                     // we may need to adjust minDistance, yd, and/or offset
@@ -267,6 +278,20 @@ QString Fingering::accessibleInfo() const
       if (tid() == Tid::STRING_NUMBER)
             rez += " " + QObject::tr("String number");
       return QString("%1: %2").arg(rez, plainText());
+      }
+
+//---------------------------------------------------------
+//   isOnCrossBeamSide
+//---------------------------------------------------------
+
+bool Fingering::isOnCrossBeamSide() const
+      {
+      Chord* chord = note() ? note()->chord() : nullptr;
+      if (!chord)
+            return false;
+      return layoutType() == ElementType::CHORD
+           && chord->beam() && (chord->beam()->cross() || chord->staffMove() != 0)
+           && placeAbove() == chord->up();
       }
 
 //---------------------------------------------------------

--- a/libmscore/fingering.h
+++ b/libmscore/fingering.h
@@ -31,7 +31,7 @@ class Fingering final : public TextBase {
       ElementType type() const override { return ElementType::FINGERING; }
 
       Note* note() const { return toNote(parent()); }
-      ElementType layoutType();
+      ElementType layoutType() const;
       Placement calculatePlacement() const;
 
       void draw(QPainter*) const override;
@@ -40,6 +40,7 @@ class Fingering final : public TextBase {
       QVariant propertyDefault(Pid id) const override;
 
       QString accessibleInfo() const override;
+      bool isOnCrossBeamSide() const;
       };
 
 

--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -1362,7 +1362,6 @@ void Score::layoutChordBaseFingering(Chord* chord, System* system, bool fromColl
       (void) fromCollectPage;
       std::set<int> shapesToRecreate;
 
-      // TODO: pitch-ordered voicing // search for: for (int voice = 3; voice >= 0; voice--) {
 
       std::list<Note*> notes;
       Segment* segment = chord->segment();
@@ -1399,6 +1398,69 @@ void Score::layoutChordBaseFingering(Chord* chord, System* system, bool fromColl
       for (int staffIdx : shapesToRecreate)
             segment->createShape(staffIdx);
       }
+
+//---------------------------------------------------------
+//   layoutChordBaseFingering
+//    Works only for non-crossbeam/moved chords
+//---------------------------------------------------------
+
+void Score::layoutVoicedFingering(Segment* s, System* system)
+      {
+      auto score = s->score();
+      std::set<int> shapesToRecreate;
+      std::vector<Fingering*> belowFingerings;
+      std::vector<Fingering*> aboveFingerings;
+
+      // Accumulate:
+      for (Element* e : s->elist()) {
+            if (!e || !e->isChord() || !score->staff(e->staffIdx())->show())
+                  continue;
+
+            Chord* c = toChord(e);
+            bool crossedOver = c->beam() && (c->beam()->cross() || c->staffMove() != 0);
+            if (crossedOver)
+                  continue;
+
+            for (auto f : c->getFingerings(Direction::DOWN))
+                  belowFingerings.emplace_back(f);
+
+            for (auto f : c->getFingerings(Direction::UP))
+                  aboveFingerings.emplace_back(f);
+            }
+
+      // Sort via pitch:
+      std::sort(belowFingerings.begin(),
+                belowFingerings.end(),
+                [](const Fingering* a, const Fingering* b) -> bool { return a->note()->pitch() > b->note()->pitch();
+                });
+
+      std::sort(aboveFingerings.begin(),
+                aboveFingerings.end(),
+                [](const Fingering* a, const Fingering* b) -> bool { return a->note()->pitch() < b->note()->pitch();
+                });
+
+      auto layoutFingering = [&](std::vector<Fingering*>& fingers) -> void {
+            for (auto f : fingers) {
+                  f->layout();
+                  if (f->addToSkyline()) {
+                        Note* n = f->note();
+                        auto r = f->bbox().translated(f->pos() + n->pos() + n->chord()->pos() + s->pos() + s->measure()->pos());
+                        system->staff(f->note()->chord()->vStaffIdx())->skyline().add(r);
+                        }
+                  shapesToRecreate.insert(f->staffIdx());
+                  }
+            };
+
+      layoutFingering(belowFingerings);
+      layoutFingering(aboveFingerings);
+
+      for (auto staffIdx : shapesToRecreate)
+            s->createShape(staffIdx);
+      }
+
+//---------------------------------------------------------
+//   beamNoContinue
+//---------------------------------------------------------
 
 #define beamModeMid(a) (a == Beam::Mode::MID || a == Beam::Mode::BEGIN32 || a == Beam::Mode::BEGIN64)
 
@@ -4773,7 +4835,7 @@ void Score::layoutSystemElements(System* system, LayoutContext& lc)
             }
 
       //-------------------------------------------------------------
-      // layout articulations and fingering (4.x includes stretch bends here)
+      // layout articulations
       //-------------------------------------------------------------
 
       for (Segment* s : sl) {
@@ -4781,14 +4843,17 @@ void Score::layoutSystemElements(System* system, LayoutContext& lc)
                   if (!e || !e->isChord() || !score()->staff(e->staffIdx())->show())
                         continue;
                   Chord* c = toChord(e);
-
                   c->layoutArticulations();
                   c->layoutArticulations2();
-
-                  bool crossedOver = c->beam() && (c->beam()->cross() || c->staffMove() != 0);
-                  if (!crossedOver)
-                        score()->layoutChordBaseFingering(c, system);
                   }
+            }
+
+      //-------------------------------------------------------------
+      // layout fingerings
+      //-------------------------------------------------------------
+
+      for (Segment* s : sl) {
+            score()->layoutVoicedFingering(s, system);
             }
 
       //-------------------------------------------------------------

--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -10,6 +10,8 @@
 //  the file LICENCE.GPL
 //=============================================================================
 
+#include "global/log.h"
+
 #include "accidental.h"
 #include "ambitus.h"
 #include "arpeggio.h"
@@ -1351,6 +1353,53 @@ void Score::layoutChords3(std::vector<Note*>& notes, const Staff* staff, Segment
             }
       }
 
+//---------------------------------------------------------
+//   layoutChordBaseFingering
+//---------------------------------------------------------
+
+void Score::layoutChordBaseFingering(Chord* chord, System* system, bool fromCollectPage)
+      {
+      (void) fromCollectPage;
+      std::set<int> shapesToRecreate;
+
+      // TODO: pitch-ordered voicing // search for: for (int voice = 3; voice >= 0; voice--) {
+
+      std::list<Note*> notes;
+      Segment* segment = chord->segment();
+      for (auto gc : chord->graceNotes()) {
+            for (auto n : gc->notes())
+                  notes.push_back(n);
+            }
+      for (auto n : chord->notes())
+            notes.push_back(n);
+      std::list<Fingering*> fingerings;
+      for (auto note : notes) {
+            for (auto el : note->el()) {
+                  if (el->isFingering()) {
+                        Fingering* f = toFingering(el);
+                        bool perform = f->layoutType() == ElementType::CHORD && (!f->isOnCrossBeamSide()); // || preLayoutNoteheadSide);
+                        if (perform) {
+                              if (f->placeAbove())
+                                    fingerings.push_back(f);
+                              else
+                                    fingerings.push_front(f);
+                              }
+                        }
+                  }
+            }
+      for (Fingering* f : fingerings) {
+            f->layout();
+            if (f->addToSkyline()) {
+                  Note* n = f->note();
+                  auto r = f->bbox().translated(f->pos() + n->pos() + n->chord()->pos() + segment->pos() + segment->measure()->pos());
+                  system->staff(f->note()->chord()->vStaffIdx())->skyline().add(r);
+                  }
+            shapesToRecreate.insert(f->staffIdx());
+            }
+      for (int staffIdx : shapesToRecreate)
+            segment->createShape(staffIdx);
+      }
+
 #define beamModeMid(a) (a == Beam::Mode::MID || a == Beam::Mode::BEGIN32 || a == Beam::Mode::BEGIN64)
 
 bool beamNoContinue(Beam::Mode mode)
@@ -2013,6 +2062,115 @@ void LayoutContext::distributeStaves(Page* page, qreal footerPadding)
             system->layoutInstrumentNames();
             }
       vgdl.deleteAll();
+      }
+
+//---------------------------------------------------------
+//   layoutCrossStaffElements
+//---------------------------------------------------------
+
+void LayoutContext::layoutCrossStaffElements(Page* page)
+      {
+      for (System* system : page->systems()) {
+            if (!system->firstMeasure())
+                  continue;
+
+            Fraction stick = system->firstMeasure()->tick();
+            Fraction etick = system->endTick();
+
+            IF_ASSERT_FAILED(stick < etick)
+                  continue;
+
+            // edited for page start/end tick
+            if (etick <= page->startTick() || etick > page->endTick())
+                  continue;
+
+            layoutCrossStaffSlurs(system);
+            layoutArticAndFingeringOnCrossStaffBeams(system);
+            }
+      }
+
+//---------------------------------------------------------
+//   layoutCrossStaffSlurs
+//    TODO
+//    023c08c2e2 ("Fix cross-staff fingering layout and tidy up code", 2024-09-18)
+//---------------------------------------------------------
+
+void LayoutContext::layoutCrossStaffSlurs(System* system)
+      {
+      (void)system;
+
+#if 0
+      Fraction stick = system->firstMeasure()->tick();
+      Fraction etick = system->endTick();
+
+      // processedSpanners or score spanner map?
+      auto spanners = system->score()->spannerMap().findOverlapping(stick.ticks(), etick.ticks());
+      for (auto interval : spanners) {
+            Spanner* sp = interval.value;
+            if (!sp->isSlur() || sp->tick() == system->endTick())
+                  continue;
+            Slur* slur = toSlur(sp);
+            // isCrossStaff not implemented yet
+            // hasCrossBeams not implemented yet
+            if (slur->isCrossStaff() || slur->hasCrossBeams()) {
+                  slur->layoutSystem(system, slur);
+
+                  ChordRest* scr = toChordRest(slur->startElement());
+                  ChordRest* ecr = toChordRest(slur->endElement());
+                  if (scr && scr->isChord())
+                        toChord(scr)->layoutArticulations3(slur);
+                  if (ecr && ecr->isChord())
+                        toChord(ecr)->layoutArticulations3(slur);
+                  }
+            }
+#endif
+      }
+
+//---------------------------------------------------------
+//   layoutArticAndFingeringOnCrossStaffBeams
+//---------------------------------------------------------
+
+void LayoutContext::layoutArticAndFingeringOnCrossStaffBeams(System* system)
+      {
+      for (const auto mb : system->measures()) {
+            if (!mb->isMeasure())
+                  continue;
+            for (const auto& segment : toMeasure(mb)->segments()) {
+                  if (!segment.isChordRestType())
+                        continue;
+                  for (auto item : segment.elist()) {
+                        if (!item || !item->isChord())
+                              continue;
+
+                        auto c = toChord(item);
+
+                        bool hasCrossBeam = c->beam() && (c->beam()->cross() || c->staffMove());
+                        if (!hasCrossBeam) {
+                              continue;
+                              }
+
+                        c->layoutArticulations();
+                        c->layoutArticulations2(true);
+
+                        for (auto note : c->notes()) {
+                              for (auto e : note->el()) {
+                                    if (!e || !e->isFingering())
+                                          continue;
+                                    auto fingering = toFingering(e);
+                                    if (fingering->isOnCrossBeamSide()) {
+                                          fingering->layout();
+                                          if (fingering->addToSkyline()) {
+                                                const auto n = fingering->note();
+                                                const auto r = fingering->bbox().translated(
+                                                fingering->pos() + n->pos() + n->chord()->pos() + segment.pos() + segment.measure()->pos());
+                                                system->staff(fingering->note()->chord()->vStaffIdx())->skyline().add(r);
+                                                }
+                                          }
+                                    }
+                              }
+                        }
+                  }
+            }
       }
 
 //---------------------------------------------------------
@@ -4599,6 +4757,15 @@ void Score::layoutSystemElements(System* system, LayoutContext& lc)
                                                       skyline.add(t->shape().translated(t->pos() + e->pos() + p));
                                                 }
                                           }
+
+                                    // add beams to skline
+                                    if (e->isChordRest()) {
+                                         ChordRest* cr = toChordRest(e);
+                                         if (isTopBeam(cr)) {
+                                               Beam* b = cr->beam();
+                                               b->addSkyline(skyline);
+                                               }
+                                          }
                                     }
                               }
                         }
@@ -4606,90 +4773,22 @@ void Score::layoutSystemElements(System* system, LayoutContext& lc)
             }
 
       //-------------------------------------------------------------
-      // layout articulations
+      // layout articulations and fingering (4.x includes stretch bends here)
       //-------------------------------------------------------------
 
       for (Segment* s : sl) {
             for (Element* e : s->elist()) {
-                  if (!e || !e->isChordRest() || !score()->staff(e->staffIdx())->show())
+                  if (!e || !e->isChord() || !score()->staff(e->staffIdx())->show())
                         continue;
-                  ChordRest* cr = toChordRest(e);
-                  // articulations
-                  if (cr->isChord()) {
-                        Chord* c = toChord(cr);
-                        c->layoutArticulations();
-                        c->layoutArticulations2();
-                        }
+                  Chord* c = toChord(e);
+
+                  c->layoutArticulations();
+                  c->layoutArticulations2();
+
+                  bool crossedOver = c->beam() && (c->beam()->cross() || c->staffMove() != 0);
+                  if (!crossedOver)
+                        score()->layoutChordBaseFingering(c, system);
                   }
-            }
-
-      //-------------------------------------------------------------
-      // layout fingerings, add beams to skylines
-      //-------------------------------------------------------------
-
-      for (Segment* s : sl) {
-            std::set<int> recreateShapes;
-
-            // Fingering should always be ordered top-down. Best would be by pitch, but by voice will suffice
-            for (int voice = 3; voice >= 0; voice--) {
-                  for (Element* e : s->elist()) {
-                        if (!e || !e->isChordRest() || !score()->staff(e->staffIdx())->show())
-                              continue;
-
-                        ChordRest* cr = toChordRest(e);
-
-                        // add beam to skyline
-                        if (isTopBeam(cr)) {
-                              Beam* b = cr->beam();
-                              b->addSkyline(system->staff(b->staffIdx())->skyline());
-                              }
-
-                        // layout chord-based fingerings
-                        if (e->isChord()) {
-                              Chord* c = toChord(e);
-                              std::list<Note*> notes;
-                              for (auto gc : c->graceNotes()) {
-                                    for (auto n : gc->notes()) {
-                                          notes.push_back(n);
-                                          }
-                                    }
-                              for (auto n : c->notes()) {
-                                    notes.push_back(n);
-                                    }
-                              std::list<Fingering*> fingerings;
-                              for (Note* note : notes) {
-                                    for (Element* el : note->el()) {
-                                          if (el->isFingering()) {
-                                                Fingering* f = toFingering(el);
-                                                if (f->layoutType() == ElementType::CHORD) {
-                                                      if (f->placeAbove())
-                                                            fingerings.push_back(f);
-                                                      else
-                                                            fingerings.push_front(f);
-                                                      }
-                                                }
-                                          }
-                                    }
-
-                              for (Fingering* f : fingerings) {
-                                    auto test = f->placeBelow() ? (3 - voice) : voice;
-                                    if (f->voice() != test)
-                                          continue;
-
-                                    f->layout();
-
-                                    if (f->addToSkyline()) {
-                                          Note* n = f->note();
-                                          QRectF r = f->bbox().translated(f->pos() + n->pos() + n->chord()->pos() + s->pos() + s->measure()->pos());
-                                          system->staff(f->note()->chord()->vStaffIdx())->skyline().add(r);
-                                          }
-                                    recreateShapes.insert(f->staffIdx());
-                                    }
-                              }
-                        }
-                  }
-            for (auto staffIdx : recreateShapes)
-                  s->createShape(staffIdx);
             }
 
       //-------------------------------------------------------------
@@ -5261,8 +5360,10 @@ void LayoutContext::collectPage()
                                     if (!currentScore->staff(track2staff(track))->show())
                                           continue;
                                     ChordRest* cr = toChordRest(e);
-                                    if (notTopBeam(cr))                 // layout cross staff beams
+                                    if (notTopBeam(cr)) {
+                                          // layout cross staff beams
                                           cr->beam()->layout();
+                                          }
                                     if (notTopTuplet(cr)) {
                                           // fix layout of tuplets
                                           DurationElement* de = cr;
@@ -5293,6 +5394,12 @@ void LayoutContext::collectPage()
                                                 if (t->twoNotes() && c1 && c2 && (c1->staffMove() || c2->staffMove()))
                                                       t->layout();
                                                 }
+
+                                          c->layoutArticulations();
+                                          c->layoutArticulations2();
+
+                                          if (c->beam() && (c->beam()->cross() || c->staffMove() != 0))
+                                                score->layoutChordBaseFingering(c, s, true);
                                           }
                                     }
                               else if (e->isBarLine())
@@ -5323,6 +5430,14 @@ void LayoutContext::collectPage()
             qreal height = s ? s->pos().y() + s->height() + s->minBottom() : page->tm();
             page->bbox().setRect(0.0, 0.0, score->loWidth(), height + page->bm());
             }
+
+      // Fingering and articulations on top of cross-staff beams must be laid out here
+      layoutCrossStaffElements(page);
+
+#if 0 // MSS4 performs the following:
+      for (const System* system : page->systems())
+            SystemLayout::centerElementsBetweenStaves(system);
+#endif
 
       page->rebuildBspTree();
       }

--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -4662,6 +4662,7 @@ void Score::layoutSystemElements(System* system, LayoutContext& lc)
       //-------------------------------------------------------------
 
       for (SpannerSegment*& ss : system->spannerSegments()) {
+            // Test: indiscrimiantely set to nullptr. don't think it's needed though
             if (ss->system() == system)
                   ss->setParent(nullptr);
             }
@@ -4901,12 +4902,13 @@ void Score::layoutSystemElements(System* system, LayoutContext& lc)
             lc.processedSpanners.insert(sp);
             if (sp->tick() < etick && sp->tick2() >= stick) {
                   if (sp->isSlur()) {
-                        // skip cross-staff slurs
                         ChordRest* scr = sp->startCR();
                         ChordRest* ecr = sp->endCR();
                         int idx = sp->vStaffIdx();
-                        if (scr && ecr && (scr->vStaffIdx() != idx || ecr->vStaffIdx() != idx))
-                              continue;
+                        const bool crossStaff = (scr && ecr && (scr->vStaffIdx() != idx || ecr->vStaffIdx() != idx));
+                        if (crossStaff) {
+                              // Update: don't skip now that there's a two-pass system
+                              }
                         spanner.push_back(sp);
                         }
                   }

--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -1355,6 +1355,7 @@ void Score::layoutChords3(std::vector<Note*>& notes, const Staff* staff, Segment
 
 //---------------------------------------------------------
 //   layoutChordBaseFingering
+//    Omits layout of crossbeamed fingerings
 //---------------------------------------------------------
 
 void Score::layoutChordBaseFingering(Chord* chord, System* system, bool fromCollectPage)
@@ -1400,7 +1401,7 @@ void Score::layoutChordBaseFingering(Chord* chord, System* system, bool fromColl
       }
 
 //---------------------------------------------------------
-//   layoutChordBaseFingering
+//   layoutVoicedFingering
 //    Works only for non-crossbeam/moved chords
 //---------------------------------------------------------
 
@@ -1415,25 +1416,24 @@ void Score::layoutVoicedFingering(Segment* s, System* system)
       for (Element* e : s->elist()) {
             if (!e || !e->isChord() || !score->staff(e->staffIdx())->show())
                   continue;
-
             Chord* c = toChord(e);
-            bool crossedOver = c->beam() && (c->beam()->cross() || c->staffMove() != 0);
-            if (crossedOver)
-                  continue;
-
-            for (auto f : c->getFingerings(Direction::DOWN))
-                  belowFingerings.emplace_back(f);
-
-            for (auto f : c->getFingerings(Direction::UP))
-                  aboveFingerings.emplace_back(f);
+            for (auto f : c->getFingerings(Direction::DOWN)) {
+                  if (!f->isOnCrossBeamSide()) {
+                        belowFingerings.emplace_back(f);
+                        }
+                  }
+            for (auto f : c->getFingerings(Direction::UP)) {
+                  if (!f->isOnCrossBeamSide()) {
+                        aboveFingerings.emplace_back(f);
+                        }
+                  }
             }
 
-      // Sort via pitch:
+      // Pitch-based sort:
       std::sort(belowFingerings.begin(),
                 belowFingerings.end(),
                 [](const Fingering* a, const Fingering* b) -> bool { return a->note()->pitch() > b->note()->pitch();
                 });
-
       std::sort(aboveFingerings.begin(),
                 aboveFingerings.end(),
                 [](const Fingering* a, const Fingering* b) -> bool { return a->note()->pitch() < b->note()->pitch();
@@ -4654,6 +4654,18 @@ void Score::updateMeasureNumbers() {
 
 void Score::layoutSystemElements(System* system, LayoutContext& lc)
       {
+
+      //-------------------------------------------------------------
+      //    detach spanners:
+      //          not relying on destructor for this in order
+      //          to be able to perform a dual layout
+      //-------------------------------------------------------------
+
+      for (SpannerSegment*& ss : system->spannerSegments()) {
+            if (ss->system() == system)
+                  ss->setParent(nullptr);
+            }
+
       //-------------------------------------------------------------
       //    create cr segment list to speed up computations
       //-------------------------------------------------------------
@@ -5459,12 +5471,7 @@ void LayoutContext::collectPage()
                                                 if (t->twoNotes() && c1 && c2 && (c1->staffMove() || c2->staffMove()))
                                                       t->layout();
                                                 }
-
-                                          c->layoutArticulations();
-                                          c->layoutArticulations2();
-
-                                          if (c->beam() && (c->beam()->cross() || c->staffMove() != 0))
-                                                score->layoutChordBaseFingering(c, s, true);
+                                          // Layout articulations / fingerings wuz here
                                           }
                                     }
                               else if (e->isBarLine())
@@ -5473,6 +5480,9 @@ void LayoutContext::collectPage()
                         }
                   m->layout2();
                   }
+
+            // Re-layout entire system to correct articulation/fingering layout after cross-beams updating
+            currentScore->layoutSystemElements(s, *this);
             }
 
       // If this is the last page we layout, we must also relayout the first barlines of the

--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -4794,32 +4794,6 @@ void Score::layoutSystemElements(System* system, LayoutContext& lc)
                                     if (e->addToSkyline() || e->isChord())
                                           skyline.add(e->shape().translated(e->pos() + p));
 
-                                    // Allow tuplets to get skyline even when "avoid staves" is disabled
-                                    // (still want to avoid elements via auto-place, e.g. hairpins...)
-                                    if (e->isChordRest()) {
-                                          if (auto t = toChordRest(e)->tuplet()) {
-                                                bool addToSky = true;
-
-                                                // Omit skyline if any cross-staffed elements:
-                                                for (auto& te : t->elements()) {
-
-                                                      if (te->staffIdx() != te->vStaffIdx()) {
-                                                            addToSky = false;
-                                                            // TODO: Figure how to do something like this while finding the right formula
-                                                                // SysStaff* ss = system->staff(e->vStaffIdx());
-                                                                // Skyline& vSkyline = ss->skyline();
-                                                                // vSkyline.add(t->shape().translated(m->pos()));
-                                                            }
-                                                      }
-                                                if (t->addToSkyline() && addToSky) {
-                                                      // Note: layout isn't 100% realtime:
-                                                      QPointF offset(m->pos());
-                                                      offset.rx() += t->offset().x();
-                                                      offset.ry() += t->offset().y();
-                                                      skyline.add(t->shape().translated(offset));
-                                                      }
-                                                }
-                                          }
 
                                     // add tremolo to skyline
                                     if (e->isChord() && toChord(e)->tremolo()) {
@@ -4884,6 +4858,15 @@ void Score::layoutSystemElements(System* system, LayoutContext& lc)
                         Tuplet* t = de->tuplet();
                         t->layout();
                         de = t;
+
+                        // Add tuplet to skyline after layout to avoid other score elements
+                        if (!t->addToSkyline())
+                              continue;
+                        auto m = s->measure();
+                        auto offset(m->pos());
+                        offset += t->offset();
+                        auto shape = t->shape().translated(offset);
+                        system->staff(t->staffIdx())->skyline().add(shape);
                         }
                   }
             }

--- a/libmscore/layout.h
+++ b/libmscore/layout.h
@@ -119,6 +119,10 @@ struct LayoutContext {
       static void layoutPage(Page* page, qreal restHeight, qreal footerPadding);
       static void checkDivider(bool left, System* s, qreal yOffset, bool remove = false);
       static void distributeStaves(Page* page, qreal footerPadding);
+
+      static void layoutCrossStaffElements(Page* page);
+      static void layoutCrossStaffSlurs(System* system);
+      static void layoutArticAndFingeringOnCrossStaffBeams(System* system);
       };
 
 //---------------------------------------------------------

--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -2426,6 +2426,22 @@ QString Note::noteTypeUserName() const
       }
 
 //---------------------------------------------------------
+//   getFingerings
+//---------------------------------------------------------
+
+std::vector<Fingering*> Note::getFingerings() const
+      {
+      std::vector<Fingering*> fingerings;
+      for (auto e : el()) {
+            if (e->isFingering()) {
+                  auto f = toFingering(e);
+                  fingerings.emplace_back(f);
+                  }
+            }
+      return fingerings;
+      }
+
+//---------------------------------------------------------
 //   scanElements
 //---------------------------------------------------------
 

--- a/libmscore/note.h
+++ b/libmscore/note.h
@@ -469,6 +469,8 @@ class Note final : public Element {
       ElementList& el()                           { return _el; }
       const ElementList& el() const               { return _el; }
 
+      std::vector<Fingering*> getFingerings() const;
+
       int subchannel() const                    { return _subchannel; }
       void setSubchannel(int val)               { _subchannel = val;  }
 

--- a/libmscore/page.cpp
+++ b/libmscore/page.cpp
@@ -713,6 +713,15 @@ QRectF Page::tbbox(MeasureBase* firstMeasure,  MeasureBase* lastMeasure)
       }
 
 //---------------------------------------------------------
+//   startTick
+//---------------------------------------------------------
+
+Fraction Page::startTick() const
+      {
+      return _systems.empty() ? Fraction(-1,1) : _systems.front()->measures().front()->tick();
+      }
+
+//---------------------------------------------------------
 //   endTick
 //---------------------------------------------------------
 

--- a/libmscore/page.h
+++ b/libmscore/page.h
@@ -78,6 +78,7 @@ class Page final : public Element {
       QPointF pagePos() const override { return QPointF(); }     ///< position in page coordinates
       QList<Element*> elements();               ///< list of visible elements
       QRectF tbbox(MeasureBase* firstMeasure=nullptr, MeasureBase* lastMeasure=nullptr);
+      Fraction startTick() const;
       Fraction endTick() const;
       };
 

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -1109,6 +1109,7 @@ class Score : public QObject, public ScoreElement {
       void layoutChords3(std::vector<Note*>&, const Staff*, Segment*);
 
       static void layoutChordBaseFingering(Chord* chord, System* system, bool fromCollectPage = false);
+      static void layoutVoicedFingering(Segment* s, System* system);
 
       SynthesizerState& synthesizerState()     { return _synthesizerState; }
       void setSynthesizerState(const SynthesizerState& s);

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -1108,6 +1108,8 @@ class Score : public QObject, public ScoreElement {
       qreal layoutChords2(std::vector<Note*>& notes, bool up);
       void layoutChords3(std::vector<Note*>&, const Staff*, Segment*);
 
+      static void layoutChordBaseFingering(Chord* chord, System* system, bool fromCollectPage = false);
+
       SynthesizerState& synthesizerState()     { return _synthesizerState; }
       void setSynthesizerState(const SynthesizerState& s);
 

--- a/libmscore/system.cpp
+++ b/libmscore/system.cpp
@@ -859,25 +859,8 @@ void System::layout2()
 
       //---------------------------------------------------
       //  layout cross-staff slurs and ties
+      //  No longer needed due to two-pass system
       //---------------------------------------------------
-
-      Fraction stick = measures().front()->tick();
-      Fraction etick = measures().back()->endTick();
-      auto spanners = score()->spannerMap().findOverlapping(stick.ticks(), etick.ticks());
-
-      std::vector<Spanner*> spanner;
-      for (auto interval : spanners) {
-            Spanner* sp = interval.value;
-            if (sp->tick() < etick && sp->tick2() >= stick) {
-                  if (sp->isSlur()) {
-                        ChordRest* scr = sp->startCR();
-                        ChordRest* ecr = sp->endCR();
-                        int idx = sp->vStaffIdx();
-                        if (scr && ecr && (scr->vStaffIdx() != idx || ecr->vStaffIdx() != idx))
-                              sp->layoutSystem(this);
-                        }
-                  }
-            }
 
       }
 

--- a/libmscore/tuplet.cpp
+++ b/libmscore/tuplet.cpp
@@ -173,6 +173,22 @@ void Tuplet::resetNumberProperty()
       }
 
 //---------------------------------------------------------
+//   containsCrossStaffElements
+//---------------------------------------------------------
+
+bool Tuplet::containsCrossStaffElements() const
+      {
+      bool rv = false;
+      for (const DurationElement* e : elements()) {
+            if (e->staffIdx() != e->vStaffIdx()) {
+                  rv = true;
+                  break;
+                  }
+            }
+      return rv;
+      }
+
+//---------------------------------------------------------
 //   layout
 //---------------------------------------------------------
 

--- a/libmscore/tuplet.h
+++ b/libmscore/tuplet.h
@@ -99,6 +99,8 @@ class Tuplet final : public DurationElement {
       void clear()                                          { _elements.clear(); }
       bool contains(const DurationElement* el) const { return std::find(_elements.begin(), _elements.end(), el) != _elements.end(); }
 
+      bool containsCrossStaffElements() const;
+
       void layout() override;
       void scanElements(void* data, void (*func)(void*, Element*), bool all=true) override;
 

--- a/mscore/inspector/inspectorBase.cpp
+++ b/mscore/inspector/inspectorBase.cpp
@@ -219,8 +219,15 @@ void InspectorBase::setValue(const InspectorItem& ii, QVariant val)
                               break;
                               }
                         }
-                  if (!found)
-                        qDebug("ComboBox item not found: pid <%s> data <%d>", propertyName(id), ival);
+                  if (!found) {
+                        const QString propName(propertyName(id));
+                        const auto start = static_cast<int>(Tid::DEFAULT);
+                        const auto end = static_cast<int>(Tid::IGNORED_STYLES);
+                        if (ival >= start && ival <= end && propName == "style")
+                              ; // Ignore: this is checking TextBase with specific Text ID
+                        else
+                              qDebug("ComboBox item not found: pid <%s> data <%d>", propertyName(id), ival);
+                        }
                   }
             else
                   cb->setCurrentIndex(ival);

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -2850,6 +2850,10 @@ void ScoreView::selectSlur(bool backward)
             auto theLogic = [&](const auto& it, bool& foundSelf) -> SpannerSegment* {
                   const auto rejected = nullptr;
                   const auto s = it->second;
+
+                  if (s->segmentsEmpty())
+                        return rejected;
+
                   const int begin = it->first;
 
                   const int selectedPos = selectedSpanner ? selectedSpanner->tick().ticks() : selected->tick().ticks();
@@ -2874,6 +2878,7 @@ void ScoreView::selectSlur(bool backward)
                   if (sameType && sameStaff) {
                         if (!foundSelf && (begin == selectedPos))
                               return rejected;
+
                         else return backward ? s->backSegment() : s->frontSegment();
                         }
                   else return rejected;
@@ -5430,9 +5435,18 @@ void ScoreView::adjustCanvasPosition(const Element* el, bool playBack, int staff
             auto spanner = ss->spanner();
             auto start = spanner->startElement();
             auto end = spanner->endElement();
-            auto terminus = (spanner->frontSegment() == ss) ? start : end;
-            m = toMeasure(terminus->findMeasure());
-            el = terminus;
+            if (!spanner->segmentsEmpty()) {
+                  if (auto fs = spanner->frontSegment()) {
+                        if (auto terminus = (fs == ss) ? start : end) {
+                              m = toMeasure(terminus->findMeasure());
+                              el = terminus;
+                              }
+                        }
+                  }
+            else {
+                  m = end->findMeasure();
+                  el = start;
+                  }
             }
       else if (el->isSpanner()) {
             Element* se = static_cast<const Spanner*>(el)->startElement();

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -4224,11 +4224,10 @@ void ScoreView::cmd(const char* s)
 
                   const auto ee = cv->getEditElement();
                   if (ee && ee->isSpannerSegment()) {
-                        auto sseg = toSpannerSegment(ee);
-                        auto span = sseg->spanner();
-                        cv->score()->deleteItem(span);
+                        auto ss = toSpannerSegment(ee);
+                        cv->score()->select(ss);
                         }
-                  else cv->score()->cmdDeleteSelection();
+                  cv->score()->cmdDeleteSelection();
 
                   cv->score()->endCmd();
 

--- a/mtest/libmscore/tools/undoSlashRhythm01-ref.mscx
+++ b/mtest/libmscore/tools/undoSlashRhythm01-ref.mscx
@@ -946,8 +946,8 @@
             <durationType>quarter</durationType>
             </Rest>
           <Beam>
-            <l1>-10</l1>
-            <l2>-10</l2>
+            <l1>-9</l1>
+            <l2>-9</l2>
             </Beam>
           <Chord>
             <small>1</small>
@@ -981,8 +981,8 @@
               </Note>
             </Chord>
           <Beam>
-            <l1>-10</l1>
-            <l2>-10</l2>
+            <l1>-9</l1>
+            <l2>-9</l2>
             </Beam>
           <Chord>
             <small>1</small>

--- a/mtest/libmscore/tools/undoSlashRhythm02-ref.mscx
+++ b/mtest/libmscore/tools/undoSlashRhythm02-ref.mscx
@@ -805,8 +805,8 @@
             <durationType>quarter</durationType>
             </Rest>
           <Beam>
-            <l1>-10</l1>
-            <l2>-10</l2>
+            <l1>-9</l1>
+            <l2>-9</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>
@@ -834,8 +834,8 @@
               </Note>
             </Chord>
           <Beam>
-            <l1>-10</l1>
-            <l2>-10</l2>
+            <l1>-9</l1>
+            <l2>-9</l2>
             </Beam>
           <Chord>
             <durationType>eighth</durationType>

--- a/mtest/musicxml/io/testBackupRoundingError_ref.mscx
+++ b/mtest/musicxml/io/testBackupRoundingError_ref.mscx
@@ -699,7 +699,7 @@
           <Beam>
             <StemDirection>up</StemDirection>
             <l1>0</l1>
-            <l2>-1</l2>
+            <l2>0</l2>
             </Beam>
           <Chord>
             <BeamMode>begin</BeamMode>
@@ -1246,8 +1246,8 @@
             </Tuplet>
           <Beam>
             <StemDirection>down</StemDirection>
-            <l1>5</l1>
-            <l2>5</l2>
+            <l1>6</l1>
+            <l2>6</l2>
             </Beam>
           <Chord>
             <BeamMode>begin</BeamMode>
@@ -1852,7 +1852,7 @@
             </Rest>
           <Beam>
             <StemDirection>up</StemDirection>
-            <l1>8</l1>
+            <l1>7</l1>
             <l2>6</l2>
             </Beam>
           <Chord>
@@ -1897,7 +1897,7 @@
             </Tuplet>
           <Beam>
             <StemDirection>up</StemDirection>
-            <l1>4</l1>
+            <l1>3</l1>
             <l2>8</l2>
             </Beam>
           <Chord>

--- a/mtest/musicxml/io/testCueGraceNotes_ref.mscx
+++ b/mtest/musicxml/io/testCueGraceNotes_ref.mscx
@@ -252,7 +252,7 @@
           <Beam>
             <StemDirection>down</StemDirection>
             <l1>14</l1>
-            <l2>12</l2>
+            <l2>13</l2>
             </Beam>
           <Chord>
             <BeamMode>begin</BeamMode>
@@ -299,8 +299,8 @@
             </Chord>
           <Beam>
             <StemDirection>down</StemDirection>
-            <l1>17</l1>
-            <l2>13</l2>
+            <l1>18</l1>
+            <l2>14</l2>
             </Beam>
           <Chord>
             <BeamMode>begin</BeamMode>


### PR DESCRIPTION
Resolves (hopefully): #194 

For example:

<img width="759" height="279" alt="image" src="https://github.com/user-attachments/assets/b455d519-823d-4d85-a9dc-81ae1dc122d0" />


The same score renders in 3.6.2 as:

<img width="631" height="255" alt="image" src="https://github.com/user-attachments/assets/828bcab0-543b-4469-9cce-a7bdb9f04908" />

Updated again:

<img width="748" height="321" alt="image" src="https://github.com/user-attachments/assets/77ff4e19-b956-4401-8520-7fc9bc67c752" />

Note, the bottom fingering can be inbetween (not head side and not beamside) by turning off autoplace. Instead of being stupid about non-autoplace, it will go above or below the notehead. Unfortunately they won't stack like that though (I guess I could try to get that to work.. I should try to get the MSS4 people to provide some options for this stuff too)

<img width="760" height="451" alt="image" src="https://github.com/user-attachments/assets/de406173-37f1-451b-a501-c95c08df6512" />



This is a mixture of some backporting from 4.x around 2023-2025 and some  changes that were required from what I could tell for the 3.x series. Plus the regular fingering update to consider pitches.


OK: Lots of MTEST results with additional 
`<minDistance>-999</minDistance>`
I know the culprit (was using indiscriminate rebasing)

Problem also is that other elements get laid out before hand, then the crossed articulations/fingerings come around again and lose the proper Y-Order. so the PR is bogus right now:

<img width="177" height="458" alt="image" src="https://github.com/user-attachments/assets/85409e0b-3456-48e7-93cf-20e4b189f26c" />

Mss4 has had so many updates since 2022 regarding the layout of systems that it's hard to "decipher" what is doing what for me here.

Update: Kind of okay after a second full system layout

+ Think there's as problem with slurs and cross staffing though - even got a crash, so that needs to be fixed somehow