### PR TITLE
Feature/text frame/word wrap

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -5240,6 +5240,21 @@ void Score::cmdAddPitch(Note* selectedNote, int step)
       }
 
 //---------------------------------------------------------
+//   cmdBakeSoftWrap
+//---------------------------------------------------------
+
+void Score::cmdBakeSoftWrap()
+      {
+      for (Element* e : selection().elements()) {
+            if (!e->isText())
+                  continue;
+
+            Text* text = toText(e);
+            text->bakeSoftWraps();
+            }
+      }
+
+//---------------------------------------------------------
 //   cmdToggleVisible
 //---------------------------------------------------------
 
@@ -5960,6 +5975,7 @@ void Score::cmd(const QAction* a, EditData& ed)
             { "fret-12",                    [](Score* cs, EditData&){ cs->cmdAddFret(12);                                             }},
             { "fret-13",                    [](Score* cs, EditData&){ cs->cmdAddFret(13);                                             }},
             { "fret-14",                    [](Score* cs, EditData&){ cs->cmdAddFret(14);                                             }},
+            { "bake-soft-wrap",             [](Score* cs, EditData&){ cs->cmdBakeSoftWrap();                                          }},
             { "toggle-visible",             [](Score* cs, EditData&){ cs->cmdToggleVisible();                                         }},
             { "reset-stretch",              [](Score* cs, EditData&){ cs->resetUserStretch();                                         }},
             { "mirror-note",                [](Score* cs, EditData&){ cs->cmdMirrorNoteHead();                                        }},

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -666,6 +666,7 @@ class Score : public QObject, public ScoreElement {
       void cmdIncDurationDotted()   { cmdIncDecDuration(-1, true); }
       void cmdDecDurationDotted()   { cmdIncDecDuration( 1, true); }
       void cmdToggleLayoutBreak(LayoutBreak::Type, bool before=false, bool all=false);
+      void cmdBakeSoftWrap();
 
       void addRemoveBreaks(int interval, bool lock);
 

--- a/libmscore/textbase.cpp
+++ b/libmscore/textbase.cpp
@@ -172,6 +172,36 @@ int TextCursor::columns() const
       }
 
 //---------------------------------------------------------
+//   character
+//---------------------------------------------------------
+
+QChar TextBlock::character(int column) const
+      {
+      int col = 0;
+      for (const TextFragment& f : _fragments) {
+            for (const QChar& c : qAsConst(f.text)) {
+                  if (col == column)
+                        return c;
+                  if (!c.isHighSurrogate())
+                        ++col;
+                  }
+            }
+      return QChar();
+      }
+
+//---------------------------------------------------------
+//   dump
+//---------------------------------------------------------
+
+QString TextBlock::dump() const
+      {
+      QString text;
+      for (const TextFragment& f : _fragments)
+            text += f.text;
+      return text;
+      }
+
+//---------------------------------------------------------
 //   currentCharacter
 //---------------------------------------------------------
 
@@ -234,7 +264,11 @@ QRectF TextCursor::cursorRect() const
       QFont _font  = fragment ? fragment->font(_text) : _text->font();
       qreal ascent = QFontMetricsF(_font, MScore::paintDevice()).ascent();
       qreal h = ascent;
-      qreal x = tline.xpos(column(), _text);
+
+      const bool softWrap =
+            _row > 0 && !_text->textBlockList()[_row - 1].eol();
+
+      qreal x = tline.xpos(column(), _text, softWrap);
       qreal y = tline.y() - ascent * .9;
       return QRectF(x, y, 4.0, h);
       }
@@ -516,7 +550,10 @@ bool TextCursor::set(const QPointF& p, QTextCursor::MoveMode mode)
                   break;
                   }
             }
-      _column = curLine().column(pt.x(), _text);
+      const bool softWrap =
+            _row > 0 && !_text->_layout[_row - 1].eol();
+
+      _column = curLine().column(pt.x(), _text, softWrap);
 
       _text->score()->setUpdateAll();
       if (mode == QTextCursor::MoveAnchor)
@@ -929,12 +966,56 @@ QFont TextFragment::font(const TextBase* t) const
 //   draw
 //---------------------------------------------------------
 
-void TextBlock::draw(QPainter* p, const TextBase* t) const
+void TextBlock::draw(QPainter* p, const TextBase* t, bool softWrap) const
       {
       // Translate to V-alignment
       p->translate(0.0, _y);
-      for (const TextFragment& f : _fragments)
-            f.draw(p, t);
+
+      bool suppressLeadingSpace = false;
+      qreal subsequentFragmentOffset = 0.0;
+
+      if (softWrap &&
+          !_fragments.isEmpty() &&
+          !_fragments.front().text.isEmpty() &&
+          _fragments.front().text.at(0).isSpace()) {
+
+            const TextFragment& first = _fragments.front();
+
+            suppressLeadingSpace = true;
+
+            // If the leading space shares a fragment with visible
+            // text, removing it makes that fragment visually one
+            // space narrower.  Later fragments therefore need to
+            // move left by the same amount.
+            //
+            // If the leading space is a fragment by itself, however,
+            // TextBlock::layout() has already positioned subsequent
+            // fragments correctly, so no offset is needed.
+            if (first.text.size() > 1) {
+                  QFontMetricsF fm(first.font(t), MScore::paintDevice());
+                  subsequentFragmentOffset = fm.width(first.text.left(1));
+                  }
+            }
+
+      bool firstFragment = true;
+
+      for (const TextFragment& f : _fragments) {
+            TextFragment tf = f;
+
+            if (firstFragment) {
+                  if (suppressLeadingSpace)
+                        tf.text.remove(0, 1);
+                  }
+            else if (subsequentFragmentOffset != 0.0) {
+                  tf.pos.rx() -= subsequentFragmentOffset;
+                  }
+
+            if (!tf.text.isEmpty())
+                  tf.draw(p, t);
+
+            firstFragment = false;
+            }
+
       p->translate(0.0, -_y);
       }
 
@@ -951,6 +1032,7 @@ void TextBlock::layout(TextBase* t)
 
       qreal layoutWidth = 0;
       Element* e = t->parent();
+
       if (e && t->layoutToParentWidth()) {
             layoutWidth = e->width();
             switch(e->type()) {
@@ -1046,9 +1128,12 @@ void TextBlock::layout(TextBase* t)
             rx = (layoutWidth - (_bbox.left() + _bbox.right())) * .5;
       else  // Align::LEFT
             rx = -_bbox.left();
+
       rx += lm;
+
       for (TextFragment& f : _fragments)
             f.pos.rx() += rx;
+
       _bbox.translate(rx, 0.0);
       }
 
@@ -1074,24 +1159,49 @@ QList<TextFragment>* TextBlock::fragmentsWithoutEmpty()
 //   xpos
 //---------------------------------------------------------
 
-qreal TextBlock::xpos(int column, const TextBase* t) const
+qreal TextBlock::xpos(int column, const TextBase* t, bool softWrap) const
       {
+      qreal softWrapOffset = 0.0;
+
+      if (softWrap &&
+          column > 0 &&
+          !_fragments.isEmpty()) {
+            const TextFragment& first = _fragments.front();
+
+            // Only compensate geometrically when removing the retained
+            // soft-wrap space actually shifts visible text in this same
+            // fragment.  If the space occupies a fragment by itself,
+            // later fragments are already positioned correctly by layout().
+            if (first.text.size() > 1 &&
+                first.text.at(0).isSpace()) {
+                  QFontMetricsF fm(first.font(t), MScore::paintDevice());
+                  softWrapOffset = fm.width(first.text.left(1));
+                  }
+            }
+
       int col = 0;
       for (const TextFragment& f : _fragments) {
             if (column == col)
-                  return f.pos.x();
+                  return f.pos.x() - softWrapOffset;
+
             QFontMetricsF fm(f.font(t), MScore::paintDevice());
             int idx = 0;
+
             for (const QChar& c : qAsConst(f.text)) {
                   ++idx;
                   if (c.isHighSurrogate())
                         continue;
+
                   ++col;
+
                   if (column == col)
-                        return f.pos.x() + fm.width(f.text.left(idx));
+                        return f.pos.x()
+                               + fm.width(f.text.left(idx))
+                               - softWrapOffset;
                   }
             }
-      return _bbox.x();
+
+      return _bbox.x() - softWrapOffset;
       }
 
 //---------------------------------------------------------
@@ -1134,11 +1244,12 @@ const CharFormat* TextBlock::formatAt(int column) const
 //   boundingRect
 //---------------------------------------------------------
 
-QRectF TextBlock::boundingRect(int col1, int col2, const TextBase* t) const
+QRectF TextBlock::boundingRect(int col1, int col2, const TextBase* t, bool softWrap) const
       {
-      qreal x1 = xpos(col1, t);
-      qreal x2 = xpos(col2, t);
-      return QRectF(x1, _bbox.y(), x2-x1, _bbox.height());
+      qreal x1 = xpos(col1, t, softWrap);
+      qreal x2 = xpos(col2, t, softWrap);
+
+      return QRectF(x1, _bbox.y(), x2 - x1, _bbox.height());
       }
 
 //---------------------------------------------------------
@@ -1163,26 +1274,43 @@ int TextBlock::columns() const
 //    Text coordinate system
 //---------------------------------------------------------
 
-int TextBlock::column(qreal x, TextBase* t) const
+int TextBlock::column(qreal x, TextBase* t, bool softWrap) const
       {
+      if (softWrap && !_fragments.isEmpty()) {
+            const TextFragment& f = _fragments.front();
+
+            if (f.text.size() > 1 &&
+                f.text.at(0).isSpace()) {
+                  QFontMetricsF fm(f.font(t), MScore::paintDevice());
+                  x += fm.width(f.text.left(1));
+                  }
+            }
+
       int col = 0;
       for (const TextFragment& f : _fragments) {
             int idx = 0;
+
             if (x <= f.pos.x())
                   return col;
+
             qreal px = 0.0;
+
             for (const QChar& c : qAsConst(f.text)) {
                   ++idx;
                   if (c.isHighSurrogate())
                         continue;
+
                   QFontMetricsF fm(f.font(t), MScore::paintDevice());
                   qreal xo = fm.width(f.text.left(idx));
-                  if (x <= f.pos.x() + px + (xo-px)*.5)
+
+                  if (x <= f.pos.x() + px + (xo - px) * 0.5)
                         return col;
+
                   ++col;
                   px = xo;
                   }
             }
+
       return col;
       }
 
@@ -1807,7 +1935,262 @@ void TextBase::createLayout()
             }
       if (_layout.empty())
             _layout.append(TextBlock());
+
       layoutInvalid = false;
+
+      // Re-create automatic wrapping after rebuilding _layout
+      if (layoutToParentWidth() && parent() && parent()->isTBox()) {
+            TextCursor wrapCursor(this);
+            wrapCursor.init();
+
+            while (wrapTextBlock(&wrapCursor))
+                  ;
+            }
+      }
+
+//---------------------------------------------------------
+//   wrapTextBlock
+//----------------------------------------------------------
+
+bool TextBase::wrapTextBlock(TextCursor* cursor)
+      {
+
+      Element* e = parent();
+      if (!e || !layoutToParentWidth() || !e->isTBox())
+            return false;
+
+      Box* b = toBox(e);
+      const qreal width =
+            b->width() - (b->leftMargin() + b->rightMargin()) * DPMM;
+
+      const int cursorRow = cursor->row();
+      const int cursorColumn = cursor->column();
+
+      // Find the beginning of this logical paragraph
+      int firstRow = cursorRow;
+
+      while (firstRow > 0 && !_layout[firstRow - 1].eol())
+            --firstRow;
+
+      // Find the end of this logical paragraph
+      int lastRow = cursorRow;
+      while (lastRow < _layout.size() - 1 && !_layout[lastRow].eol())
+            ++lastRow;
+
+      // Find the first overflowing row in this paragraph
+      int breakRow = -1;
+      int breakLocalColumn = -1;
+
+      for (int r = firstRow; r <= lastRow; ++r) {
+            const TextBlock& block = _layout[r];
+
+            qreal textWidth = 0.0;
+            int breakColumn = -1;
+            int col = 0;
+            bool overflow = false;
+
+            for (const TextFragment& f : block.fragments()) {
+                  QFontMetricsF fm(f.font(this), MScore::paintDevice());
+
+                  for (int i = 0; i < f.text.size(); ) {
+                        QString s;
+
+                        if (f.text.at(i).isHighSurrogate() && i + 1 < f.text.size()) {
+                              s = f.text.mid(i, 2);
+                              i += 2;
+                              }
+                        else {
+                              s = f.text.mid(i, 1);
+                              ++i;
+                              }
+
+                        if (textWidth + fm.width(s) > width) {
+                              overflow = true;
+                              break;
+                              }
+
+                        if (s.at(0).isSpace())
+                              breakColumn = col;
+
+                        textWidth += fm.width(s);
+                        ++col;
+                        }
+
+                  if (overflow)
+                        break;
+                  }
+
+            if (overflow && breakColumn >= 0) {
+                  breakRow = r;
+                  breakLocalColumn = breakColumn;
+
+                  break;
+                  }
+            }
+
+      if (breakRow < 0 || breakLocalColumn < 0)
+            return false;
+
+      // Have an overflowing row - split it:
+      const int oldRow = breakRow;
+
+      TextBlock& block = _layout[oldRow];
+
+      const bool oldEol = block.eol();
+
+      TextCursor splitCursor = *cursor;
+      splitCursor.setRow(oldRow);
+      splitCursor.setColumn(breakLocalColumn);
+
+      TextBlock newBlock = block.split(breakLocalColumn, &splitCursor);
+
+      const bool hasLeadingSpace =
+            newBlock.columns() > 0 && newBlock.text(0, 1) == " ";
+      (void)hasLeadingSpace;
+
+      newBlock.setEol(oldEol);
+
+      if (oldRow + 1 < _layout.size()) {
+            TextBlock& nextBlock = _layout[oldRow + 1];
+
+            QList<TextFragment> combined = newBlock.fragments();
+            combined.append(nextBlock.fragments());
+            nextBlock.fragments() = combined;
+            }
+      else {
+            _layout.insert(oldRow + 1, newBlock);
+            }
+
+      // Adjust the cursor if it was in the portion moved to the new row
+      if (cursorRow == oldRow && cursorColumn > breakLocalColumn) {
+            cursor->setRow(oldRow + 1);
+            cursor->setColumn(cursorColumn - breakLocalColumn);
+            }
+      else {
+            cursor->setRow(cursorRow);
+            cursor->setColumn(cursorColumn);
+            }
+
+      cursor->clearSelection();
+
+      return true;
+      }
+
+//---------------------------------------------------------
+//   unwrapTextBlock
+//---------------------------------------------------------
+
+bool TextBase::unwrapTextBlock(TextCursor* cursor)
+      {
+      Element* e = parent();
+      if (!e || !layoutToParentWidth() || !e->isTBox())
+            return false;
+
+      if (_layout.size() < 2)
+            return false;
+
+      const int cursorRow = cursor->row();
+      const int cursorColumn = cursor->column();
+
+      // Find the beginning of the logical paragraph.
+      // A false eol() between two rows means that the row
+      // boundary is only an automatic "soft" wrap:
+      int firstRow = cursorRow;
+      while (firstRow > 0 && !_layout[firstRow - 1].eol())
+            --firstRow;
+
+      // Find the end of the same logical paragraph
+      int lastRow = cursorRow;
+      while (lastRow < _layout.size() - 1 && !_layout[lastRow].eol())
+            ++lastRow;
+
+      if (firstRow == lastRow)
+            return false;
+
+      // Save the cursor as an offset from the beginning of
+      // the logical paragraph.  Soft row boundaries contribute
+      // no character of their own.
+      int logicalColumn = cursorColumn;
+
+      for (int r = firstRow; r < cursorRow; ++r)
+            logicalColumn += _layout[r].columns();
+
+      // Preserve the eol state of the actual final row
+      const bool finalEol = _layout[lastRow].eol();
+
+      // Join all soft-wrapped continuation rows into firstRow.
+      // The leading spaces retained by wrapTextBlock() are
+      // preserved here - they are real characters in the
+      // logical text.
+      TextBlock& firstBlock = _layout[firstRow];
+
+      for (int r = firstRow + 1; r <= lastRow; ++r)
+            firstBlock.fragments().append(_layout[r].fragments());
+
+      firstBlock.setEol(finalEol);
+
+      // Remove the old continuation rows in reverse to maintain valid indexes
+      for (int r = lastRow; r > firstRow; --r)
+            _layout.removeAt(r);
+
+      // Restore cursor to the same logical text position
+      // in the single joined block
+      cursor->setRow(firstRow);
+      cursor->setColumn(logicalColumn);
+      cursor->clearSelection();
+
+      // Re-wrap the reconstructed paragraph to the current width
+      bool changed = false;
+      while (wrapTextBlock(cursor))
+            changed = true;
+
+      return changed;
+      }
+
+//---------------------------------------------------------
+//   bakeSoftWraps
+//---------------------------------------------------------
+
+bool TextBase::bakeSoftWraps()
+      {
+      if (!parent() || !parent()->isTBox() || _layout.size() < 2)
+            return false;
+
+      const QList<TextBlock> oldLayout = _layout;
+      const bool oldTextInvalid = textInvalid;
+
+      bool changed = false;
+
+      for (int row = 0; row < _layout.size() - 1; ++row) {
+            TextBlock& block = _layout[row];
+            TextBlock& nextBlock = _layout[row + 1];
+
+            if (block.eol())
+                  continue;
+
+            if (nextBlock.columns() > 0 &&
+                nextBlock.character(0).isSpace())
+                  nextBlock.remove(0, nullptr);
+
+            block.setEol(true);
+            changed = true;
+            }
+
+      if (!changed)
+            return false;
+
+      // Serialize the temporarily baked layout
+      textInvalid = true;
+      const QString bakedXmlText = xmlText();
+
+      // Put the live object back exactly as it was before baking
+      _layout = oldLayout;
+      textInvalid = oldTextInvalid;
+
+      // Make the actual score change
+      undoChangeProperty(Pid::TEXT, bakedXmlText);
+
+      return true;
       }
 
 //---------------------------------------------------------
@@ -3190,8 +3573,13 @@ void TextBase::draw(QPainter* p) const
             }
       p->setBrush(Qt::NoBrush);
       p->setPen(textColor());
-      for (const TextBlock& t : _layout)
-            t.draw(p, this);
+
+      for (int row = 0; row < _layout.size(); ++row) {
+            const bool softWrap =
+                  row > 0 && !_layout[row - 1].eol();
+
+            _layout[row].draw(p, this, softWrap);
+            }
       }
 
 //---------------------------------------------------------
@@ -3221,15 +3609,19 @@ void TextBase::drawEditMode(QPainter* p, EditData& ed)
             sort(r1, c1, r2, c2);
             int row = 0;
             for (const TextBlock& t : qAsConst(_layout)) {
-                  t.draw(p, this);
+                  const bool softWrap =
+                              row > 0 && !_layout[row - 1].eol();
+
+                  t.draw(p, this, softWrap);
+
                   if (row >= r1 && row <= r2) {
                         QRectF br;
                         if (row == r1 && r1 == r2)
-                              br = t.boundingRect(c1, c2, this);
+                              br = t.boundingRect(c1, c2, this, softWrap);
                         else if (row == r1)
-                              br = t.boundingRect(c1, t.columns(), this);
+                              br = t.boundingRect(c1, t.columns(), this, softWrap);
                         else if (row == r2)
-                              br = t.boundingRect(0, c2, this);
+                              br = t.boundingRect(0, c2, this, softWrap);
                         else
                               br = t.boundingRect();
                         br.translate(0.0, t.y());

--- a/libmscore/textbase.cpp
+++ b/libmscore/textbase.cpp
@@ -469,6 +469,7 @@ bool TextCursor::movePosition(QTextCursor::MoveOperation op, QTextCursor::MoveMo
 
                   case QTextCursor::NextWord: {
                         int cols =  columns();
+                        // qDebug("NextWord start row=%d col=%d cols=%d", _row, _column, cols);
                         if (_column < cols) {
                               ++_column;
                               while (_column < cols && !currentCharacter().isSpace())
@@ -476,6 +477,7 @@ bool TextCursor::movePosition(QTextCursor::MoveOperation op, QTextCursor::MoveMo
                               while (_column < cols && currentCharacter().isSpace())
                                     ++_column;
                               }
+                        // qDebug("NextWord end row=%d col=%d", _row, _column);
                         }
 #if !defined(Q_OS_MAC)
                         if (mode == QTextCursor::MoveAnchor)
@@ -1135,6 +1137,20 @@ void TextBlock::layout(TextBase* t)
             f.pos.rx() += rx;
 
       _bbox.translate(rx, 0.0);
+
+      qDebug() << "BLOCK LAYOUT:"
+               << "bboxLeft=" << _bbox.left()
+               << "rx=" << rx
+               << "fragments=" << _fragments.size();
+
+      int n = 0;
+      for (const TextFragment& f : _fragments) {
+            qDebug() << "  frag" << n++
+                     << "text=[" << f.text << "]"
+                     << "posX=" << f.pos.x()
+                     << "bold=" << f.format.bold()
+                     << "italic=" << f.format.italic();
+            }
       }
 
 //---------------------------------------------------------
@@ -1593,12 +1609,24 @@ void TextFragment::changeFormat(FormatId id, QVariant data)
 
 TextBlock TextBlock::split(int column, Ms::TextCursor* cursor)
       {
+      bool tempOutput = false;
       TextBlock tl;
 
       int col = 0;
       for (auto i = _fragments.begin(); i != _fragments.end(); ++i) {
+            if (tempOutput) qDebug() << "Frag:" << qAsConst(i->text);
             int idx = 0;
             for (const QChar& c : qAsConst(i->text)) {
+                  if (tempOutput) {
+                        if (col == column) qDebug() << "SPLIT";
+                        qDebug().nospace().noquote()
+                              << "\t"
+                              << "col=" << col << " "
+                              // << "idx=" << idx << " "
+                              // << "column=" << column << " "
+                              << "char=[" << QString(c) << "]"
+                              ;
+                        }
                   if (col == column) {
                         if (idx) {
                               if (idx < i->text.size()) {
@@ -1954,6 +1982,7 @@ void TextBase::createLayout()
 
 bool TextBase::wrapTextBlock(TextCursor* cursor)
       {
+      bool logRowColEol = false;
 
       Element* e = parent();
       if (!e || !layoutToParentWidth() || !e->isTBox())
@@ -1976,6 +2005,15 @@ bool TextBase::wrapTextBlock(TextCursor* cursor)
       int lastRow = cursorRow;
       while (lastRow < _layout.size() - 1 && !_layout[lastRow].eol())
             ++lastRow;
+
+      if (logRowColEol) {
+            for (int r = 0; r < rows(); ++r) {
+                  qDebug().nospace()
+                        << "row=" << r << " "
+                        << "columns=" << _layout[r].columns()  << " "
+                        << "eol=" << _layout[r].eol();
+                  }
+            }
 
       // Find the first overflowing row in this paragraph
       int breakRow = -1;
@@ -2024,6 +2062,12 @@ bool TextBase::wrapTextBlock(TextCursor* cursor)
                   breakRow = r;
                   breakLocalColumn = breakColumn;
 
+                  if (logRowColEol)
+                        qDebug().nospace()
+                              << "wrap: "
+                              << "breakRow=" << breakRow << " "
+                              << "breakLocalColumn=" << breakLocalColumn;
+
                   break;
                   }
             }
@@ -2033,8 +2077,16 @@ bool TextBase::wrapTextBlock(TextCursor* cursor)
 
       // Have an overflowing row - split it:
       const int oldRow = breakRow;
+      const int oldColumn = cursorColumn;
 
       TextBlock& block = _layout[oldRow];
+
+      if (logRowColEol)
+            qDebug().nospace()
+                  << "wrap:"
+                  << "oldRow=" << oldRow << " "
+                  << "oldColumn=" << oldColumn << " "
+                  << "breakColumn=" << breakLocalColumn;
 
       const bool oldEol = block.eol();
 
@@ -2042,13 +2094,34 @@ bool TextBase::wrapTextBlock(TextCursor* cursor)
       splitCursor.setRow(oldRow);
       splitCursor.setColumn(breakLocalColumn);
 
+      const QString beforeSplit = block.dump();
+
       TextBlock newBlock = block.split(breakLocalColumn, &splitCursor);
+
+      if (logRowColEol)
+            qDebug().nospace()
+                  << "split result/wrapcheck" << "\n"
+                  << "before=[" << beforeSplit << "]" << "\n"
+                  << "old=[" << block.dump() << "]" << "\n"
+                  << "new=[" << newBlock.dump() << "]" << "\n"
+                  << "concat=[" << (block.dump() + newBlock.dump()) << "]";
 
       const bool hasLeadingSpace =
             newBlock.columns() > 0 && newBlock.text(0, 1) == " ";
       (void)hasLeadingSpace;
 
       newBlock.setEol(oldEol);
+
+      qDebug() << "REFLOW:"
+               << "oldRow=" << oldRow
+               << "old=[" << block.dump() << "]"
+               << "new=[" << newBlock.dump() << "]"
+               << "hasNext=" << (oldRow + 1 < _layout.size())
+               << "next=["
+               << (oldRow + 1 < _layout.size()
+                   ? _layout[oldRow + 1].dump()
+                   : QString())
+               << "]";
 
       if (oldRow + 1 < _layout.size()) {
             TextBlock& nextBlock = _layout[oldRow + 1];
@@ -2061,6 +2134,20 @@ bool TextBase::wrapTextBlock(TextCursor* cursor)
             _layout.insert(oldRow + 1, newBlock);
             }
 
+      if (logRowColEol) {
+            for (int r = 0; r < rows(); ++r) {
+                  QString rowText;
+                  for (const TextFragment& f : _layout[r].fragments()) {
+                        rowText += f.text;
+                        qDebug().nospace()
+                              << "row=" << r << " "
+                              << "columns=" << _layout[r].columns() << " "
+                              << "eol=" << _layout[r].eol() << " "
+                              << "text=[" << rowText << "]";
+                        }
+                  }
+            }
+
       // Adjust the cursor if it was in the portion moved to the new row
       if (cursorRow == oldRow && cursorColumn > breakLocalColumn) {
             cursor->setRow(oldRow + 1);
@@ -2070,6 +2157,12 @@ bool TextBase::wrapTextBlock(TextCursor* cursor)
             cursor->setRow(cursorRow);
             cursor->setColumn(cursorColumn);
             }
+
+      if (logRowColEol)
+            qDebug().nospace()
+                  << "wrap AFTER cursor adjustment:" << " "
+                  << "row=" << cursor->row()  << " "
+                  << "col=" << cursor->column();
 
       cursor->clearSelection();
 

--- a/libmscore/textbase.cpp
+++ b/libmscore/textbase.cpp
@@ -469,7 +469,6 @@ bool TextCursor::movePosition(QTextCursor::MoveOperation op, QTextCursor::MoveMo
 
                   case QTextCursor::NextWord: {
                         int cols =  columns();
-                        // qDebug("NextWord start row=%d col=%d cols=%d", _row, _column, cols);
                         if (_column < cols) {
                               ++_column;
                               while (_column < cols && !currentCharacter().isSpace())
@@ -477,7 +476,6 @@ bool TextCursor::movePosition(QTextCursor::MoveOperation op, QTextCursor::MoveMo
                               while (_column < cols && currentCharacter().isSpace())
                                     ++_column;
                               }
-                        // qDebug("NextWord end row=%d col=%d", _row, _column);
                         }
 #if !defined(Q_OS_MAC)
                         if (mode == QTextCursor::MoveAnchor)
@@ -1137,20 +1135,6 @@ void TextBlock::layout(TextBase* t)
             f.pos.rx() += rx;
 
       _bbox.translate(rx, 0.0);
-
-      qDebug() << "BLOCK LAYOUT:"
-               << "bboxLeft=" << _bbox.left()
-               << "rx=" << rx
-               << "fragments=" << _fragments.size();
-
-      int n = 0;
-      for (const TextFragment& f : _fragments) {
-            qDebug() << "  frag" << n++
-                     << "text=[" << f.text << "]"
-                     << "posX=" << f.pos.x()
-                     << "bold=" << f.format.bold()
-                     << "italic=" << f.format.italic();
-            }
       }
 
 //---------------------------------------------------------
@@ -1609,24 +1593,12 @@ void TextFragment::changeFormat(FormatId id, QVariant data)
 
 TextBlock TextBlock::split(int column, Ms::TextCursor* cursor)
       {
-      bool tempOutput = false;
       TextBlock tl;
 
       int col = 0;
       for (auto i = _fragments.begin(); i != _fragments.end(); ++i) {
-            if (tempOutput) qDebug() << "Frag:" << qAsConst(i->text);
             int idx = 0;
             for (const QChar& c : qAsConst(i->text)) {
-                  if (tempOutput) {
-                        if (col == column) qDebug() << "SPLIT";
-                        qDebug().nospace().noquote()
-                              << "\t"
-                              << "col=" << col << " "
-                              // << "idx=" << idx << " "
-                              // << "column=" << column << " "
-                              << "char=[" << QString(c) << "]"
-                              ;
-                        }
                   if (col == column) {
                         if (idx) {
                               if (idx < i->text.size()) {
@@ -1982,7 +1954,6 @@ void TextBase::createLayout()
 
 bool TextBase::wrapTextBlock(TextCursor* cursor)
       {
-      bool logRowColEol = false;
 
       Element* e = parent();
       if (!e || !layoutToParentWidth() || !e->isTBox())
@@ -2005,15 +1976,6 @@ bool TextBase::wrapTextBlock(TextCursor* cursor)
       int lastRow = cursorRow;
       while (lastRow < _layout.size() - 1 && !_layout[lastRow].eol())
             ++lastRow;
-
-      if (logRowColEol) {
-            for (int r = 0; r < rows(); ++r) {
-                  qDebug().nospace()
-                        << "row=" << r << " "
-                        << "columns=" << _layout[r].columns()  << " "
-                        << "eol=" << _layout[r].eol();
-                  }
-            }
 
       // Find the first overflowing row in this paragraph
       int breakRow = -1;
@@ -2062,12 +2024,6 @@ bool TextBase::wrapTextBlock(TextCursor* cursor)
                   breakRow = r;
                   breakLocalColumn = breakColumn;
 
-                  if (logRowColEol)
-                        qDebug().nospace()
-                              << "wrap: "
-                              << "breakRow=" << breakRow << " "
-                              << "breakLocalColumn=" << breakLocalColumn;
-
                   break;
                   }
             }
@@ -2077,16 +2033,8 @@ bool TextBase::wrapTextBlock(TextCursor* cursor)
 
       // Have an overflowing row - split it:
       const int oldRow = breakRow;
-      const int oldColumn = cursorColumn;
 
       TextBlock& block = _layout[oldRow];
-
-      if (logRowColEol)
-            qDebug().nospace()
-                  << "wrap:"
-                  << "oldRow=" << oldRow << " "
-                  << "oldColumn=" << oldColumn << " "
-                  << "breakColumn=" << breakLocalColumn;
 
       const bool oldEol = block.eol();
 
@@ -2094,34 +2042,13 @@ bool TextBase::wrapTextBlock(TextCursor* cursor)
       splitCursor.setRow(oldRow);
       splitCursor.setColumn(breakLocalColumn);
 
-      const QString beforeSplit = block.dump();
-
       TextBlock newBlock = block.split(breakLocalColumn, &splitCursor);
-
-      if (logRowColEol)
-            qDebug().nospace()
-                  << "split result/wrapcheck" << "\n"
-                  << "before=[" << beforeSplit << "]" << "\n"
-                  << "old=[" << block.dump() << "]" << "\n"
-                  << "new=[" << newBlock.dump() << "]" << "\n"
-                  << "concat=[" << (block.dump() + newBlock.dump()) << "]";
 
       const bool hasLeadingSpace =
             newBlock.columns() > 0 && newBlock.text(0, 1) == " ";
       (void)hasLeadingSpace;
 
       newBlock.setEol(oldEol);
-
-      qDebug() << "REFLOW:"
-               << "oldRow=" << oldRow
-               << "old=[" << block.dump() << "]"
-               << "new=[" << newBlock.dump() << "]"
-               << "hasNext=" << (oldRow + 1 < _layout.size())
-               << "next=["
-               << (oldRow + 1 < _layout.size()
-                   ? _layout[oldRow + 1].dump()
-                   : QString())
-               << "]";
 
       if (oldRow + 1 < _layout.size()) {
             TextBlock& nextBlock = _layout[oldRow + 1];
@@ -2134,20 +2061,6 @@ bool TextBase::wrapTextBlock(TextCursor* cursor)
             _layout.insert(oldRow + 1, newBlock);
             }
 
-      if (logRowColEol) {
-            for (int r = 0; r < rows(); ++r) {
-                  QString rowText;
-                  for (const TextFragment& f : _layout[r].fragments()) {
-                        rowText += f.text;
-                        qDebug().nospace()
-                              << "row=" << r << " "
-                              << "columns=" << _layout[r].columns() << " "
-                              << "eol=" << _layout[r].eol() << " "
-                              << "text=[" << rowText << "]";
-                        }
-                  }
-            }
-
       // Adjust the cursor if it was in the portion moved to the new row
       if (cursorRow == oldRow && cursorColumn > breakLocalColumn) {
             cursor->setRow(oldRow + 1);
@@ -2157,12 +2070,6 @@ bool TextBase::wrapTextBlock(TextCursor* cursor)
             cursor->setRow(cursorRow);
             cursor->setColumn(cursorColumn);
             }
-
-      if (logRowColEol)
-            qDebug().nospace()
-                  << "wrap AFTER cursor adjustment:" << " "
-                  << "row=" << cursor->row()  << " "
-                  << "col=" << cursor->column();
 
       cursor->clearSelection();
 

--- a/libmscore/textbase.cpp
+++ b/libmscore/textbase.cpp
@@ -976,10 +976,10 @@ void TextBlock::draw(QPainter* p, const TextBase* t, bool softWrap) const
 
       if (softWrap &&
           !_fragments.isEmpty() &&
-          !_fragments.front().text.isEmpty() &&
-          _fragments.front().text.at(0).isSpace()) {
+          !_fragments.at(0).text.isEmpty() &&
+          _fragments.at(0).text.at(0).isSpace()) {
 
-            const TextFragment& first = _fragments.front();
+            const TextFragment& first = _fragments.at(0);
 
             suppressLeadingSpace = true;
 
@@ -1166,7 +1166,7 @@ qreal TextBlock::xpos(int column, const TextBase* t, bool softWrap) const
       if (softWrap &&
           column > 0 &&
           !_fragments.isEmpty()) {
-            const TextFragment& first = _fragments.front();
+            const TextFragment& first = _fragments.at(0);
 
             // Only compensate geometrically when removing the retained
             // soft-wrap space actually shifts visible text in this same
@@ -1277,7 +1277,7 @@ int TextBlock::columns() const
 int TextBlock::column(qreal x, TextBase* t, bool softWrap) const
       {
       if (softWrap && !_fragments.isEmpty()) {
-            const TextFragment& f = _fragments.front();
+            const TextFragment& f = _fragments.at(0);
 
             if (f.text.size() > 1 &&
                 f.text.at(0).isSpace()) {

--- a/libmscore/textbase.h
+++ b/libmscore/textbase.h
@@ -198,22 +198,22 @@ class TextBlock {
       TextBlock() {}
       bool operator ==(const TextBlock& x)         { return _fragments == x._fragments; }
       bool operator !=(const TextBlock& x)         { return _fragments != x._fragments; }
-      void draw(QPainter*, const TextBase*) const;
+      void draw(QPainter*, const TextBase*, bool softWrap = false) const;
       void layout(TextBase*);
       const QList<TextFragment>& fragments() const { return _fragments; }
       QList<TextFragment>& fragments()             { return _fragments; }
       QList<TextFragment>* fragmentsWithoutEmpty();
       const QRectF& boundingRect() const           { return _bbox; }
-      QRectF boundingRect(int col1, int col2, const TextBase*) const;
+      QRectF boundingRect(int col1, int col2, const TextBase*, bool softWrap = false) const;
       int columns() const;
       void insert(TextCursor*, const QString&);
       void insertEmptyFragmentIfNeeded(TextCursor*);
       void removeEmptyFragment();
       QString remove(int column, TextCursor*);
       QString remove(int start, int n, TextCursor*);
-      int column(qreal x, TextBase*) const;
+      int column(qreal x, TextBase*, bool softWrap = false) const;
       TextBlock split(int column, TextCursor* cursor);
-      qreal xpos(int col, const TextBase*) const;
+      qreal xpos(int col, const TextBase*, bool softWrap = false) const;
       const CharFormat* formatAt(int) const;
       const TextFragment* fragment(int col) const;
       QList<TextFragment>::iterator fragment(int column, int* rcol, int* ridx);
@@ -224,6 +224,8 @@ class TextBlock {
       bool eol() const          { return _eol; }
       void setEol(bool val)     { _eol = val; }
       void changeFormat(FormatId, QVariant val, int start, int n);
+      QChar character(int column) const;
+      QString dump() const;
       };
 
 //---------------------------------------------------------
@@ -275,6 +277,7 @@ class TextBase : public Element {
       void layoutFrame();
       void layoutEdit();
       void createLayout();
+      bool wrapTextBlock(TextCursor* cursor);
       void insertSym(EditData& ed, SymId id);
 
    public:
@@ -414,6 +417,9 @@ class TextBase : public Element {
       void setStrike(bool val)               { _fontStyle = val ? _fontStyle + FontStyle::Strike    : _fontStyle - FontStyle::Strike;    }
 
       bool hasCustomFormatting() const;
+
+      bool unwrapTextBlock(TextCursor* cursor);
+      bool bakeSoftWraps();
 
       friend class TextCursor;
       using ScoreElement::undoChangeProperty;

--- a/libmscore/textedit.cpp
+++ b/libmscore/textedit.cpp
@@ -60,6 +60,8 @@ void TextBase::editInsertText(TextCursor* cursor, const QString& s)
       cursor->setColumn(cursor->column() + col);
       cursor->clearSelection();
 
+      wrapTextBlock(cursor);
+
       triggerLayout();
       }
 
@@ -621,7 +623,35 @@ void ChangeText::insertText(EditData* ed)
       {
       TextCursor tc = c;
       tc.setFormat(format); // To undo TextCursor::updateCursorFormat()
+
+      // Keep the undo command's cursor synchronized with wrapping
       c.text()->editInsertText(&tc, s);
+      removeCursor = tc;
+
+
+      int logicalColumn = removeCursor.column();
+
+      for (int r = removeCursor.row() - 1; r >= 0; --r) {
+            logicalColumn += c.text()->textBlockList()[r].columns();
+
+            if (c.text()->textBlockList()[r].eol())
+                  break;
+            }
+
+      removeCursor.setColumn(tc.column() - s.size());
+
+      removeLogicalPosition = removeCursor.column();
+
+      const QList<TextBlock>& blocks = c.text()->textBlockList();
+
+      for (int r = 0; r < removeCursor.row(); ++r) {
+            removeLogicalPosition += blocks[r].columns();
+
+            // Explicit newline also occupies a logical character position
+            if (blocks[r].eol())
+                  ++removeLogicalPosition;
+            }
+
       if (ed) {
             TextCursor* ttc = c.text()->cursor(*ed);
             *ttc = tc;
@@ -635,15 +665,62 @@ void ChangeText::insertText(EditData* ed)
 void ChangeText::removeText(EditData* ed)
       {
       TextCursor tc = c;
-      TextBlock& l  = c.curLine();
-      int column    = c.column();
-      format = *l.formatAt(column + s.size() - 1);
+
+      if (removeLogicalPosition >= 0) {
+            QList<TextBlock>& blocks = c.text()->textBlockList();
+
+            int remaining = removeLogicalPosition;
+            int row = 0;
+
+            for (; row < blocks.size(); ++row) {
+                  const int columns = blocks[row].columns();
+
+                  if (remaining <= columns)
+                        break;
+
+                  remaining -= columns;
+
+                  if (blocks[row].eol()) {
+                        if (remaining == 0) {
+                              ++row;
+                              break;
+                              }
+                        --remaining;
+                        }
+                  }
+
+            if (row >= blocks.size())
+                  row = blocks.size() - 1;
+
+            tc = removeCursor;
+            tc.setRow(row);
+            tc.setColumn(remaining);
+            }
+
+      TextBlock& l = tc.curLine();
+      int column = tc.column();
+
+      const int formatColumn = column + s.size() - 1;
+      const CharFormat* fmt = l.formatAt(formatColumn);
+
+      if (!fmt) {
+            return;
+            }
+
+      format = *fmt;
 
       for (int n = 0; n < s.size(); ++n)
-            l.remove(column, &c);
+            l.remove(column, &tc);
+
+      c.text()->unwrapTextBlock(&tc);
+
       c.text()->triggerLayout();
+
+      tc.clearSelection();
+
       if (ed)
             *c.text()->cursor(*ed) = tc;
+
       c.text()->setTextInvalid();
       }
 

--- a/libmscore/textedit.cpp
+++ b/libmscore/textedit.cpp
@@ -54,28 +54,13 @@ void TextBase::editInsertText(TextCursor* cursor, const QString& s)
             QString nonBreakingSpace = QString(QChar(0xa0));
             cursor->curLine().insert(cursor, nonBreakingSpace);
             }
-      else {
-            // qDebug().nospace() << "BEFORE INSERT: "
-            //          << "row=" << cursor->row() << " "
-            //          << "col=" << cursor->column() << " "
-            //          << "char=" << QString(cursor->curLine().character(cursor->column()));
-
+      else
             cursor->curLine().insert(cursor, s);
-
-            // qDebug().nospace() << "AFTER RAW INSERT: "
-            //          << "row=" << cursor->row()  << " "
-            //          << "col=" << cursor->column();
-            }
 
       cursor->setColumn(cursor->column() + col);
       cursor->clearSelection();
 
       wrapTextBlock(cursor);
-
-      // qDebug().nospace() << "AFTER WRAP: "
-      //          << "row=" << cursor->row() << " "
-      //          << "col=" << cursor->column() << " "
-      //          << "char=" << QString(cursor->curLine().character(cursor->column()));
 
       triggerLayout();
       }
@@ -653,15 +638,6 @@ void ChangeText::insertText(EditData* ed)
                   break;
             }
 
-      qDebug() << "INSERT REMOVE POSITION:"
-               << "row=" << removeCursor.row()
-               << "col=" << removeCursor.column()
-               << "logical=" << logicalColumn;
-
-
-      qDebug() << "\t" << "removeCursor column:" << tc.column() - s.size();
-
-      // suspicious:
       removeCursor.setColumn(tc.column() - s.size());
 
       removeLogicalPosition = removeCursor.column();
@@ -675,11 +651,6 @@ void ChangeText::insertText(EditData* ed)
             if (blocks[r].eol())
                   ++removeLogicalPosition;
             }
-
-      qDebug() << "stored remove position:"
-               << "row=" << removeCursor.row()
-               << "col=" << removeCursor.column()
-               << "logical=" << removeLogicalPosition;
 
       if (ed) {
             TextCursor* ttc = c.text()->cursor(*ed);
@@ -724,50 +695,15 @@ void ChangeText::removeText(EditData* ed)
             tc = removeCursor;
             tc.setRow(row);
             tc.setColumn(remaining);
-
-            qDebug() << "resolved remove position:"
-                     << "logical=" << removeLogicalPosition
-                     << "row=" << row
-                     << "col=" << remaining
-                     << "lineColumns=" << tc.curLine().columns();
             }
 
       TextBlock& l = tc.curLine();
       int column = tc.column();
 
-      int fi = 0;
-      for (const TextFragment& f : l.fragments()) {
-            qDebug("  fragment %d: text=[%s] size=%d",
-                   fi++, qPrintable(f.text), f.text.size());
-            }
-
       const int formatColumn = column + s.size() - 1;
       const CharFormat* fmt = l.formatAt(formatColumn);
 
-      // qDebug() << "UNDO REMOVE:"
-      //          << "s=[" << s << "]"
-      //          << "row=" << tc.row()
-      //          << "column=" << column
-      //          << "lineColumns=" << l.columns();
-
       if (!fmt) {
-            // int logicalColumn = removeCursor.column();
-
-            // for (int r = removeCursor.row() - 1; r >= 0; --r) {
-            //       logicalColumn += c.text()->textBlockList()[r].columns();
-
-            //       if (c.text()->textBlockList()[r].eol())
-            //             break;
-            //       }
-
-            qDebug() << "INVALID RESOLVED REMOVE:"
-                     << "logical=" << removeLogicalPosition
-                     // << "row=" << row
-                     << "column=" << column
-                     << "formatColumn=" << formatColumn
-                     << "lineColumns=" << l.columns()
-                     << "s=[" << s << "]";
-
             return;
             }
 

--- a/libmscore/textedit.cpp
+++ b/libmscore/textedit.cpp
@@ -54,13 +54,28 @@ void TextBase::editInsertText(TextCursor* cursor, const QString& s)
             QString nonBreakingSpace = QString(QChar(0xa0));
             cursor->curLine().insert(cursor, nonBreakingSpace);
             }
-      else
+      else {
+            // qDebug().nospace() << "BEFORE INSERT: "
+            //          << "row=" << cursor->row() << " "
+            //          << "col=" << cursor->column() << " "
+            //          << "char=" << QString(cursor->curLine().character(cursor->column()));
+
             cursor->curLine().insert(cursor, s);
+
+            // qDebug().nospace() << "AFTER RAW INSERT: "
+            //          << "row=" << cursor->row()  << " "
+            //          << "col=" << cursor->column();
+            }
 
       cursor->setColumn(cursor->column() + col);
       cursor->clearSelection();
 
       wrapTextBlock(cursor);
+
+      // qDebug().nospace() << "AFTER WRAP: "
+      //          << "row=" << cursor->row() << " "
+      //          << "col=" << cursor->column() << " "
+      //          << "char=" << QString(cursor->curLine().character(cursor->column()));
 
       triggerLayout();
       }
@@ -638,6 +653,15 @@ void ChangeText::insertText(EditData* ed)
                   break;
             }
 
+      qDebug() << "INSERT REMOVE POSITION:"
+               << "row=" << removeCursor.row()
+               << "col=" << removeCursor.column()
+               << "logical=" << logicalColumn;
+
+
+      qDebug() << "\t" << "removeCursor column:" << tc.column() - s.size();
+
+      // suspicious:
       removeCursor.setColumn(tc.column() - s.size());
 
       removeLogicalPosition = removeCursor.column();
@@ -651,6 +675,11 @@ void ChangeText::insertText(EditData* ed)
             if (blocks[r].eol())
                   ++removeLogicalPosition;
             }
+
+      qDebug() << "stored remove position:"
+               << "row=" << removeCursor.row()
+               << "col=" << removeCursor.column()
+               << "logical=" << removeLogicalPosition;
 
       if (ed) {
             TextCursor* ttc = c.text()->cursor(*ed);
@@ -695,15 +724,50 @@ void ChangeText::removeText(EditData* ed)
             tc = removeCursor;
             tc.setRow(row);
             tc.setColumn(remaining);
+
+            qDebug() << "resolved remove position:"
+                     << "logical=" << removeLogicalPosition
+                     << "row=" << row
+                     << "col=" << remaining
+                     << "lineColumns=" << tc.curLine().columns();
             }
 
       TextBlock& l = tc.curLine();
       int column = tc.column();
 
+      int fi = 0;
+      for (const TextFragment& f : l.fragments()) {
+            qDebug("  fragment %d: text=[%s] size=%d",
+                   fi++, qPrintable(f.text), f.text.size());
+            }
+
       const int formatColumn = column + s.size() - 1;
       const CharFormat* fmt = l.formatAt(formatColumn);
 
+      // qDebug() << "UNDO REMOVE:"
+      //          << "s=[" << s << "]"
+      //          << "row=" << tc.row()
+      //          << "column=" << column
+      //          << "lineColumns=" << l.columns();
+
       if (!fmt) {
+            // int logicalColumn = removeCursor.column();
+
+            // for (int r = removeCursor.row() - 1; r >= 0; --r) {
+            //       logicalColumn += c.text()->textBlockList()[r].columns();
+
+            //       if (c.text()->textBlockList()[r].eol())
+            //             break;
+            //       }
+
+            qDebug() << "INVALID RESOLVED REMOVE:"
+                     << "logical=" << removeLogicalPosition
+                     // << "row=" << row
+                     << "column=" << column
+                     << "formatColumn=" << formatColumn
+                     << "lineColumns=" << l.columns()
+                     << "s=[" << s << "]";
+
             return;
             }
 

--- a/libmscore/textedit.h
+++ b/libmscore/textedit.h
@@ -58,13 +58,16 @@ class TextEditUndoCommand : public UndoCommand {
 class ChangeText : public TextEditUndoCommand {
       QString s;
       CharFormat format;
+      TextCursor removeCursor;
+      int removeLogicalPosition = -1;
 
    protected:
       void insertText(EditData*);
       void removeText(EditData*);
 
    public:
-      ChangeText(const TextCursor* tc, const QString& t) : TextEditUndoCommand(*tc), s(t), format(*tc->format()) {}
+      ChangeText(const TextCursor* tc, const QString& t)
+            : TextEditUndoCommand(*tc), s(t), format(*tc->format()), removeCursor(*tc) {}
       virtual void undo(EditData*) override = 0;
       virtual void redo(EditData*) override = 0;
       const TextCursor& cursor() const { return c; }

--- a/mscore/inspector/inspectorText.cpp
+++ b/mscore/inspector/inspectorText.cpp
@@ -34,8 +34,27 @@ InspectorText::InspectorText(QWidget* parent)
             { f.title, f.panel }
             };
 
+      const Element* el = inspector->element();
+      const bool isTextFrameText = el->isText() && el->parent() && el->parent()->isTBox();
+      if (!isTextFrameText)
+            f.hardcodeWordWrap->hide();
+
       populateStyle(f.style);
       mapSignals(iiList, ppList);
+      connect (f.hardcodeWordWrap, &QPushButton::clicked,
+               this, &InspectorText::on_hardcodeWordWrap_clicked);
+      }
+
+//---------------------------------------------------------
+//   on_hardcodeWordWrap_clicked
+//---------------------------------------------------------
+
+void InspectorText::on_hardcodeWordWrap_clicked()
+      {
+      Score* s = inspector->element()->score();
+      s->startCmd();
+      s->cmdBakeSoftWrap();
+      s->endCmd();
       }
 
 }

--- a/mscore/inspector/inspectorText.h
+++ b/mscore/inspector/inspectorText.h
@@ -31,6 +31,9 @@ class InspectorText : public InspectorTextBase {
 
    public:
       InspectorText(QWidget* parent);
+
+   private slots:
+      void on_hardcodeWordWrap_clicked();
       };
 
 }

--- a/mscore/inspector/inspector_frametext.ui
+++ b/mscore/inspector/inspector_frametext.ui
@@ -2,6 +2,14 @@
 <ui version="4.0">
  <class>InspectorFrameText</class>
  <widget class="QWidget" name="InspectorFrameText">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>261</width>
+    <height>108</height>
+   </rect>
+  </property>
   <property name="accessibleName">
    <string>Frame Text Inspector</string>
   </property>
@@ -41,7 +49,6 @@
      </property>
      <property name="font">
       <font>
-       <weight>75</weight>
        <bold>true</bold>
       </font>
      </property>
@@ -71,7 +78,7 @@
       <property name="verticalSpacing">
        <number>0</number>
       </property>
-      <item row="0" column="0">
+      <item row="1" column="0">
        <widget class="QLabel" name="label">
         <property name="text">
          <string>Style:</string>
@@ -84,7 +91,7 @@
         </property>
        </widget>
       </item>
-      <item row="0" column="1">
+      <item row="1" column="1">
        <widget class="QComboBox" name="style">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -98,6 +105,13 @@
        </widget>
       </item>
      </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QPushButton" name="hardcodeWordWrap">
+     <property name="text">
+      <string>Hardcode Autowrap</string>
+     </property>
     </widget>
    </item>
   </layout>

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -5653,8 +5653,14 @@ void ScoreView::adjustCanvasPosition(const Element* el, bool playBack, int staff
       else if (editing){
             auto ry = sys->canvasBoundingRect().y();
             auto h = sys->canvasBoundingRect().height();
-            ry -= sys->minTop();
+
+            if (auto vbox = sys->vbox())
+                  ry -= vbox->topGap();
+            else
+                  ry -= sys->minTop();
+
             h  += sys->minBottom();
+
             showRect.setY(ry);
             showRect.setHeight(h);
             }

--- a/mscore/shortcut.cpp
+++ b/mscore/shortcut.cpp
@@ -4473,6 +4473,13 @@ Shortcut Shortcut::_sc[] = {
          },
       {
          MsWidget::SCORE_TAB,
+         STATE_NORMAL,
+         "bake-soft-wrap",
+         QT_TRANSLATE_NOOP("action","Convert automatically wrapped text into hard line breaks"),
+         QT_TRANSLATE_NOOP("action","Convert automatically wrapped text into hard line breaks")
+         },
+      {
+         MsWidget::SCORE_TAB,
          STATE_NORMAL | STATE_NOTE_ENTRY,
          "toggle-visible",
          QT_TRANSLATE_NOOP("action","Toggle Visibility"),


### PR DESCRIPTION
Always wanted to have text frames automatically word-wrap, so spent some time with it.

Needs to be further tested, so should make a corresponding issue so I can track any problems as time goes on, but right now it seems decent.

- Aside: fixed adjust canvas view change when editing a text/vertical frame. Apparently the system's minTop() function was some whacky number instead of being realistic when not a music system.

There's a command called "Bake Soft Wrap" to convert the text into a hard-wrapped version so that the file will be compatible with 3.6.2 or 4/5.x (until hopefully 5.x actually implements a feature like this for their version). It will also appear in the Inspector for Text Frames and can be applied in bulk:


<img width="409" height="421" alt="image" src="https://github.com/user-attachments/assets/338c6162-cb1c-4b31-ae5c-79bb0c940425" />
