### PR TITLE
Text and Vertical Frames now have attribute: "Bind to next system"

### DIFF
--- a/libmscore/box.cpp
+++ b/libmscore/box.cpp
@@ -228,12 +228,24 @@ void Box::write(XmlWriter& xml) const
 
 void Box::writeProperties(XmlWriter& xml) const
       {
-      for (Pid id : {
-         Pid::BOX_HEIGHT, Pid::BOX_WIDTH, Pid::TOP_GAP, Pid::BOTTOM_GAP,
-         Pid::LEFT_MARGIN, Pid::RIGHT_MARGIN, Pid::TOP_MARGIN, Pid::BOTTOM_MARGIN, Pid::BOX_AUTOSIZE }) {
+      const auto boxIds = {
+            Pid::BOX_HEIGHT,
+            Pid::BOX_WIDTH,
+            Pid::TOP_GAP,
+            Pid::BOTTOM_GAP,
+            Pid::LEFT_MARGIN,
+            Pid::RIGHT_MARGIN,
+            Pid::TOP_MARGIN,
+            Pid::BOTTOM_MARGIN,
+            Pid::BOX_AUTOSIZE,
+            Pid::BIND_TO_NEXT_SYSTEM,
+            };
+
+      for (Pid id : boxIds)
             writeProperty(xml, id);
-            }
+
       Element::writeProperties(xml);
+
       for (const Element* e : el())
             e->write(xml);
       }
@@ -286,6 +298,8 @@ bool Box::readProperties(XmlReader& e)
             _topMargin = e.readDouble();
       else if (tag == "bottomMargin")
             _bottomMargin = e.readDouble();
+      else if (tag == "bindToNextSystem")
+          _bindToNextSystem = e.readBool();
       else if (tag == "boxAutoSize")
             _isAutoSizeEnabled = e.readBool();
       else if (tag == "Text") {
@@ -385,6 +399,8 @@ QVariant Box::getProperty(Pid propertyId) const
                   return _topMargin;
             case Pid::BOTTOM_MARGIN:
                   return _bottomMargin;
+            case Pid::BIND_TO_NEXT_SYSTEM:
+                  return _bindToNextSystem;
             case Pid::BOX_AUTOSIZE:
                   return (score()->mscVersion() >= 302) ? _isAutoSizeEnabled : false;
             default:
@@ -424,6 +440,9 @@ bool Box::setProperty(Pid propertyId, const QVariant& v)
             case Pid::BOTTOM_MARGIN:
                   _bottomMargin = v.toDouble();
                   break;
+            case Pid::BIND_TO_NEXT_SYSTEM:
+                  _bindToNextSystem = v.toBool();
+                  break;
             case Pid::BOX_AUTOSIZE:
                   _isAutoSizeEnabled = v.toBool();
                   break;
@@ -450,6 +469,8 @@ QVariant Box::propertyDefault(Pid id) const
             case Pid::BOTTOM_GAP:
                   return isHBox() ? 0.0 : score()->styleP(Sid::frameSystemDistance);
 
+            case Pid::BIND_TO_NEXT_SYSTEM:
+                  return false;
             case Pid::LEFT_MARGIN:
             case Pid::RIGHT_MARGIN:
             case Pid::TOP_MARGIN:
@@ -478,6 +499,7 @@ void Box::copyValues(Box* origin)
       _topMargin    = origin->topMargin() * factor;
       _leftMargin   = origin->leftMargin() * factor;
       _rightMargin  = origin->rightMargin() * factor;
+      _bindToNextSystem = origin->bindToNextSystem();
       }
 
 //---------------------------------------------------------

--- a/libmscore/box.h
+++ b/libmscore/box.h
@@ -41,6 +41,7 @@ class Box : public MeasureBase {
       qreal _rightMargin            { 0.0   };       // inner margins in metric mm
       qreal _topMargin              { 0.0   };
       qreal _bottomMargin           { 0.0   };
+      bool _bindToNextSystem        { false };
       bool _isAutoSizeEnabled       { true  };
       bool editMode                 { false };
 
@@ -82,6 +83,8 @@ class Box : public MeasureBase {
       void setTopGap(qreal val)       { _topGap = val;        }
       qreal bottomGap() const         { return _bottomGap;    }
       void setBottomGap(qreal val)    { _bottomGap = val;     }
+      bool bindToNextSystem() const   { return _bindToNextSystem; }
+      void setBindToNextSystem(bool v) { _bindToNextSystem = v; }
       bool isAutoSizeEnabled() const  { return _isAutoSizeEnabled; }
       void setAutoSizeEnabled(const bool val) { _isAutoSizeEnabled = val; }
       void copyValues(Box* origin);

--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -5315,6 +5315,16 @@ void LayoutContext::collectPage()
       // re-calculate positions for systems before current
       // (they may have been filled on previous layout)
       int pSystems = page->systems().size();
+      if (deferredGroup.active()) {
+            deferredGroup.previousSystem = nullptr;
+            prevSystem = nullptr;
+
+            while (page->systems().size())
+                  page->popSystem();
+
+            pSystems = page->systems().size();
+            }
+
       if (pSystems > 0) {
             page->system(0)->restoreLayout2();
             y = page->system(0)->y() + page->system(0)->height();
@@ -5359,7 +5369,7 @@ void LayoutContext::collectPage()
                   distance = prevSystem->minDistance(curSystem);
             else {
                   // this is the first system on page
-                  if (curSystem->vbox()) {
+                  if (deferredGroup.active() || curSystem->vbox()) {
                         // if the header exists and there is a frame, move the frame downwards
                         // to avoid collisions
                         distance = headerExtension ? headerExtension + headerFooterPadding : 0.0;
@@ -5391,13 +5401,79 @@ void LayoutContext::collectPage()
                               distance = qMax(distance, top);
                               }
                         }
+                  if (deferredGroup.active()) {
+                        deferredGroup.startY = y;
+                        deferredGroup.startDistance = distance;
+                        deferredGroup.previousSystem = nullptr;
+                        }
                   }
 
+            Box* const box = curSystem->vbox();
+            const bool special = box && box->bindToNextSystem();
+
+            if (special && !deferredGroup.active())
+                  deferredGroup.saveState(this, box, y, distance);
+
             y += distance;
+
             curSystem->setPos(page->lm(), y);
             curSystem->restoreLayout2();
-            page->appendSystem(curSystem);
-            y += curSystem->height();
+
+            if (deferredGroup.active()) {
+                  deferredGroup.systems.push_back(curSystem);
+
+                  if (deferredGroup.remainingBoxes) {
+                        if (--deferredGroup.remainingBoxes == 0) {
+                              deferredGroup.waitingForTerminator = true;
+                              }
+                        }
+                  else if (deferredGroup.waitingForTerminator) {
+                        deferredGroup.waitingForTerminator = false;
+
+                        qreal required  = deferredGroup.startY;
+                              required += deferredGroup.startDistance;
+                              required += deferredGroup.extent();
+                              required += footerExtension > 0 ? footerExtension : 0;
+
+                        System* last = deferredGroup.systems.back();
+
+                        qreal margin = std::max(last->minBottom(),
+                                                last->spacerDistance(false));
+
+                              margin += (footerExtension > 0)
+                                          ? (footerExtension + headerFooterPadding)
+                                          : 0;
+
+                        required += std::max(margin, slb);
+
+                        const bool shouldDefer =
+                              (required >= endY) && breakPages;
+
+                        if (shouldDefer)
+                              deferredGroupBreak = true;
+                        else {
+                              y = deferredGroup.commitToPage(this);
+                              deferredGroup.clear();
+                              }
+                        }
+                  }
+            else {
+                  page->appendSystem(curSystem);
+                  y += curSystem->height();
+                  }
+
+            if (deferredGroupBreak) {
+                  pageOldMeasure = nullptr;
+
+                  y = deferredGroup.restoreState(this);
+
+                  if (!page->systems().empty())
+                        layoutPage(page, endY - y, footerExtension > 0 ? footerExtension + headerFooterPadding : 0.0);
+
+                  deferredGroup.clear();
+                  deferredGroupBreak = false;
+                  break;
+                  }
 
             //
             //  check for page break or if next system will fit on page
@@ -5457,12 +5533,12 @@ void LayoutContext::collectPage()
                               }
                         }
                   }
+
             prevSystem = curSystem;
             Q_ASSERT(curSystem != nextSystem);
             curSystem  = nextSystem;
 
             bool breakPage = !curSystem || (breakPages && prevSystem->pageBreak());
-
             if (!breakPage) {
                   qreal dist = prevSystem->minDistance(curSystem) + curSystem->height();
                   Box* vbox = curSystem->vbox();
@@ -5493,6 +5569,7 @@ void LayoutContext::collectPage()
                   // we need to collect next page in order to correctly set system positions
                   if (collected)
                         pageOldMeasure = nullptr;
+
                   break;
                   }
             }
@@ -5874,6 +5951,23 @@ LayoutContext::~LayoutContext()
 
       for (MuseScoreView* v : score->getViewer())
             v->layoutChanged();
+      }
+
+//---------------------------------------------------------
+//   LayoutContext::DeferredGroup::extent()
+//---------------------------------------------------------
+
+qreal LayoutContext::DeferredGroup::extent() const
+      {
+      qreal total = 0.0;
+
+      for (int i = 0; i < systems.size(); ++i) {
+            total += systems[i]->height();
+            if (i)
+                  total += systems[i - 1]->minDistance(systems[i]);
+            }
+
+      return total;
       }
 
 //---------------------------------------------------------

--- a/libmscore/layout.h
+++ b/libmscore/layout.h
@@ -14,6 +14,8 @@
 #define __LAYOUT_H__
 
 #include "system.h"
+#include "page.h"
+#include "box.h"
 
 namespace Ms {
 
@@ -102,6 +104,110 @@ struct LayoutContext {
       int measureNo            { 0 };
       Fraction startTick;
       Fraction endTick;
+
+      // Vertical/Text Box chaining:
+      struct DeferredGroup {
+            qreal startY = 0.0;
+            qreal startDistance = 0.0;
+            unsigned remainingBoxes = 0;
+            unsigned pageSystemCount = 0;
+            bool waitingForTerminator = false;
+            QVector<System*> systems;
+            Page* startPage = nullptr;
+            System* restartSystem = nullptr;
+            System* previousSystem = nullptr;
+            MeasureBase* restartPrevMeasure = nullptr;
+            MeasureBase* restartCurMeasure  = nullptr;
+            MeasureBase* restartNextMeasure = nullptr;
+            Fraction restartTick;
+            int restartMeasureNo;
+            bool restartRangeDone;
+
+            void saveState(LayoutContext* lc, MeasureBase* startingVBox, qreal y, qreal distance) {
+                  restartSystem      = lc->curSystem;
+                  previousSystem     = lc->prevSystem;
+                  restartPrevMeasure = lc->prevMeasure;
+                  restartCurMeasure  = lc->curMeasure;
+                  restartNextMeasure = lc->nextMeasure;
+                  restartTick        = lc->tick;
+                  restartMeasureNo   = lc->measureNo;
+                  restartRangeDone   = lc->rangeDone;
+                  pageSystemCount    = lc->page->systems().size();
+                  startPage          = lc->page;
+                  startY             = y;
+                  startDistance      = distance;
+
+                  const MeasureBase* mb = startingVBox;
+                  remainingBoxes = 1;
+                  while (true) {
+                        mb = mb->next();
+                        if (!mb || !mb->isVBoxBase())
+                              break;
+                        const Box* const nextBox = toBox(mb);
+                        if (!nextBox->bindToNextSystem())
+                              break;
+                        ++remainingBoxes;
+                        }
+                  }
+
+            qreal restoreState(LayoutContext* lc) {
+                  lc->prevSystem  = previousSystem;
+                  lc->curSystem   = restartSystem;
+                  lc->prevMeasure = restartPrevMeasure;
+                  lc->curMeasure  = restartCurMeasure;
+                  lc->nextMeasure = restartNextMeasure;
+                  lc->tick        = restartTick;
+                  lc->measureNo   = restartMeasureNo;
+                  lc->rangeDone   = restartRangeDone;
+
+                  return startY;
+                  }
+
+            qreal commitToPage(LayoutContext* lc) {
+                  qreal yy = startY;
+                  const System* prev = previousSystem;
+
+                  for (System* s : systems) {
+                        qreal dist = prev ? prev->minDistance(s) : startDistance;
+                        yy += dist;
+                        s->setPos(lc->page->lm(), yy);
+                        s->restoreLayout2();
+                        lc->page->appendSystem(s);
+                        yy += s->height();
+                        prev = s;
+                        }
+
+                  lc->curSystem = systems.last();
+                  lc->rangeDone = false;
+                  return yy; // return total height
+                  }
+
+            void clear() {
+                  startY = 0.0;
+                  startDistance = 0.0;
+                  remainingBoxes = 0;
+                  restartTick = {};
+                  waitingForTerminator = false;
+                  previousSystem = nullptr;
+                  restartSystem = nullptr;
+                  restartCurMeasure = nullptr;
+                  restartNextMeasure = nullptr;
+                  restartPrevMeasure = nullptr;
+                  pageSystemCount = 0;
+                  restartMeasureNo = 0;
+                  restartRangeDone = false;
+                  systems.clear();
+                  startPage = nullptr;
+                  }
+
+            bool active() const {
+                  return remainingBoxes || waitingForTerminator || !systems.empty();
+                  }
+            qreal extent() const;
+            };
+
+      DeferredGroup deferredGroup;
+      bool deferredGroupBreak = false;
 
       LayoutContext(Score* s);
       LayoutContext(const LayoutContext&) = delete;

--- a/libmscore/page.cpp
+++ b/libmscore/page.cpp
@@ -88,6 +88,18 @@ void Page::appendSystem(System* s)
       }
 
 //---------------------------------------------------------
+//   popSystem
+//---------------------------------------------------------
+
+void Page::popSystem()
+      {
+      if (!systems().isEmpty()) {
+            System* s = systems().takeLast();
+            s->setParent(nullptr);
+            }
+      }
+
+//---------------------------------------------------------
 //   draw
 //    bounding rectangle fr is relative to page QPointF
 //---------------------------------------------------------

--- a/libmscore/page.h
+++ b/libmscore/page.h
@@ -58,6 +58,7 @@ class Page final : public Element {
       void read(XmlReader&) override;
 
       void appendSystem(System* s);
+      void popSystem();
 
       int no() const                     { return _no;        }
       void setNo(int n)                  { _no = n;           }

--- a/libmscore/property.cpp
+++ b/libmscore/property.cpp
@@ -119,6 +119,7 @@ static constexpr PropertyMetaData propertyList[] = {
       { Pid::BOTTOM_MARGIN,             P_TYPE::REAL,           false, "bottomMargin",           DUMMY_QT_TRANSLATE_NOOP("propertyName", "bottom margin")                                 },
       { Pid::LAYOUT_BREAK,              P_TYPE::LAYOUT_BREAK,   false, "subtype",                DUMMY_QT_TRANSLATE_NOOP("propertyName", "subtype")                                       },
       { Pid::AUTOSCALE,                 P_TYPE::BOOL,           false, "autoScale",              DUMMY_QT_TRANSLATE_NOOP("propertyName", "autoscale")                                     },
+      { Pid::BIND_TO_NEXT_SYSTEM,       P_TYPE::BOOL,           false, "bindToNextSystem",       DUMMY_QT_TRANSLATE_NOOP("propertyName", "bind vbox to next system during layout")        },
       { Pid::SIZE,                      P_TYPE::SIZE,           false, "size",                   DUMMY_QT_TRANSLATE_NOOP("propertyName", "size")                                          },
 
       { Pid::SCALE,                     P_TYPE::SCALE,          false, "scale",                  DUMMY_QT_TRANSLATE_NOOP("propertyName", "scale")                                         },

--- a/libmscore/property.h
+++ b/libmscore/property.h
@@ -125,6 +125,7 @@ enum class Pid : short {
       BOTTOM_MARGIN,
       LAYOUT_BREAK,
       AUTOSCALE,
+      BIND_TO_NEXT_SYSTEM,
       SIZE,
 
       SCALE,

--- a/libmscore/scoreElement.h
+++ b/libmscore/scoreElement.h
@@ -470,6 +470,10 @@ static inline Box* toBox(ScoreElement* e) {
      Q_ASSERT(e == 0 || e->isBox());
       return (Box*)e;
       }
+static inline const Box* toBox(const ScoreElement* e) {
+      Q_ASSERT(e == 0 || e->isBox());
+      return (const Box*)e;
+      }
 static inline SpannerSegment* toSpannerSegment(ScoreElement* e) {
       Q_ASSERT(e == 0 || e->isSpannerSegment());
       return (SpannerSegment*)e;

--- a/mscore/inspector/inspector.cpp
+++ b/mscore/inspector/inspector.cpp
@@ -580,14 +580,15 @@ InspectorVBox::InspectorVBox(QWidget* parent)
       vb.setupUi(addWidget());
 
       iList = {
-            { Pid::TOP_GAP,       0, vb.topGap,       vb.resetTopGap       },
-            { Pid::BOTTOM_GAP,    0, vb.bottomGap,    vb.resetBottomGap    },
-            { Pid::LEFT_MARGIN,   0, vb.leftMargin,   vb.resetLeftMargin   },
-            { Pid::RIGHT_MARGIN,  0, vb.rightMargin,  vb.resetRightMargin  },
-            { Pid::TOP_MARGIN,    0, vb.topMargin,    vb.resetTopMargin    },
-            { Pid::BOTTOM_MARGIN, 0, vb.bottomMargin, vb.resetBottomMargin },
-            { Pid::BOX_HEIGHT,    0, vb.height,       0                    },
-            { Pid::BOX_AUTOSIZE,  0, vb.enableAutoSize, vb.resetAutoSize   }
+            { Pid::TOP_GAP,              0, vb.topGap,            vb.resetTopGap            },
+            { Pid::BOTTOM_GAP,           0, vb.bottomGap,         vb.resetBottomGap         },
+            { Pid::LEFT_MARGIN,          0, vb.leftMargin,        vb.resetLeftMargin        },
+            { Pid::RIGHT_MARGIN,         0, vb.rightMargin,       vb.resetRightMargin       },
+            { Pid::TOP_MARGIN,           0, vb.topMargin,         vb.resetTopMargin         },
+            { Pid::BOTTOM_MARGIN,        0, vb.bottomMargin,      vb.resetBottomMargin      },
+            { Pid::BOX_HEIGHT,           0, vb.height,            0                         },
+            { Pid::BOX_AUTOSIZE,         0, vb.enableAutoSize,    vb.resetAutoSize          },
+            { Pid::BIND_TO_NEXT_SYSTEM,  0, vb.bindToNextSystem,  vb.resetBindToNextSystem  },
             };
       pList = { { vb.title, vb.panel } };
       mapSignals();
@@ -603,12 +604,13 @@ InspectorTBox::InspectorTBox(QWidget* parent)
       tb.setupUi(addWidget());
 
       iList = {
-            { Pid::TOP_GAP,       0, tb.topGap,       tb.resetTopGap       },
-            { Pid::BOTTOM_GAP,    0, tb.bottomGap,    tb.resetBottomGap    },
-            { Pid::LEFT_MARGIN,   0, tb.leftMargin,   tb.resetLeftMargin   },
-            { Pid::RIGHT_MARGIN,  0, tb.rightMargin,  tb.resetRightMargin  },
-            { Pid::TOP_MARGIN,    0, tb.topMargin,    tb.resetTopMargin    },
-            { Pid::BOTTOM_MARGIN, 0, tb.bottomMargin, tb.resetBottomMargin },
+            { Pid::TOP_GAP,             0, tb.topGap,       tb.resetTopGap               },
+            { Pid::BOTTOM_GAP,          0, tb.bottomGap,    tb.resetBottomGap            },
+            { Pid::LEFT_MARGIN,         0, tb.leftMargin,   tb.resetLeftMargin           },
+            { Pid::RIGHT_MARGIN,        0, tb.rightMargin,  tb.resetRightMargin          },
+            { Pid::TOP_MARGIN,          0, tb.topMargin,    tb.resetTopMargin            },
+            { Pid::BOTTOM_MARGIN,       0, tb.bottomMargin, tb.resetBottomMargin         },
+            { Pid::BIND_TO_NEXT_SYSTEM, 0, tb.bindToNextSystem, tb.resetBindToNextSystem },
             };
       pList = { { tb.title, tb.panel } };
       mapSignals();

--- a/mscore/inspector/inspector_tbox.ui
+++ b/mscore/inspector/inspector_tbox.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>265</width>
-    <height>213</height>
+    <width>288</width>
+    <height>290</height>
    </rect>
   </property>
   <property name="accessibleName">
@@ -49,7 +49,6 @@
      </property>
      <property name="font">
       <font>
-       <weight>75</weight>
        <bold>true</bold>
       </font>
      </property>
@@ -76,19 +75,6 @@
       <property name="spacing">
        <number>3</number>
       </property>
-      <item row="1" column="0">
-       <widget class="QLabel" name="label_3">
-        <property name="text">
-         <string>Bottom gap:</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-        </property>
-        <property name="buddy">
-         <cstring>bottomGap</cstring>
-        </property>
-       </widget>
-      </item>
       <item row="5" column="0">
        <widget class="QLabel" name="label_6">
         <property name="text">
@@ -124,29 +110,42 @@
         </property>
        </widget>
       </item>
-      <item row="6" column="0">
-       <widget class="QLabel" name="label_7">
-        <property name="text">
-         <string>Bottom margin:</string>
+      <item row="1" column="2">
+       <widget class="Ms::ResetButton" name="resetBottomGap" native="true">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
         </property>
-        <property name="alignment">
-         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-        </property>
-        <property name="buddy">
-         <cstring>bottomMargin</cstring>
+        <property name="accessibleName">
+         <string>Reset 'Bottom gap' value</string>
         </property>
        </widget>
       </item>
-      <item row="4" column="0">
-       <widget class="QLabel" name="label_5">
+      <item row="3" column="0">
+       <widget class="QLabel" name="label_4">
         <property name="text">
-         <string>Right margin:</string>
+         <string>Left margin:</string>
         </property>
         <property name="alignment">
          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
         </property>
         <property name="buddy">
-         <cstring>rightMargin</cstring>
+         <cstring>leftMargin</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="2">
+       <widget class="Ms::ResetButton" name="resetBottomMargin" native="true">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="accessibleName">
+         <string>Reset 'Bottom margin' value</string>
         </property>
        </widget>
       </item>
@@ -160,6 +159,35 @@
         </property>
         <property name="accessibleName">
          <string>Right margin</string>
+        </property>
+        <property name="suffix">
+         <string>mm</string>
+        </property>
+        <property name="minimum">
+         <double>-10000.000000000000000</double>
+        </property>
+        <property name="maximum">
+         <double>10000.000000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0" colspan="3">
+       <widget class="Line" name="line">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="1">
+       <widget class="QDoubleSpinBox" name="topMargin">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="accessibleName">
+         <string>Top margin</string>
         </property>
         <property name="suffix">
          <string>mm</string>
@@ -194,10 +222,132 @@
         </property>
        </widget>
       </item>
-      <item row="2" column="0" colspan="3">
-       <widget class="Line" name="line">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
+      <item row="5" column="2">
+       <widget class="Ms::ResetButton" name="resetTopMargin" native="true">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="accessibleName">
+         <string>Reset 'Top margin' value</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_3">
+        <property name="text">
+         <string>Bottom gap:</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+        </property>
+        <property name="buddy">
+         <cstring>bottomGap</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_2">
+        <property name="text">
+         <string>Top gap:</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+        </property>
+        <property name="buddy">
+         <cstring>topGap</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="2">
+       <widget class="Ms::ResetButton" name="resetLeftMargin" native="true">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="accessibleName">
+         <string>Reset 'Left margin' value</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="2">
+       <widget class="Ms::ResetButton" name="resetRightMargin" native="true">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="accessibleName">
+         <string>Reset 'Right margin' value</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="2">
+       <widget class="Ms::ResetButton" name="resetTopGap" native="true">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="accessibleName">
+         <string>Reset 'Top gap' value</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QDoubleSpinBox" name="bottomGap">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="accessibleName">
+         <string>Bottom gap</string>
+        </property>
+        <property name="suffix">
+         <string extracomment="spatium unit">sp</string>
+        </property>
+        <property name="minimum">
+         <double>-10000.000000000000000</double>
+        </property>
+        <property name="maximum">
+         <double>10000.000000000000000</double>
+        </property>
+        <property name="singleStep">
+         <double>0.500000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="0">
+       <widget class="QLabel" name="label_7">
+        <property name="text">
+         <string>Bottom margin:</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+        </property>
+        <property name="buddy">
+         <cstring>bottomMargin</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0">
+       <widget class="QLabel" name="label_5">
+        <property name="text">
+         <string>Right margin:</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+        </property>
+        <property name="buddy">
+         <cstring>rightMargin</cstring>
         </property>
        </widget>
       </item>
@@ -229,156 +379,15 @@
         </property>
        </widget>
       </item>
-      <item row="0" column="0">
-       <widget class="QLabel" name="label_2">
+      <item row="7" column="0" colspan="2">
+       <widget class="QCheckBox" name="bindToNextSystem">
         <property name="text">
-         <string>Top gap:</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-        </property>
-        <property name="buddy">
-         <cstring>topGap</cstring>
+         <string>Bind to next system</string>
         </property>
        </widget>
       </item>
-      <item row="1" column="1">
-       <widget class="QDoubleSpinBox" name="bottomGap">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="accessibleName">
-         <string>Bottom gap</string>
-        </property>
-        <property name="suffix">
-         <string extracomment="spatium unit">sp</string>
-        </property>
-        <property name="minimum">
-         <double>-10000.000000000000000</double>
-        </property>
-        <property name="maximum">
-         <double>10000.000000000000000</double>
-        </property>
-        <property name="singleStep">
-         <double>0.500000000000000</double>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="0">
-       <widget class="QLabel" name="label_4">
-        <property name="text">
-         <string>Left margin:</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-        </property>
-        <property name="buddy">
-         <cstring>leftMargin</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="5" column="1">
-       <widget class="QDoubleSpinBox" name="topMargin">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="accessibleName">
-         <string>Top margin</string>
-        </property>
-        <property name="suffix">
-         <string>mm</string>
-        </property>
-        <property name="minimum">
-         <double>-10000.000000000000000</double>
-        </property>
-        <property name="maximum">
-         <double>10000.000000000000000</double>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="2">
-       <widget class="Ms::ResetButton" name="resetTopGap" native="true">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="accessibleName">
-         <string>Reset 'Top gap' value</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="2">
-       <widget class="Ms::ResetButton" name="resetBottomGap" native="true">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="accessibleName">
-         <string>Reset 'Bottom gap' value</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="2">
-       <widget class="Ms::ResetButton" name="resetLeftMargin" native="true">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="accessibleName">
-         <string>Reset 'Left margin' value</string>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="2">
-       <widget class="Ms::ResetButton" name="resetRightMargin" native="true">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="accessibleName">
-         <string>Reset 'Right margin' value</string>
-        </property>
-       </widget>
-      </item>
-      <item row="5" column="2">
-       <widget class="Ms::ResetButton" name="resetTopMargin" native="true">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="accessibleName">
-         <string>Reset 'Top margin' value</string>
-        </property>
-       </widget>
-      </item>
-      <item row="6" column="2">
-       <widget class="Ms::ResetButton" name="resetBottomMargin" native="true">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="accessibleName">
-         <string>Reset 'Bottom margin' value</string>
-        </property>
-       </widget>
+      <item row="7" column="2">
+       <widget class="Ms::ResetButton" name="resetBindToNextSystem" native="true"/>
       </item>
      </layout>
     </widget>

--- a/mscore/inspector/inspector_vbox.ui
+++ b/mscore/inspector/inspector_vbox.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>265</width>
-    <height>263</height>
+    <width>374</width>
+    <height>356</height>
    </rect>
   </property>
   <property name="accessibleName">
@@ -52,7 +52,6 @@
      </property>
      <property name="font">
       <font>
-       <weight>75</weight>
        <bold>true</bold>
       </font>
      </property>
@@ -79,29 +78,41 @@
       <property name="spacing">
        <number>3</number>
       </property>
-      <item row="5" column="0">
-       <widget class="QLabel" name="label_5">
-        <property name="text">
-         <string>Right margin:</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-        </property>
-        <property name="buddy">
-         <cstring>rightMargin</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="2">
-       <widget class="Ms::ResetButton" name="resetBottomGap" native="true">
+      <item row="1" column="1">
+       <widget class="QDoubleSpinBox" name="bottomGap">
         <property name="sizePolicy">
-         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
           <horstretch>0</horstretch>
           <verstretch>0</verstretch>
          </sizepolicy>
         </property>
         <property name="accessibleName">
-         <string>Reset 'Bottom gap' value</string>
+         <string>Bottom gap</string>
+        </property>
+        <property name="suffix">
+         <string extracomment="spatium unit">sp</string>
+        </property>
+        <property name="minimum">
+         <double>-10000.000000000000000</double>
+        </property>
+        <property name="maximum">
+         <double>10000.000000000000000</double>
+        </property>
+        <property name="singleStep">
+         <double>0.500000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_3">
+        <property name="text">
+         <string>Bottom gap:</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+        </property>
+        <property name="buddy">
+         <cstring>bottomGap</cstring>
         </property>
        </widget>
       </item>
@@ -130,101 +141,6 @@
         </property>
         <property name="singleStep">
          <double>0.500000000000000</double>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="0">
-       <widget class="QLabel" name="label_4">
-        <property name="text">
-         <string>Left margin:</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-        </property>
-        <property name="buddy">
-         <cstring>leftMargin</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QDoubleSpinBox" name="bottomGap">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="accessibleName">
-         <string>Bottom gap</string>
-        </property>
-        <property name="suffix">
-         <string extracomment="spatium unit">sp</string>
-        </property>
-        <property name="minimum">
-         <double>-10000.000000000000000</double>
-        </property>
-        <property name="maximum">
-         <double>10000.000000000000000</double>
-        </property>
-        <property name="singleStep">
-         <double>0.500000000000000</double>
-        </property>
-       </widget>
-      </item>
-      <item row="7" column="1">
-       <widget class="QDoubleSpinBox" name="bottomMargin">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="accessibleName">
-         <string>Bottom margin</string>
-        </property>
-        <property name="suffix">
-         <string>mm</string>
-        </property>
-        <property name="minimum">
-         <double>-10000.000000000000000</double>
-        </property>
-        <property name="maximum">
-         <double>10000.000000000000000</double>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="1">
-       <widget class="QDoubleSpinBox" name="height">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="accessibleName">
-         <string>Height</string>
-        </property>
-        <property name="suffix">
-         <string>sp</string>
-        </property>
-        <property name="minimum">
-         <double>-10000.000000000000000</double>
-        </property>
-        <property name="maximum">
-         <double>10000.000000000000000</double>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="2">
-       <widget class="Ms::ResetButton" name="resetLeftMargin" native="true">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="accessibleName">
-         <string>Reset 'Left margin' value</string>
         </property>
        </widget>
       </item>
@@ -272,16 +188,42 @@
         </property>
        </widget>
       </item>
-      <item row="7" column="0">
-       <widget class="QLabel" name="label_7">
+      <item row="4" column="0">
+       <widget class="QLabel" name="label_4">
         <property name="text">
-         <string>Bottom margin:</string>
+         <string>Left margin:</string>
         </property>
         <property name="alignment">
          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
         </property>
         <property name="buddy">
-         <cstring>bottomMargin</cstring>
+         <cstring>leftMargin</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="2">
+       <widget class="Ms::ResetButton" name="resetLeftMargin" native="true">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="accessibleName">
+         <string>Reset 'Left margin' value</string>
+        </property>
+       </widget>
+      </item>
+      <item row="8" column="2">
+       <widget class="Ms::ResetButton" name="resetAutoSize" native="true">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="accessibleName">
+         <string>Reset 'Auto-Size' value</string>
         </property>
        </widget>
       </item>
@@ -298,8 +240,8 @@
         </property>
        </widget>
       </item>
-      <item row="5" column="2">
-       <widget class="Ms::ResetButton" name="resetRightMargin" native="true">
+      <item row="6" column="2">
+       <widget class="Ms::ResetButton" name="resetTopMargin" native="true">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
           <horstretch>0</horstretch>
@@ -307,46 +249,20 @@
          </sizepolicy>
         </property>
         <property name="accessibleName">
-         <string>Reset 'Right margin' value</string>
+         <string>Reset 'Top margin' value</string>
         </property>
        </widget>
       </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="label">
-        <property name="text">
-         <string>Height:</string>
+      <item row="1" column="2">
+       <widget class="Ms::ResetButton" name="resetBottomGap" native="true">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
         </property>
-        <property name="alignment">
-         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-        </property>
-        <property name="buddy">
-         <cstring>height</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="label_3">
-        <property name="text">
-         <string>Bottom gap:</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-        </property>
-        <property name="buddy">
-         <cstring>bottomGap</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="6" column="0">
-       <widget class="QLabel" name="label_6">
-        <property name="text">
-         <string>Top margin:</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-        </property>
-        <property name="buddy">
-         <cstring>topMargin</cstring>
+        <property name="accessibleName">
+         <string>Reset 'Bottom gap' value</string>
         </property>
        </widget>
       </item>
@@ -372,19 +288,6 @@
         </property>
        </widget>
       </item>
-      <item row="6" column="2">
-       <widget class="Ms::ResetButton" name="resetTopMargin" native="true">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="accessibleName">
-         <string>Reset 'Top margin' value</string>
-        </property>
-       </widget>
-      </item>
       <item row="0" column="2">
        <widget class="Ms::ResetButton" name="resetTopGap" native="true">
         <property name="sizePolicy">
@@ -395,6 +298,59 @@
         </property>
         <property name="accessibleName">
          <string>Reset 'Top gap' value</string>
+        </property>
+       </widget>
+      </item>
+      <item row="8" column="0">
+       <widget class="QCheckBox" name="enableAutoSize">
+        <property name="text">
+         <string>Enable Auto-Size</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0" colspan="3">
+       <widget class="Line" name="line">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="0">
+       <widget class="QLabel" name="label_7">
+        <property name="text">
+         <string>Bottom margin:</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+        </property>
+        <property name="buddy">
+         <cstring>bottomMargin</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="2">
+       <widget class="Ms::ResetButton" name="resetRightMargin" native="true">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="accessibleName">
+         <string>Reset 'Right margin' value</string>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="0">
+       <widget class="QLabel" name="label_5">
+        <property name="text">
+         <string>Right margin:</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+        </property>
+        <property name="buddy">
+         <cstring>rightMargin</cstring>
         </property>
        </widget>
       </item>
@@ -411,32 +367,85 @@
         </property>
        </widget>
       </item>
-      <item row="3" column="0" colspan="3">
-       <widget class="Line" name="line">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-       </widget>
-      </item>
-      <item row="8" column="0">
-       <widget class="QCheckBox" name="enableAutoSize">
+      <item row="6" column="0">
+       <widget class="QLabel" name="label_6">
         <property name="text">
-         <string>Enable Auto-Size</string>
+         <string>Top margin:</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+        </property>
+        <property name="buddy">
+         <cstring>topMargin</cstring>
         </property>
        </widget>
       </item>
-      <item row="8" column="2">
-       <widget class="Ms::ResetButton" name="resetAutoSize" native="true">
+      <item row="2" column="1">
+       <widget class="QDoubleSpinBox" name="height">
         <property name="sizePolicy">
-         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
           <horstretch>0</horstretch>
           <verstretch>0</verstretch>
          </sizepolicy>
         </property>
         <property name="accessibleName">
-         <string>Reset 'Auto-Size' value</string>
+         <string>Height</string>
+        </property>
+        <property name="suffix">
+         <string>sp</string>
+        </property>
+        <property name="minimum">
+         <double>-10000.000000000000000</double>
+        </property>
+        <property name="maximum">
+         <double>10000.000000000000000</double>
         </property>
        </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="label">
+        <property name="text">
+         <string>Height:</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+        </property>
+        <property name="buddy">
+         <cstring>height</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="1">
+       <widget class="QDoubleSpinBox" name="bottomMargin">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="accessibleName">
+         <string>Bottom margin</string>
+        </property>
+        <property name="suffix">
+         <string>mm</string>
+        </property>
+        <property name="minimum">
+         <double>-10000.000000000000000</double>
+        </property>
+        <property name="maximum">
+         <double>10000.000000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="9" column="0">
+       <widget class="QCheckBox" name="bindToNextSystem">
+        <property name="text">
+         <string>Bind to next system</string>
+        </property>
+       </widget>
+      </item>
+      <item row="9" column="2">
+       <widget class="Ms::ResetButton" name="resetBindToNextSystem" native="true"/>
       </item>
      </layout>
     </widget>


### PR DESCRIPTION
This allows forcing n-systems of text frames or vertical frames to the next musical system, or just to up-to wherever there's a text/vertical frame without this attribute. It gives more dynamism to layout so that Page Breaks aren't necessary in order to have a text box or two to be the start of a new page for instance if they + the first musical system afterwards don't fit all together at the end of a page. That way, if there are some changes to the previous system, the user/I won't have to make some changes to where the page break is etc. 

<img width="1024" height="667" alt="example" src="https://github.com/user-attachments/assets/4af56b9c-6909-400f-9f81-115e22ce3cfb" />


I think it'd be nice to get going with MSS4/5 also, but they never seemed to deem this a priority, although it was mentioned on the forums throughout the past 10 years etc.

I have yet to encounter a problem with the layout mechanism, so it's probably good to go, but gotta keep an eye out for misbehavin'. I excessively stored some states but don't feel like minimizing the situation - harmless for now.

Note to self: I think it's time to start deleting the branches that have been merged. I was using ordinated numbers, whole 132 of them so far, ... many of which are "smorgasbords"