### PR TITLE
Update "second pass layout" (stemming from cross-staff elements) + Provide Search by Tick

### DIFF
--- a/global/settings/types/preferencekeys.h
+++ b/global/settings/types/preferencekeys.h
@@ -130,6 +130,7 @@
 #define PREF_SCORE_HOVER_COLOR                              "ui/score/mouse/behavior/hoverColor"
 #define PREF_SCORE_HOVER_COLOR_ENABLE                       "ui/score/mouse/behavior/hoverEnabled"
 #define PREF_SCORE_NOTE_INPUT_DISABLE_MOUSE_INPUT           "ui/score/noteEntry/disableMouseEntry"
+#define PREF_SCORE_PRERENDER_MIDI_ON_LOAD                   "ui/score/onScoreLoad/preRenderMIDI"
 #define PREF_UI_SCORE_DISABLE_NOTE_DRAG_VERTICAL            "ui/score/mouse/behavior/disableNoteDragVertical"
 #define PREF_UI_SCORE_LASSO_WITHOUT_SHIFT                   "ui/score/mouse/behavior/enableLassoWithoutShift"
 #define PREF_UI_SCORE_LASSO_ANNOTATIONS                     "ui/score/mouse/behavior/lasso/annotations"

--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -314,27 +314,39 @@ void CmdState::dump()
 
 void Score::update(bool resetCmdState)
       {
+      bool layoutEntirePage = false;
       bool updateAll = false;
       for (MasterScore* ms : *movements()) {
             CmdState& cs = ms->cmdState();
+            Fraction layoutStart = cs.startTick();
+            Fraction layoutEnd = cs.endTick();
+
+            if (auto singleElement = cs.element()) {
+                  if (singleElement->isFingering() ||
+                      singleElement->isArticulation()) {
+                        layoutEntirePage = true;
+                        }
+                  }
+
             ms->deletePostponed();
             if (!printing()) {
                   if (cs.layoutRange()) {
-                        for (Score*& s : ms->scoreList()) {
-                              auto layoutStart = cs.startTick();
-                              auto layoutEnd = cs.endTick();
-                              const bool fullPageLayout = true;
-                              if (fullPageLayout) {
+                        for (Score*& s : ms->scoreList()) {         
+                              if (layoutEntirePage) {
+                                    bool foundStartPageOfLayout = false;
                                     for (auto page : s->pages()) {
-                                          if (page->startTick() > cs.startTick())
+                                          auto pageStart = page->startTick();
+                                          auto pageEnd   = page->endTick();
+                                          if (pageEnd < layoutStart)
                                                 continue;
-                                          layoutStart = page->startTick();
-                                          break;
-                                          }
-                                    for (auto page : s->pages()) {
-                                          if (page->endTick() < cs.endTick())
+                                          else if (!foundStartPageOfLayout) {
+                                                layoutStart = pageStart;
+                                                foundStartPageOfLayout = true;
+                                                }
+                                          else if (layoutEnd > pageEnd)
                                                 continue;
-                                          layoutEnd = page->endTick();
+
+                                          layoutEnd = pageEnd;
                                           break;
                                           }
                                     }

--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -5404,7 +5404,9 @@ void LayoutContext::collectPage()
             }
 
       Fraction stick = Fraction(-1,1);
-      for (System* s : qAsConst(page->systems())) {
+      const auto& systems = page->systems();
+      for (auto s : systems) {
+            bool doSecondLayout = false;
             Score* currentScore = s->score();
             for (MeasureBase* mb : s->measures()) {
                   if (!mb->isMeasure())
@@ -5423,10 +5425,12 @@ void LayoutContext::collectPage()
                                           continue;
                                     ChordRest* cr = toChordRest(e);
                                     if (notTopBeam(cr)) {
+                                          doSecondLayout = true;
                                           // layout cross staff beams
                                           cr->beam()->layout();
                                           }
                                     if (notTopTuplet(cr)) {
+                                          doSecondLayout = true;
                                           // fix layout of tuplets
                                           DurationElement* de = cr;
                                           while (de->tuplet() && de->tuplet()->elements().front() == de) {
@@ -5438,6 +5442,8 @@ void LayoutContext::collectPage()
 
                                     if (cr->isChord()) {
                                           Chord* c = toChord(cr);
+                                          if (c->staffMove())
+                                                doSecondLayout = true;
                                           for (Chord* cc : qAsConst(c->graceNotes())) {
                                                 if (cc->beam() && cc->beam()->elements().front() == cc)
                                                       cc->beam()->layout();
@@ -5453,8 +5459,10 @@ void LayoutContext::collectPage()
                                                 Tremolo* t = c->tremolo();
                                                 Chord* c1 = t->chord1();
                                                 Chord* c2 = t->chord2();
-                                                if (t->twoNotes() && c1 && c2 && (c1->staffMove() || c2->staffMove()))
+                                                if (t->twoNotes() && c1 && c2 && (c1->staffMove() || c2->staffMove())) {
+                                                      doSecondLayout = true;
                                                       t->layout();
+                                                      }
                                                 }
                                           // Layout articulations / fingerings wuz here
                                           }
@@ -5467,7 +5475,9 @@ void LayoutContext::collectPage()
                   }
 
             // Re-layout entire system to correct articulation/fingering layout after cross-beams updating
-            currentScore->layoutSystemElements(s, *this);
+            if (doSecondLayout) {
+                  currentScore->layoutSystemElements(s, *this);
+                  }
             }
 
       // If this is the last page we layout, we must also relayout the first barlines of the

--- a/libmscore/spanner.cpp
+++ b/libmscore/spanner.cpp
@@ -1129,7 +1129,13 @@ void Spanner::setTick(const Fraction& v)
 
 void Spanner::setTick2(const Fraction& f)
       {
-      setTicks(f - _tick);
+      Fraction ticks { f - _tick };
+      if (!ticks.positive()) {
+            qDebug() << accessibleInfo() << "has negative ticks:" << ticks.print() << "from start:" << _tick.print() << "end:" << f.print();
+            ticks = -ticks;
+            }
+
+      setTicks(ticks);
       }
 
 //---------------------------------------------------------

--- a/libmscore/system.cpp
+++ b/libmscore/system.cpp
@@ -1080,8 +1080,9 @@ void System::add(Element* el)
                   {
                   SpannerSegment* ss = toSpannerSegment(el);
 #ifndef NDEBUG
-                  if (_spannerSegments.contains(ss))
-                        qDebug("System::add() %s %p already there", ss->name(), ss);
+                  if (_spannerSegments.contains(ss)) {
+                        // qDebug("System::add() %s %p already there", ss->name(), ss);
+                        }
                   else
 #endif
                   _spannerSegments.append(ss);

--- a/libmscore/tuplet.cpp
+++ b/libmscore/tuplet.cpp
@@ -983,7 +983,7 @@ void Tuplet::add(Element* e)
 #ifndef NDEBUG
       for(DurationElement* el : _elements) {
             if (el == e) {
-                  qDebug("%p: %p %s already there", this, e, e->name());
+                  // qDebug("%p: %p %s already there", this, e, e->name());
                   return;
                   }
             }

--- a/mscore/file.cpp
+++ b/mscore/file.cpp
@@ -434,7 +434,9 @@ Score* MuseScore::openScore(const QString& fn, bool switchTab, const bool consid
                   }
 
             EventMap events;
-            score->renderMidi(&events, synthesizerState());
+
+            if (preferences.getBool(PREF_SCORE_PRERENDER_MIDI_ON_LOAD))
+                  score->renderMidi(&events, synthesizerState());
             }
       return score;
       }

--- a/mscore/file.cpp
+++ b/mscore/file.cpp
@@ -2549,7 +2549,8 @@ Score::FileError readScore(MasterScore* score, QString name, bool ignoreVersionE
       score->updateChannel();
       score->updateExpressive(MuseScore::synthesizer("Fluid"));
       score->setSaved(false);
-      score->update();
+      // TEST: Omit updating here since MuseScore::openScore() performs full layout after this
+      // score->update();
       score->styleChanged();
 
       if (!ignoreVersionError && !MScore::noGui)

--- a/mscore/preferences.cpp
+++ b/mscore/preferences.cpp
@@ -231,6 +231,7 @@ void Preferences::init(bool storeInMemoryOnly)
             {PREF_SCORE_NOTE_DEFAULTPLAYDURATION,                  new IntPreference(300 /* ms */, false)},
             {PREF_SCORE_NOTE_WARNPITCHRANGE,                       new BoolPreference(true, false)},
             {PREF_SCORE_NOTE_INPUT_DISABLE_MOUSE_INPUT,            new BoolPreference(false, true)},
+            {PREF_SCORE_PRERENDER_MIDI_ON_LOAD,                    new BoolPreference(true, true)},
             {PREF_UI_SCORE_FADE_FOCUS,                             new BoolPreference(false, true)},
             {PREF_UI_SCORE_CURRENT_SYS_ON_TOP,                     new BoolPreference(false, true)},
             {PREF_UI_SCORE_CURRENT_SYS_ON_TOP_SKYLINE,             new BoolPreference(false, true)},

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -7826,6 +7826,27 @@ bool ScoreView::searchMeasure(int n)
       }
 
 //---------------------------------------------------------
+//   searchTick
+//---------------------------------------------------------
+
+bool ScoreView::searchTick(Fraction t)
+      {
+      bool rv = true;
+      Measure* m = nullptr;
+      for (m = _score->firstMeasureMM(); m; m = m->nextMeasureMM()) {
+            if (t > m->tick())
+                  continue;
+            break;
+            }
+      if (!m) {
+            m = score()->lastMeasureMM();
+            rv = false;
+            }
+      gotoMeasure(m);
+      return rv;
+      }
+
+//---------------------------------------------------------
 //   searchRehearsalMark
 //---------------------------------------------------------
 

--- a/mscore/scoreview.h
+++ b/mscore/scoreview.h
@@ -495,6 +495,7 @@ class ScoreView : public QWidget, public MuseScoreView {
       QRectF canvasViewport() const { return toLogical(geometry()); }
 
       bool searchMeasure(int i);
+      bool searchTick(Fraction);
       bool searchPage(int i);
       bool searchRehearsalMark(const QString& s);
       void gotoMeasure(Measure*);

--- a/mscore/searchComboBox.cpp
+++ b/mscore/searchComboBox.cpp
@@ -47,7 +47,7 @@ void SearchComboBox::performSearch()
       if (s.isEmpty())
             return;
       ScoreView* cv = mscore->currentScoreView();
-      if (cv == 0)
+      if (!cv)
             return;
 
       bool ok;
@@ -65,8 +65,22 @@ void SearchComboBox::performSearch()
                         _found = cv->searchPage(n);
                         }
                   }
+            else {
+                  QStringList parts = s.split('/');
+                  if (parts.size() == 2) {
+                        bool okNumerator = false;
+                        bool okDenominator = false;
+                        int numerator = parts[0].trimmed().toInt(&okNumerator);
+                        int denominator = parts[1].trimmed().toInt(&okDenominator);
+                        if (okNumerator && okDenominator) {
+                              setSearchType(SearchType::SEARCH_TICK);
+                              Fraction tick { numerator, denominator };
+                              _found = cv->searchTick(tick);
+                              }
+                        }
+                  }
 
-            if (searchType() != SearchType::SEARCH_PAGE) {
+            if (searchType() != SearchType::SEARCH_PAGE && searchType() != SearchType::SEARCH_TICK) {
                   setSearchType(SearchType::SEARCH_REHEARSAL_MARK);
                   if (s.size() >= 2 && s[0].toLower() == 'r' && s[1].isNumber())
                         _found = cv->searchRehearsalMark(s.mid(1));

--- a/mscore/searchComboBox.h
+++ b/mscore/searchComboBox.h
@@ -11,6 +11,7 @@ public:
             SEARCH_MEASURE,
             SEARCH_PAGE,
             SEARCH_REHEARSAL_MARK,
+            SEARCH_TICK,
             NO_SEARCH
             };
 private:


### PR DESCRIPTION
+ Provide Search by Tick (type a fraction into search text)

https://github.com/user-attachments/assets/9050dccc-6c6f-46d1-82c8-6075850116b0

+ Made Pre-Render Midi (on score load) be contingent upon a preference: `ui/score/onScoreLoad/preRenderMIDI` since it can slow down score loading (especially large scores)
+ Found double score-layout when doing load (noticeable time difference on large score)
<img width="1732" height="349" alt="image" src="https://github.com/user-attachments/assets/97cf5ef7-dad0-46a1-81f9-a01f189bf6f0" />
Not 100% sure it's okay, but it seems fine to me so far.

+ Selectively perform full page layout per edit rather than indiscriminately as was done recently
+ Selectively perform second-pass layout (for cross-staff elements) only if a system has cross-staff elements)

Another PR  will provide a set of Progress Bars for rendering MIDI, since it can be canceled easily, making it easy to keep the preference on but then on large scores shut it down. Will also do something similar for score-loading to see progress and saving...


