### PR TITLE
Archive Scores: enable multiple sets

### DIFF
--- a/mscore/file.cpp
+++ b/mscore/file.cpp
@@ -466,63 +466,130 @@ Score* MuseScore::openScore(const QString& fn, bool switchTab, const bool consid
 
 //---------------------------------------------------------
 //   saveOpenScoresList
+//    "archive-open-scores"
 //---------------------------------------------------------
 
-bool MuseScore::saveOpenScoresList()
+bool MuseScore::saveOpenScoresList(int selectIdx)
       {
+      (void) selectIdx;
       QDir dir;
       dir.mkpath(dataPath);
-      QFile f(dataPath + "/scorelist");
-      if (!f.open(QIODevice::WriteOnly)) {
-            qDebug("cannot create session file <%s>", qPrintable(f.fileName()));
+      QFile fileIn(dataPath + "/scorelist");
+      QFile fileOut(dataPath + "/tmpdata");
+
+      if (!fileIn.open(QIODevice::ReadOnly)) {
+            qDebug("Cannot open session file <%s>", qPrintable(fileIn.fileName()));
+            }
+
+      if (!fileOut.open(QIODevice::WriteOnly)) {
+            qDebug("cannot create session file <%s>", qPrintable(fileOut.fileName()));
             return false;
+            }      
+
+      QXmlStreamReader reader(&fileIn);
+      QXmlStreamWriter writer(&fileOut);
+
+      writer.setAutoFormatting(true);
+      writer.writeStartDocument();
+
+      if (!reader.hasError()) {
+            while (!reader.atEnd()) {
+                  reader.readNext();
+                  if (reader.isStartElement()) {
+                        /// TODO: maybe allow to update a set instead of making a new one each time:
+                        // if (reader.name() == "Archive") {
+                              // ++currentIdx;
+                              // if (currentIdx == discardIdx) {
+                              //       qDebug().nospace() << "Skipping Archive #" << currentIdx;
+                              //       reader.skipCurrentElement();   // discard this subtree
+                              //       continue;
+                              //       }
+                              // writer.writeStartElement(reader.name().toString());
+                              // }
+
+                        writer.writeStartElement(reader.name().toString());
+                        for (const auto &attr : reader.attributes()) {
+                              writer.writeAttribute(attr.name().toString(),
+                                                    attr.value().toString());
+                              }
+                        }
+                  else if (reader.isEndElement()) {
+                        if (reader.name() == "museScore") {
+                              // Now let's make new archive before closing off museScore:
+                              writer.writeStartElement("Archive");
+                              for (MasterScore*& score : scoreList) {
+                                    writer.writeStartElement("Score");
+                                    writer.writeTextElement("created", QString::number(score->created()));
+                                    QString path;
+                                    if (score->importedFilePath().isEmpty() || score->masterScore()->fileInfo()->exists()) {
+                                          // score was not imported from another format, e.g. MIDI file or was saved
+                                          path = score->masterScore()->fileInfo()->absoluteFilePath();
+                                          }
+                                    else {
+                                          // score was imported but not saved - store original file (e.g. MIDI) path
+                                          path = score->importedFilePath();
+                                          }
+
+                                    writer.writeTextElement("path", path);
+                                    writer.writeEndElement(); // Score
+                                    }
+                              writer.writeEndElement(); // Archive
+                              }
+                        writer.writeEndElement(); // museScore
+                        }
+                  else if (reader.isCharacters()) {
+                        if (!reader.isWhitespace()) {
+                              writer.writeCharacters(reader.text().toString());
+                              }
+                        }
+                  }
+            }
+      else {
+            // No existing archive file:
+            writer.writeStartElement(QStringLiteral("museScore version=\"" MSC_VERSION "\" full-version=\"%1\"").arg(fullVersion()));
+            writer.writeStartElement("Archive");
+            for (MasterScore*& score : scoreList) {
+                  writer.writeStartElement("Score");
+                  writer.writeTextElement("created", QString::number(score->created()));
+                  QString path;
+                  if (score->importedFilePath().isEmpty() || score->masterScore()->fileInfo()->exists()) {
+                        // score was not imported from another format, e.g. MIDI file or was saved
+                        path = score->masterScore()->fileInfo()->absoluteFilePath();
+                        }
+                  else {
+                        // score was imported but not saved - store original file (e.g. MIDI) path
+                        path = score->importedFilePath();
+                        }
+
+                  writer.writeTextElement("path", path);
+                  writer.writeEndElement(); // Score
+                  }
+            writer.writeEndElement(); // Archive
+            writer.writeEndElement(); // museScore
             }
 
-      XmlWriter xml(0, &f);
-      xml.header();
-      xml.stag(QStringLiteral("museScore version=\"" MSC_VERSION "\" full-version=\"%1\"").arg(fullVersion()));
 
+      fileIn.close();
+      fileOut.close();
 
-      for (MasterScore*& score : scoreList) {
-            xml.stag("Score");
-            xml.tag("created", score->created());
-            QString path;
-            if (score->importedFilePath().isEmpty()) {
-                  // score was not imported from another format, e.g. MIDI file
-                  path = score->masterScore()->fileInfo()->absoluteFilePath();
-                  }
-            else if (score->masterScore()->fileInfo()->exists()) {   // score was saved
-                  path = score->masterScore()->fileInfo()->absoluteFilePath();
-                  }
-            else {      // score was imported but not saved - store original file (e.g. MIDI) path
-                  path = score->importedFilePath();
-                  }
+      QFile::remove(fileIn.fileName());
+      QFile::rename(fileOut.fileName(), fileIn.fileName());
 
-            if (score->tmpName().isEmpty()) {
-                  xml.tag("path", path);
-                  }
-            else {
-                  xml.tag("name", path);
-                  xml.tag("path", score->tmpName());
-                  }
-            xml.etag();
-            qDebug() << "Path:" << path;
-            }
       return false;
       }
 
 //---------------------------------------------------------
 //   loadOpenScoresList
+//    "open-archived-scores"
 //---------------------------------------------------------
 
-bool MuseScore::loadOpenScoresList()
+bool MuseScore::loadOpenScoresList(int selectIdx)
       {
       QDir dir;
       dir.mkpath(dataPath);
       QFile f(dataPath + "/scorelist");
 
       bool cleanExit = false;
-      QString sessionFullVersion;
 
       if (!f.exists())
             return false;
@@ -532,47 +599,119 @@ bool MuseScore::loadOpenScoresList()
             return false;
             }
 
-      XmlReader e(&f);
-      while (e.readNextStartElement()) {
-            if (e.name() == "museScore") {
-                  sessionFullVersion = e.attribute("full-version");
-                  while (e.readNextStartElement()) {
-                        const QStringRef& tag(e.name());
-                        if (tag == "Score") {
-                              QString name;
-                              bool created = false;
-                              while (e.readNextStartElement()) {
-                                    const QStringRef& t(e.name());
-                                    if (t == "name")
-                                          name = e.readElementText();
-                                    else if (t == "created")
-                                          created = e.readInt();
-                                    else if (t == "dirty")
-                                          e.readInt();
-                                    else if (t == "path") {
-                                          auto txt = e.readElementText();
-                                          Score* score = openScore(txt, true, true, name);
+      int archiveIdx = -1;
 
+      XmlReader e(&f);
+      while (!e.atEnd()) {
+            e.readNext();
+            const bool target = (archiveIdx == selectIdx);
+            const QStringRef& tag(e.name());
+
+            if (e.isStartElement()) {
+                  if (tag == "Archive") {
+                        ++archiveIdx;
+                        }
+                  if (tag == "Score" && target) {
+                        QString name;
+                        bool created = false;
+                        while (e.readNextStartElement()) {
+                              const QStringRef& t(e.name());
+                              if (t == "name")
+                                    name = e.readElementText();
+                              else if (t == "created")
+                                    created = e.readInt();
+                              else if (t == "dirty")
+                                    e.readInt();
+                              else if (t == "path") {
+                                    auto txt = e.readElementText();
+                                    if (archiveIdx == selectIdx) {
+                                          Score* score = openScore(txt, true, true, name);
                                           if (score) {
-                                                if (cleanExit) {
-                                                      // override if last session did a clean exit
+                                                if (cleanExit)
                                                       created = false;
-                                                      }
                                                 score->setCreated(created);
                                                 }
-                                          else {
-                                                // qDebug() << txt << "invalid or already opened";
-                                                }
                                           }
-                                    else {
-                                          e.unknown();
-                                          return false;
-                                          }
+                                    }
+                              else {
+                                    qDebug() << "Error:" << "tag:" << t << "unknown";
+                                    e.unknown();
+                                    return false;
                                     }
                               }
                         }
                   }
             }
+      return true;
+      }
+
+//---------------------------------------------------------
+//   clearArchivedList
+//    "file-clear-archive"
+//---------------------------------------------------------
+
+bool MuseScore::clearArchivedList(int discardIdx)
+      {
+      QDir dir;
+      dir.mkpath(dataPath);
+      QFile fileIn(dataPath + "/scorelist");
+      QFile fileOut(dataPath + "/tmpdata");
+
+      if (!fileIn.exists())
+            return false;
+
+      if (!fileIn.open(QIODevice::ReadOnly)) {
+            qDebug("Cannot open session file <%s>", qPrintable(fileIn.fileName()));
+            return false;
+            }
+
+      if (!fileOut.open(QIODevice::WriteOnly)) {
+            qDebug("Cannot open temp file <%s>", qPrintable(fileOut.fileName()));
+            return false;
+            }
+
+      int archiveIdx = -1;
+
+      QXmlStreamReader reader(&fileIn);
+      QXmlStreamWriter writer(&fileOut);
+
+      writer.setAutoFormatting(true);
+      writer.writeStartDocument();
+      while (!reader.atEnd()) {
+            reader.readNext();
+            if (reader.isStartElement()) {
+                  const QStringRef& tag(reader.name());
+
+                  if (tag == "Archive") {
+                        ++archiveIdx;
+                        if (archiveIdx == discardIdx) {
+                              reader.skipCurrentElement();
+                              continue;
+                              }
+                        }
+
+                  writer.writeStartElement(tag.toString());
+                  for (const auto &attr : reader.attributes())
+                        writer.writeAttribute(attr.name().toString(), attr.value().toString());
+                  }
+            else if (reader.isEndElement())
+                  writer.writeEndElement();
+            else if (reader.isCharacters()) {
+                  if (!reader.isWhitespace()) {
+                        writer.writeCharacters(reader.text().toString());
+                        }
+                  }
+            }
+
+      fileIn.close();
+      fileOut.close();
+
+      if (!reader.hasError()) {
+            QFile::remove(fileIn.fileName());
+            QFile::rename(fileOut.fileName(), fileIn.fileName());
+            }
+      else qDebug() << "\tError:" << reader.errorString();
+
       return true;
       }
 

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -2906,12 +2906,14 @@ void MuseScore::selectArchivedScore(QAction* action)
       switch (actionData.type())
       {
       case QVariant::String: {
-            if (actionData.toString() == "archive-open-scores") {
-                  saveOpenScoresList();
-                  }
-            else if (actionData.toString() == "open-archived-scores") {
-                  loadOpenScoresList();
-                  }
+            const int setIdx = action->property("set").toInt();
+            if (actionData.toString() == "archive-open-scores")
+                  saveOpenScoresList(setIdx);
+            else if (actionData.toString() == "open-archived-scores")
+                  loadOpenScoresList(setIdx);
+            else if (actionData.toString() == "file-clear-archive")
+                  clearArchivedList(setIdx);
+
             break;
             }
       case QVariant::Map: {
@@ -3122,10 +3124,41 @@ void MuseScore::openRecentMenu()
 
 void MuseScore::openArchivedTabsMenu()
       {
-      openArchivedScores->clear();;
+
+      auto addSubmenuActions = [](QMenu* menu, int setIdx) {
+            menu->addSeparator();
+            QAction* actionClear = menu->addAction(tr("Clear this archive"));
+            actionClear->setProperty("set", QVariant(setIdx));
+            actionClear->setData("file-clear-archive");
+
+            QAction* actionRestore = menu->addAction(tr("Restore these scores"));
+            actionRestore->setData("open-archived-scores");
+            actionRestore->setProperty("set",  QVariant(setIdx));
+            };
+
+      openArchivedScores->clear();
       bool hasAnyArchivedScores = false;
+      QMenu *currentSubMenu = nullptr;
+      unsigned qtySubMenus = 0;
+
       for (QFileInfo& fi : archivedScores(true)) {
-            QAction* action = openArchivedScores->addAction(fi.fileName().replace("&", "&&"));  // show filename only
+            bool isNumber = false;
+            int setIdx = fi.fileName().toInt(&isNumber);
+            if (isNumber) {
+                  ++qtySubMenus;
+                  if (currentSubMenu) {
+                        // Finalize current submenu's actions:
+                        setIdx -= 1;
+                        addSubmenuActions(currentSubMenu, setIdx);
+                        }
+                  // New submenu:
+                  currentSubMenu = openArchivedScores->addMenu("Set " + fi.fileName());
+                  continue;
+                  }
+
+            QMenu* menu = currentSubMenu ? currentSubMenu : openArchivedScores;
+
+            QAction* action = menu->addAction(fi.fileName().replace("&", "&&"));  // show filename only
 
             QString filePath = fi.canonicalFilePath();
 
@@ -3137,18 +3170,26 @@ void MuseScore::openArchivedTabsMenu()
             action->setToolTip(filePath);
             hasAnyArchivedScores = true;
             }
+
+      if (qtySubMenus) {
+            // Add final actions to last submenu:
+            const int setIdx = qtySubMenus - 1;
+            addSubmenuActions(currentSubMenu, setIdx);
+            }
+
+      // Main Archive menu:
       if (!scores().empty()) {
             openArchivedScores->addSeparator();
             QAction* action = openArchivedScores->addAction(tr("Archive currently opened scores"));
             action->setData("archive-open-scores");
             }
-      if (hasAnyArchivedScores) {
-            openArchivedScores->addSeparator();
-            QAction* action = openArchivedScores->addAction(tr("Restore all archived scores"));
-            action->setData("open-archived-scores");
-      }
       else {
-            // Don't leave the menu empty, but add a hint
+            openArchivedScores->addSeparator();
+            QAction* hint = openArchivedScores->addAction(tr("No opened scores to archive"));
+            hint->setEnabled(false);
+            }
+
+      if (!hasAnyArchivedScores) {
             QAction* hint = openArchivedScores->addAction(tr("No archived scores"));
             hint->setEnabled(false);
             }
@@ -7157,9 +7198,11 @@ void MuseScore::cmd(QAction* a, const QString& cmd)
             else if (cmd == "file-save-selection")
                   saveSelection(cs);
             else if (cmd == "file-open-archived-tabs")
-                  loadOpenScoresList();
+                  loadOpenScoresList(0);
             else if (cmd == "file-archive-tabs")
-                  saveOpenScoresList();
+                  saveOpenScoresList(0);
+            else if (cmd == "file-clear-archive")
+                  clearArchivedList(0);
             else if (cmd == saveOnlineMenuItem)
                   showUploadScoreDialog();
             else if (cmd == "file-import-pdf")
@@ -8072,30 +8115,31 @@ QFileInfoList MuseScore::archivedScores(bool showAlreadyLoaded) const
             }
 
       XmlReader e(&f);
+      int idx = 0;
       while (e.readNextStartElement()) {
             if (e.name() == "museScore") {
                   sessionFullVersion = e.attribute("full-version");
                   while (e.readNextStartElement()) {
-                        const QStringRef& tag(e.name());
-                        if (tag == "Score") {
-                              QString name;
-                              bool created = false;
+                        if (e.name() == "Archive") {
+                              scores.append(QString::number(idx++));
                               while (e.readNextStartElement()) {
-                                    const QStringRef& t(e.name());
-                                    if (t == "name")
-                                          name = e.readElementText();
-                                    else if (t == "created") {
-                                          created = e.readInt();
-                                          qDebug() << "Created:" << created;
-                                          }
-                                    else if (t == "dirty")
-                                          e.readInt();
-                                    else if (t == "path") {
-                                          scores.append(e.readElementText());
-                                          }
-                                    else {
-                                          qDebug() << "wtf";
-                                          e.unknown();
+                                    const QStringRef& tag(e.name());
+                                    if (tag == "Score") {
+                                          QString name;
+                                          bool created = false;
+                                          while (e.readNextStartElement()) {
+                                                const QStringRef& t(e.name());
+                                                if (t == "name")
+                                                      name = e.readElementText();
+                                                else if (t == "created")
+                                                      created = e.readInt();
+                                                else if (t == "dirty")
+                                                      e.readInt();
+                                                else if (t == "path")
+                                                      scores.append(e.readElementText());
+                                                else
+                                                      e.unknown();
+                                                }
                                           }
                                     }
                               }
@@ -8108,6 +8152,7 @@ QFileInfoList MuseScore::archivedScores(bool showAlreadyLoaded) const
       for (const QString& s : scores) {
             if (s.isEmpty())
                   continue;
+
             QFileInfo fi(s);
             bool alreadyLoaded = false;
             QString fp = fi.canonicalFilePath();
@@ -8117,14 +8162,8 @@ QFileInfoList MuseScore::archivedScores(bool showAlreadyLoaded) const
                         break;
                         }
                   }
-            if (fi.exists()) {
-                  if (showAlreadyLoaded || !alreadyLoaded) {
-                        fil.append(fi);
-                        }
-                  else {
-                        ;
-                        }
-                  }
+            if (showAlreadyLoaded || !alreadyLoaded)
+                  fil.append(fi);
             }
 
       return fil;

--- a/mscore/musescore.h
+++ b/mscore/musescore.h
@@ -790,8 +790,9 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
       MasterScore* readScore(const QString& name);
       NotesColors readNotesColors(const QString& filePath) const;
 
-      bool saveOpenScoresList();
-      bool loadOpenScoresList();
+      bool saveOpenScoresList(int);
+      bool loadOpenScoresList(int);
+      bool clearArchivedList(int);
 
       bool saveAs(Score*, bool saveCopy = false);
       bool saveSelection(Score*);

--- a/mscore/shortcut.cpp
+++ b/mscore/shortcut.cpp
@@ -116,6 +116,17 @@ Shortcut Shortcut::_sc[] = {
          },
       {
          MsWidget::MAIN_WINDOW,
+         STATE_NORMAL | STATE_NOTE_ENTRY | STATE_EDIT | STATE_PLAY,
+         "file-clear-archive",
+         QT_TRANSLATE_NOOP("action","Clear Archived Tabs"),
+         QT_TRANSLATE_NOOP("action","Clear Archived Tabs"),
+         QT_TRANSLATE_NOOP("action","Clear Archived Tabs"),
+         Icons::fileSave_ICON,
+         Qt::WindowShortcut,
+         // ShortcutFlags::A_SCORE
+         },
+      {
+         MsWidget::MAIN_WINDOW,
          STATE_NORMAL | STATE_NOTE_ENTRY | STATE_EDIT,
          "start-preference-dialog",
          QT_TRANSLATE_NOOP("action","Start Preferences Dialog…"),


### PR DESCRIPTION
Sets can be reloaded and cleared, and created based on currently opened tabs. At the moment, a particular set can't be "updated", but a new set must be made

They'll appear as Set 'n':
<img width="719" height="440" alt="image" src="https://github.com/user-attachments/assets/8ed616e5-927e-4140-9f9c-707fbd0b0eff" />
