### PR TITLE
Enable some DEBUG activities for online RELEASE build + Show Velocity of note + integer tick + New Command to show skylines et al

### DIFF
--- a/libmscore/check.cpp
+++ b/libmscore/check.cpp
@@ -179,9 +179,7 @@ bool Score::sanityCheck(const QString& name)
             for (int staffIdx = 0; staffIdx < endStaff; ++staffIdx) {
                   Rest* fmrest0 = 0;      // full measure rest in voice 0
                   Fraction voices[VOICES];
-#ifndef NDEBUG
                   m->setCorrupted(staffIdx, false);
-#endif
                   for (Segment* s = m->first(SegmentType::ChordRest); s; s = s->next(SegmentType::ChordRest)) {
                         for (int v = 0; v < VOICES; ++v) {
                               ChordRest* cr = toChordRest(s->element(staffIdx * VOICES + v));
@@ -200,9 +198,7 @@ bool Score::sanityCheck(const QString& name)
                         QString msg = QObject::tr("Measure %1, staff %2 incomplete. Expected: %3; Found: %4").arg(mNumber).arg(staffIdx + 1).arg(mLen.print(), voices[0].print());
                         qDebug() << msg;
                         error += QString("%1\n").arg(msg);
-#ifndef NDEBUG
                         m->setCorrupted(staffIdx, true);
-#endif
                         result = false;
                         // try to fix a bad full measure rest
                         if (fmrest0) {
@@ -217,9 +213,7 @@ bool Score::sanityCheck(const QString& name)
                               QString msg = QObject::tr("Measure %1, staff %2, voice %3 too long. Expected: %4; Found: %5").arg(mNumber).arg(staffIdx + 1).arg(v + 1).arg(mLen.print(), voices[v].print());
                               qDebug() << msg;
                               error += QString("%1\n").arg(msg);
-#ifndef NDEBUG
                               m->setCorrupted(staffIdx, true);
-#endif
                               result = false;
                               }
                         }

--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -94,9 +94,7 @@ class MStaff {
                                           ///< this changes some layout rules
       bool _visible          { true  };
       bool _stemless         { false };
-#ifndef NDEBUG
       bool _corrupted        { false };
-#endif
 
    public:
       MStaff()  {}
@@ -129,10 +127,8 @@ class MStaff {
       bool stemless() const          { return _stemless; }
       void setStemless(bool val)     { _stemless = val;  }
 
-#ifndef NDEBUG
       bool corrupted() const         { return _corrupted; }
       void setCorrupted(bool val)    { _corrupted = val; }
-#endif
       };
 
 MStaff::~MStaff()
@@ -154,9 +150,7 @@ MStaff::MStaff(const MStaff& m)
       _vspacerDown = 0;
       _visible     = m._visible;
       _stemless  = m._stemless;
-#ifndef NDEBUG
       _corrupted   = m._corrupted;
-#endif
       }
 
 //---------------------------------------------------------
@@ -305,10 +299,8 @@ Spacer* Measure::vspacerUp(int staffIdx) const                  { return _mstave
 void Measure::setStaffVisible(int staffIdx, bool visible)       { _mstaves[staffIdx]->setVisible(visible); }
 void Measure::setStaffStemless(int staffIdx, bool stemless)     { _mstaves[staffIdx]->setStemless(stemless); }
 
-#ifndef NDEBUG
 bool Measure::corrupted(int staffIdx) const                     { return _mstaves[staffIdx]->corrupted(); }
 void Measure::setCorrupted(int staffIdx, bool val)              { _mstaves[staffIdx]->setCorrupted(val); }
-#endif
 
 void Measure::setNoText(int staffIdx, MeasureNumber* t)         { _mstaves[staffIdx]->setNoText(t); }
 MeasureNumber* Measure::noText(int staffIdx) const              { return _mstaves[staffIdx]->noText(); }

--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -3340,6 +3340,7 @@ QString Note::accessibleInfo() const
       QString voice = QObject::tr("Voice: %1").arg(QString::number(track() % VOICES + 1));
       QString pitchName;
       QString onofftime;
+      const int playVelocity = actualPlayVelocity();
       if (!_playEvents.empty()) {
             int on = _playEvents[0].ontime();
             int off = _playEvents[0].offtime();
@@ -3355,7 +3356,13 @@ QString Note::accessibleInfo() const
             pitchName = QObject::tr("%1; String: %2; Fret: %3").arg(tpcUserName(false), QString::number(string() + 1), QString::number(fret()));
       else
             pitchName = tpcUserName(false);
-      return QObject::tr("%1; Pitch: %2; Duration: %3%4%5").arg(noteTypeUserName(), pitchName, duration, onofftime, (chord()->isGrace() ? "" : QString("; %1").arg(voice)));
+      return QObject::tr("%1; Pitch: %2; Duration: %3%4%5; MIDI Velocity: %6")
+                        .arg(noteTypeUserName(),
+                         pitchName,
+                         duration,
+                         onofftime,
+                         (chord()->isGrace() ? "" : QString("; %1").arg(voice)),
+                         QString::number(playVelocity));
       }
 
 //---------------------------------------------------------

--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -2639,6 +2639,18 @@ int Note::customizeVelocity(int velo) const
       return limit(velo, 1, 127);
       }
 
+//----------------------------------------------------------
+//   actualPlayVelocity
+//      returns Absolute MIDI velocity on current tick of staff
+//      position joined with note velocity offset (final result)
+//----------------------------------------------------------
+
+int Note::actualPlayVelocity() const
+      {
+      const int staffDynamicVelocity = staff()->velocities().val(tick());
+      return customizeVelocity(staffDynamicVelocity);
+      }
+
 //---------------------------------------------------------
 //   startDrag
 //---------------------------------------------------------

--- a/libmscore/note.h
+++ b/libmscore/note.h
@@ -498,6 +498,7 @@ class Note final : public Element {
       void resetLength();
 
       int customizeVelocity(int velo) const;
+      int actualPlayVelocity() const;
       NoteDot* dot(int n)                         { return _dots[n];          }
       const QVector<NoteDot*>& dots() const       { return _dots;             }
       QVector<NoteDot*>& dots()                   { return _dots;             }

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -7483,6 +7483,17 @@ void MuseScore::cmd(QAction* a, const QString& cmd)
                   w->setSource(QUrl(urlString));
                   }
             }
+      else if (cmd == "show-debug") {
+            // MScore::showSystemBoundingRect = a->isChecked();
+            MScore::showCorruptedMeasures = a->isChecked();
+            MScore::showBoundingRect = a->isChecked();
+            MScore::showSegmentShapes = a->isChecked();
+            MScore::showSkylines = a->isChecked();
+            if (cs) {
+                  cs->setLayoutAll();
+                  cs->update();
+                  }
+            }
       else {
             if (cv) {
                   //isAncestorOf is called to see if a widget from inspector has focus

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -1331,9 +1331,7 @@ void MuseScore::populateFileOperations()
       viewModeCombo->addItem(tr("Page View"), int(LayoutMode::PAGE));
       viewModeCombo->addItem(tr("Continuous View"), int(LayoutMode::LINE));
       viewModeCombo->addItem(tr("Single Page"), int(LayoutMode::SYSTEM));
-#ifdef NDEBUG
       if (enableExperimental)
-#endif
             viewModeCombo->addItem(tr("Floating"), int(LayoutMode::FLOAT));
 
       // Restore the saved view-mode combobox index, if any.
@@ -7422,7 +7420,6 @@ void MuseScore::cmd(QAction* a, const QString& cmd)
             reportBug("panel");
       else if (cmd == "leave-feedback")
             leaveFeedback("panel");
-#ifndef NDEBUG
       else if (cmd == "no-horizontal-stretch") {
             MScore::noHorizontalStretch = a->isChecked();
             if (cs) {
@@ -7486,7 +7483,6 @@ void MuseScore::cmd(QAction* a, const QString& cmd)
                   w->setSource(QUrl(urlString));
                   }
             }
-#endif
       else {
             if (cv) {
                   //isAncestorOf is called to see if a widget from inspector has focus

--- a/mscore/musescore.h
+++ b/mscore/musescore.h
@@ -313,9 +313,7 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
       QMenu* menuPlugins;
       QMenu* menuHelp;
       QMenu* menuTours;
-#ifndef NDEBUG
       QMenu* menuDebug;
-#endif
       AlbumManager* albumManager           { 0 };
       ExportDialog* exportDialog           { 0 };
 

--- a/mscore/prefsdialog.cpp
+++ b/mscore/prefsdialog.cpp
@@ -822,9 +822,7 @@ void PreferenceDialog::updateSCListView()
             if (enableExperimental
                         || (!s->key().startsWith("media")
                             && !s->key().startsWith("layer")
-#ifdef NDEBUG
                             && !s->key().startsWith("debugger")
-#endif
                             && !s->key().startsWith("edit_harmony")
                             && !s->key().startsWith("insert-fretframe"))) {
                   shortcutList->addTopLevelItem(newItem);

--- a/mscore/qmldockwidget.cpp
+++ b/mscore/qmldockwidget.cpp
@@ -28,9 +28,7 @@
 
 namespace Ms {
 
-#ifndef NDEBUG
 bool useSourceQmlFiles = false;
-#endif
 
 //---------------------------------------------------------
 //   FocusChainBreak
@@ -241,13 +239,11 @@ void QmlDockWidget::setupStyle()
 
 QString QmlDockWidget::qmlSourcePrefix()
       {
-#ifndef NDEBUG
       if (useSourceQmlFiles) {
             const QFileInfo fi(__FILE__);
             const QDir mscoreDir = fi.absoluteDir();
             return QUrl::fromLocalFile(mscoreDir.absolutePath()).toString() + '/';
             }
-#endif
       static const QString qmlResourcesRoot("qrc:/");
       return qmlResourcesRoot;
       }

--- a/mscore/qmldockwidget.h
+++ b/mscore/qmldockwidget.h
@@ -24,9 +24,7 @@
 
 namespace Ms {
 
-#ifndef NDEBUG
 extern bool useSourceQmlFiles;
-#endif
 
 //---------------------------------------------------------
 //   FocusChainBreak

--- a/mscore/scoreaccessibility.cpp
+++ b/mscore/scoreaccessibility.cpp
@@ -300,6 +300,8 @@ void ScoreAccessibility::currentInfoChanged(Element* hover)
                               optimizedBarsAndBeats += "; " + tr("Beat: %1").arg(QString::number(bar_beat.second));
                               }
                         barsAndBeats += "; Tick: " + el->tick().print();
+                        if (MScore::showSkylines)
+                              barsAndBeats += " (" + QString::number(el->tick().ticks()) + ")";
                         }
                   }
 

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -335,10 +335,8 @@ void ScoreView::objectPopup(const QPoint& pos, Element* obj)
       a = popup->addAction(tr("Help"));
       a->setData("help");
 
-#ifndef NDEBUG
       popup->addSeparator();
       popup->addAction("Debugger")->setData("list");
-#endif
 
       popupActive = true;
       a = popup->exec(pos);
@@ -472,9 +470,7 @@ void ScoreView::measurePopup(QContextMenuEvent* ev, Measure* obj)
       a->setEnabled(!obj->isMMRest());
       popup->addSeparator();
 
-#ifndef NDEBUG
       popup->addAction("Object Debugger")->setData("list");
-#endif
 
       a = popup->exec(gpos);
       if (a == 0)
@@ -1446,7 +1442,6 @@ void ScoreView::paintPageBorder(QPainter& p, Page* page)
             }
       }
 
-#ifndef NDEBUG
 //---------------------------------------------------------
 //   drawDebugInfo
 //---------------------------------------------------------
@@ -1496,7 +1491,6 @@ static void drawDebugInfo(QPainter& p, const Element* _e)
                   }
             }
       }
-#endif
 
 //---------------------------------------------------------
 //   drawHoverHighlight
@@ -1732,10 +1726,8 @@ void ScoreView::drawElements(QPainter& painter, QList<Element*>& el, Element* ed
             painter.translate(pos);
             e->draw(&painter);
             painter.translate(-pos);
-#ifndef NDEBUG
             if (e->selected())
                   drawDebugInfo(painter, e);
-#endif
             }
 
       if (MScore::noteheadsBehindLedger) {
@@ -1939,7 +1931,6 @@ void ScoreView::paint(const QRect& r, QPainter& p)
                   // Page Elements
                   drawElements(p, ell, editElement);
 
-#ifndef NDEBUG
                   if (!score()->printing()) {
                         if (MScore::showSystemBoundingRect) {
                               for (const System* system : qAsConst(page->systems())) {
@@ -2005,7 +1996,6 @@ void ScoreView::paint(const QRect& r, QPainter& p)
                                     }
                               }
                         }
-#endif
 
                   p.translate(-pos);
                   r1 -= _matrix.mapRect(pr).toAlignedRect();

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -5398,7 +5398,7 @@ void ScoreView::adjustCanvasPosition(const Element* el, bool playBack, int staff
             return;
             }
 
-      const MeasureBase* m;
+      const MeasureBase* m {nullptr};
       if (!el)
             return;
       else if (el->type() == ElementType::NOTE)

--- a/mscore/shortcut.cpp
+++ b/mscore/shortcut.cpp
@@ -5179,7 +5179,6 @@ Shortcut Shortcut::_sc[] = {
          Qt::ApplicationShortcut
          },
 #endif
-#ifndef NDEBUG
       {
          MsWidget::MAIN_WINDOW,
          STATE_ALL,
@@ -5270,7 +5269,6 @@ Shortcut Shortcut::_sc[] = {
          Icons::Invalid_ICON,
          Qt::ApplicationShortcut
          },
-#endif
       };
 
 

--- a/mscore/shortcut.cpp
+++ b/mscore/shortcut.cpp
@@ -3717,6 +3717,17 @@ Shortcut Shortcut::_sc[] = {
       {
          MsWidget::MAIN_WINDOW,
          STATE_NORMAL | STATE_NOTE_ENTRY | STATE_PLAY,
+         "show-debug",
+         QT_TRANSLATE_NOOP("action","Toggle Debug Options"),
+         QT_TRANSLATE_NOOP("action","Toggle Debug Options"),
+         0,
+         Icons::Invalid_ICON,
+         Qt::WindowShortcut,
+         ShortcutFlags::A_SCORE | ShortcutFlags::A_CHECKABLE
+         },
+      {
+         MsWidget::MAIN_WINDOW,
+         STATE_NORMAL | STATE_NOTE_ENTRY | STATE_PLAY,
          "toggle-all-unprintable",
          QT_TRANSLATE_NOOP("action","Show All Invisible and Unprintable Elements"),
          QT_TRANSLATE_NOOP("action","Show all invisible and unprintable elements"),


### PR DESCRIPTION
Issue: #197 

Hopefully this should enable choosing to view skylines/bounding boxes etc, and also not override to show the DEBUG menu and then save over a local workspace, cutting it off from debug builds.

Additional functionality:

- New Command: "Toggle Debug Options" which will toggle visibility of all the following in one action: **Skylines/Bounding Boxes/Segment Shapes/Broken measures**, and by proxy will enable the **tick as integer in status bar**. I kind of wouldn't mind having a Toolbar icon to toggle this all...

- Manifest the final MIDI Velocity of a notehead when selecting it (or even more fun, while hovering over it):

<img width="815" height="608" alt="image" src="https://github.com/user-attachments/assets/50c93e91-f0ca-4e90-9bcc-aa20c8db3e22" />

- Include the **tick as an integer into the Status Bar** _iff_ skylines are visible/enabled. Possibly useful when working for example with the sequencer code because it deals not so much in Fractions but rather integer ticks.