### PR TITLE
Solfeggio update + Command to cycle notehead type

### DIFF
--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -461,7 +461,7 @@ SymId Note::noteHead(int direction, NoteHead::Group group, NoteHead::Type t)
       return noteHeads[direction][int(group)][int(t)];
       }
 
-SymId Note::noteHead(int direction, NoteHead::Group group, NoteHead::Type t, int tpc, Key key, NoteHead::Scheme scheme)
+SymId Note::noteHead(int direction, NoteHead::Group group, NoteHead::Type t, NoteHead::Scheme scheme, int tpc, Key key, KeyMode mode)
       {
       // shortcut
       if (scheme == NoteHead::Scheme::HEAD_NORMAL)
@@ -577,42 +577,44 @@ SymId Note::noteHead(int direction, NoteHead::Group group, NoteHead::Type t, int
                   }
             }
       else if (scheme == NoteHead::Scheme::HEAD_SOLFEGE) {
+            // Moveable Do
+            using NG = NoteHead::Group;
+            AccidentalVal acci = static_cast<AccidentalVal>(tpc2alterByKey(tpc, key));
             int degree = tpc2degree(tpc, key);
-            int alteration = tpc2alterByKey(tpc, key);
-            if (degree == 0 && alteration == 0)
-                group = NoteHead::Group::HEAD_DO_NAME;
-            else if (degree == 0 && alteration == 1)
-                group = NoteHead::Group::HEAD_DI_NAME;
-            else if (degree == 1 && alteration == -1)
-                group = NoteHead::Group::HEAD_RA_NAME;
-            else if (degree == 1 && alteration == 0)
-                group = NoteHead::Group::HEAD_RE_NAME;
-            else if (degree == 1 && alteration == 1)
-                group = NoteHead::Group::HEAD_RI_NAME;
-            else if (degree == 2 && alteration == -1)
-                group = NoteHead::Group::HEAD_ME_NAME;
-            else if (degree == 2 && alteration == 0)
-                group = NoteHead::Group::HEAD_MI_NAME;
-            else if (degree == 3 && alteration == 0)
-                group = NoteHead::Group::HEAD_FA_NAME;
-            else if (degree == 3 && alteration == 1)
-                group = NoteHead::Group::HEAD_FI_NAME;
-            else if (degree == 4 && alteration == -1)
-                group = NoteHead::Group::HEAD_SE_NAME;
-            else if (degree == 4 && alteration == 0)
-                group = NoteHead::Group::HEAD_SOL_NAME;
-            else if (degree == 4 && alteration == 1)
-                group = NoteHead::Group::HEAD_SI_NAME;
-            else if (degree == 5 && alteration == -1)
-                group = NoteHead::Group::HEAD_LE_NAME;
-            else if (degree == 5 && alteration == 0)
-                group = NoteHead::Group::HEAD_LA_NAME;
-            else if (degree == 5 && alteration == 1)
-                group = NoteHead::Group::HEAD_LI_NAME;
-            else if (degree == 6 && alteration == -1)
-                group = NoteHead::Group::HEAD_TE_NAME;
-            else if (degree == 6 && alteration == 0)
-                group = NoteHead::Group::HEAD_TI_NAME;
+            const bool natural = (acci == AccidentalVal::NATURAL);
+            const bool sharp = (acci >= AccidentalVal::SHARP);
+            if(0){}
+            else if (mode == KeyMode::LOCRIAN)
+                  degree += 1;
+            else if (mode == KeyMode::AEOLIAN || mode == KeyMode::MINOR)
+                  degree += 2;
+            else if (mode == KeyMode::MIXOLYDIAN)
+                  degree += 3;
+            else if (mode == KeyMode::LYDIAN)
+                  degree += 4;
+            else if (mode == KeyMode::PHRYGIAN)
+                  degree += 5;
+            else if (mode == KeyMode::DORIAN)
+                  degree += 6;
+
+            const int maxDegree = 7;
+            degree = 1 + (degree % maxDegree);
+
+            // Double/Triple alterations will also result in Solfege note unlike 3.6.2
+            switch (degree) {
+            case 1:  group = sharp   ? NG::HEAD_DI_NAME : NG::HEAD_DO_NAME;                                 break;
+            case 2:  group = sharp   ? NG::HEAD_RI_NAME : natural ? NG::HEAD_RE_NAME  : NG::HEAD_RA_NAME;   break;
+            case 3:  group = natural ? NG::HEAD_MI_NAME : NG::HEAD_ME_NAME;                                 break;
+            case 4:  group = sharp   ? NG::HEAD_FI_NAME : NG::HEAD_FA_NAME;                                 break;
+            case 5:  group = sharp   ? NG::HEAD_SI_NAME : natural ? NG::HEAD_SOL_NAME : NG::HEAD_SE_NAME;   break;
+            case 6:  group = sharp   ? NG::HEAD_LI_NAME : natural ? NG::HEAD_LA_NAME  : NG::HEAD_LE_NAME;   break;
+            case 7:  group = natural ? NG::HEAD_TI_NAME : NG::HEAD_TE_NAME;                                 break;
+            default:
+                  group = NG::HEAD_C;
+                  break;
+                  }
+
+            return noteHeads[direction][int(group)][int(t)];
             }
       else if (scheme == NoteHead::Scheme::HEAD_SOLFEGE_FIXED) {
             QString stepName = tpc2stepName(tpc);
@@ -978,18 +980,22 @@ SymId Note::noteHead() const
             }
 
       Key key = Key::C;
+      KeyMode mode = KeyMode::UNKNOWN;
       NoteHead::Scheme scheme = _headScheme;
       if (st) {
             Fraction tick = chord()->tick();
             if (tick >= Fraction(0,1)) {
-                  key    = st->key(tick);
+                  key = st->key(tick);
+                  auto kse = st->keySigEvent(tick);
+                  mode = kse.mode();
                   if (scheme == NoteHead::Scheme::HEAD_AUTO)
                         scheme = st->staffTypeForElement(chord())->noteHeadScheme();
                   }
             }
       if (scheme == NoteHead::Scheme::HEAD_AUTO)
             scheme = NoteHead::Scheme::HEAD_NORMAL;
-      SymId t = noteHead(up, headGroup, ht, tpc(), key, scheme);
+
+      SymId t = noteHead(up, headGroup, ht, scheme, tpc(), key, mode);
       if (t == SymId::noSym) {
             qDebug("invalid notehead %d/%d", int(headGroup), int(ht));
             t = noteHead(up, NoteHead::Group::HEAD_NORMAL, ht);

--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -3241,6 +3241,16 @@ void Note::setHeadType(NoteHead::Type t)
       }
 
 //---------------------------------------------------------
+//   headSchemeHasAlphaNumerics
+//---------------------------------------------------------
+
+bool Note::headSchemeHasAlphaNumerics() const
+      {
+      return _headScheme > NoteHead::Scheme::HEAD_NORMAL &&
+             _headScheme < NoteHead::Scheme::HEAD_SHAPE_NOTE_4;
+      }
+
+//---------------------------------------------------------
 //   setOnTimeOffset
 //---------------------------------------------------------
 

--- a/libmscore/note.h
+++ b/libmscore/note.h
@@ -537,7 +537,7 @@ class Note final : public Element {
       void addParentheses();
 
       SymId noteHead() const;
-      static SymId noteHead(int direction, NoteHead::Group, NoteHead::Type, int tpc, Key key, NoteHead::Scheme scheme);
+      static SymId noteHead(int direction, NoteHead::Group, NoteHead::Type, NoteHead::Scheme scheme, int tpc, Key key,  KeyMode mode=KeyMode::MAJOR);
       static SymId noteHead(int direction, NoteHead::Group, NoteHead::Type);
       NoteVal noteVal() const;
 

--- a/libmscore/note.h
+++ b/libmscore/note.h
@@ -371,6 +371,7 @@ class Note final : public Element {
       void setHeadScheme(NoteHead::Scheme val);
       void setHeadGroup(NoteHead::Group val);
       void setHeadType(NoteHead::Type t);
+      bool headSchemeHasAlphaNumerics() const;
 
       int subtype() const override { return int(_headGroup); }
       QString subtypeName() const override;

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -7443,6 +7443,23 @@ void MuseScore::cmd(QAction* a, const QString& cmd)
                   cs->update();
                   }
             }
+      else if (cmd == "cycle-head-scheme") {
+            if (cs) {
+                  using NHS = NoteHead::Scheme;
+                  for (auto n : cs->selection().noteList()) {
+                        const auto scheme = n->headScheme();
+                        const auto beginScheme = NHS::HEAD_NORMAL;
+                        const auto endScheme = NHS::HEAD_SOLFEGE;
+                        const bool isBegin = (scheme <= beginScheme);
+                        const bool isPitch = (scheme == NHS::HEAD_PITCHNAME);
+                        // Normal → Pitch → Solfeggio (Movable):
+                        const auto next = isBegin ? NHS::HEAD_PITCHNAME : isPitch ? endScheme : beginScheme;
+                        n->setHeadScheme(next);
+                        }
+                  cs->setLayoutAll();
+                  cs->update();
+                  }
+            }
       else if (cmd == "show-system-bounding-rect") {
             MScore::showSystemBoundingRect = a->isChecked();
             if (cs) {

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -1745,6 +1745,25 @@ void ScoreView::drawElements(QPainter& painter, QList<Element*>& el, Element* ed
                   }
             }
 
+      // Always draw noteheads with information inside them (Solfegge/Pitch) on top of ledger/staff lines
+      if (MScore::noteheadsBehindStaff || MScore::noteheadsBehindLedger) {
+            for (const Element* e : el) {
+                  e->itemDiscovered = 0;
+                  if (!e->isNote())
+                        continue;
+                  if (!e->visible() && (score()->printing() || !score()->showInvisible()))
+                        continue;
+
+                  if (!(toNote(e)->headSchemeHasAlphaNumerics()))
+                        continue;
+
+                  QPointF pos(e->pagePos());
+                  painter.translate(pos);
+                  e->draw(&painter);
+                  painter.translate(-pos);
+            }
+      }
+
       if (haveHover && !hoverUnder) {
             if (state != ViewState::LASSO) {
                   drawHoverHighlight(painter, *dropTarget);

--- a/mscore/shortcut.cpp
+++ b/mscore/shortcut.cpp
@@ -3749,6 +3749,16 @@ Shortcut Shortcut::_sc[] = {
       {
          MsWidget::MAIN_WINDOW,
          STATE_NORMAL | STATE_NOTE_ENTRY,
+         "cycle-head-scheme",
+         QT_TRANSLATE_NOOP("action","Cycle through some common head-schemes"),
+         QT_TRANSLATE_NOOP("action","Cycle through some common head-schemes"),
+         0,
+         Icons::Invalid_ICON,
+         Qt::WindowShortcut,
+         },
+      {
+         MsWidget::MAIN_WINDOW,
+         STATE_NORMAL | STATE_NOTE_ENTRY,
          "toggle-visible-en-passant",
          QT_TRANSLATE_NOOP("action","Toggle Visibility Attribute of all En Passant Text Lines"),
          QT_TRANSLATE_NOOP("action","Toggle Visibility Attribute of all En Passant Text Lines"),


### PR DESCRIPTION
Resolves: #196 

- Consider mode when using Solfeggio noteheads: Movable do can move within the mode of the key-signature

- New Command to cycle between Normal/Movable Solfeggio/Pitch of noteheads (range selection works)

- Force noteheads with information in them (pitch/solfegge) to be above staff/ledger lines. This personal project has the adv. pref option to do otherwise, but it doesn't make sense for these types of noteheads