### PR TITLE
Command: File Reload by default will discard changes.

### DIFF
--- a/global/settings/types/preferencekeys.h
+++ b/global/settings/types/preferencekeys.h
@@ -187,6 +187,7 @@
 
 #define PREF_UI_SCORE_BYPASS_ALT_MENU                       "ui/application/altMenu/bypass"
 #define PREF_UI_SCORE_IJKL_NUDGE_MOVEMENT                   "ui/application/nudge/ijkl"
+#define PREF_UI_SCORE_RELOAD_AUTO_DISCARD                   "ui/application/fileReload/discardChanges"
 
 #define PREF_SCORE_PLAYBACK_HIGHLIGHT_NOTES                 "ui/score/playback/highlightNotes"
 #define PREF_SCORE_PLAYBACK_HIGHLIGHT_RESTS                 "ui/score/playback/highlightRests"

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -3956,7 +3956,7 @@ void MuseScore::removeTab(int i)
 
       QString tmpName = score->tmpName();
 
-      if (!scriptTestMode && !converterMode && checkDirty(score))
+      if (!scriptTestMode && !converterMode && !score->readOnly() && checkDirty(score))
             return;
       if (seq && seq->score() == score) {
             seq->stopWait();
@@ -7210,10 +7210,22 @@ void MuseScore::cmd(QAction* a, const QString& cmd)
             else if (cmd == "file-export")
                   showExportDialog();
             else if (cmd == "file-reload") {
-                  saveFile();
+                  const bool closeWithoutSaving =
+                        preferences.getBool(PREF_UI_SCORE_RELOAD_AUTO_DISCARD);
+
+                  const bool automaticallySave =
+                        !closeWithoutSaving;
+
+                  if (automaticallySave)
+                        saveFile();
+
                   const auto ms = cs->masterScore();
                   const auto fi = ms->fileInfo();
                   const auto fn = fi->absoluteFilePath();
+
+                  if (closeWithoutSaving)
+                        cs->masterScore()->setReadOnly(true);
+
                   closeScore(cs);
                   openScore(fn);
                   }

--- a/mscore/preferences.cpp
+++ b/mscore/preferences.cpp
@@ -237,6 +237,7 @@ void Preferences::init(bool storeInMemoryOnly)
             {PREF_UI_SCORE_CURRENT_SYS_ON_TOP_SKYLINE,             new BoolPreference(false, true)},
             {PREF_UI_SCORE_BYPASS_ALT_MENU,                        new BoolPreference(false, true)},
             {PREF_UI_SCORE_IJKL_NUDGE_MOVEMENT,                    new BoolPreference(false, true)},
+            {PREF_UI_SCORE_RELOAD_AUTO_DISCARD,                    new BoolPreference(true, true)},
             {PREF_UI_SCORE_OMIT_ADDING_LINKED_LINES,               new BoolPreference(false, true)},
             {PREF_SCORE_HOVER_COLOR,                               new ColorPreference(QColor(0,0,0,0), true)},
             {PREF_SCORE_HOVER_COLOR_ENABLE,                        new BoolPreference(false, true)},

--- a/mscore/shortcut.cpp
+++ b/mscore/shortcut.cpp
@@ -202,7 +202,7 @@ Shortcut Shortcut::_sc[] = {
          },
       {
          MsWidget::MAIN_WINDOW,
-         STATE_NORMAL | STATE_NOTE_ENTRY | STATE_EDIT | STATE_PLAY,
+         STATE_NORMAL | STATE_NOTE_ENTRY | STATE_EDIT | STATE_TEXT_EDIT | STATE_PLAY,
          "file-reload",
          QT_TRANSLATE_NOOP("action","Reload Current Score"),
          QT_TRANSLATE_NOOP("action","File > Reload Current Score"),


### PR DESCRIPTION
Implemented  an advanced preference to change the default behavior of previous custom implementation from automatically save to automatically discard

The point here is that during debugging or implementation testing, there've been enough times where I wanted a File Reload while discarding all changes, and other times saving all changes first - yet I don't want to have to be prompted to save or not.

ui/application/fileReload/discardChanges:
- False will automatically save
- True will automatically discard