### PR TITLE
Feature: migrate new toolbar icons and menu actions to user's workspace

### DIFF
--- a/mscore/workspace.cpp
+++ b/mscore/workspace.cpp
@@ -33,6 +33,8 @@
 #include "thirdparty/qzip/qzipreader_p.h"
 #include "thirdparty/qzip/qzipwriter_p.h"
 
+#include <cstring>
+
 #if defined(FOR_WINSTORE)  // or even just Q_OS_WIN ?
 extern Q_CORE_EXPORT int qt_ntfs_permission_lookup;
 #else
@@ -40,6 +42,8 @@ int qt_ntfs_permission_lookup;
 #endif
 
 namespace Ms {
+
+static constexpr int WORKSPACE_UI_VERSION = 0;
 
 bool WorkspacesManager::isWorkspacesListDirty = true;
 Workspace* WorkspacesManager::m_currentWorkspace = nullptr;
@@ -406,6 +410,9 @@ void Workspace::write()
       // xml.tag("name", _name);
       if (!_sourceWorkspaceName.isEmpty())
             xml.tag("source", _sourceWorkspaceName);
+
+      xml.tag("uiVersion", WORKSPACE_UI_VERSION);
+
       const PaletteWorkspace* w = mscore->getPaletteWorkspace();
       w->write(xml);
 
@@ -752,6 +759,8 @@ std::unique_ptr<PaletteTree> Workspace::getPaletteTree() const
 
 void Workspace::read(XmlReader& e)
       {
+      int uiVersion = 0;
+
       bool niToolbar = false;
       bool foToolbar = false;
       bool pcToolbar = false;
@@ -764,6 +773,8 @@ void Workspace::read(XmlReader& e)
                   e.readElementText();
             else if (tag == "source")
                   _sourceWorkspaceName = e.readElementText();
+            else if (tag == "uiVersion")
+                  uiVersion = e.readInt();
             else if (tag == "PaletteBox") {
                   PaletteWorkspace* w = mscore->getPaletteWorkspace();
                   w->read(e);
@@ -960,8 +971,73 @@ void Workspace::read(XmlReader& e)
       if (!saveComponents)
             readGlobalGUIState();
 
+      migrate(uiVersion);
+
       if (const Workspace* src = sourceWorkspace())
             mscore->getPaletteWorkspace()->setDefaultPaletteTree(src->getPaletteTree());
+      }
+
+//---------------------------------------------------------
+//   ensureMenuAction
+//---------------------------------------------------------
+
+void Workspace::ensureMenuAction(const QString& menuId,
+                                 const QString& actionId,
+                                 const QString& beforeActionId)
+      {
+      QMenu* menu = findMenuFromString(menuId);
+      QAction* action = findActionFromString(actionId);
+
+      if (!menu || !action || menu->actions().contains(action))
+            return;
+
+      QAction* beforeAction = beforeActionId.isEmpty()
+                              ? nullptr
+                              : findActionFromString(beforeActionId);
+
+      if (beforeAction && menu->actions().contains(beforeAction))
+            menu->insertAction(beforeAction, action);
+      else
+            menu->addAction(action);
+      }
+
+//---------------------------------------------------------
+//   ensureToolbarEntry
+//---------------------------------------------------------
+
+void Workspace::ensureToolbarEntry(std::list<const char*>& entries,
+                                   const char* actionId,
+                                   const char* beforeActionId)
+      {
+      if (!actionId || !*actionId)
+            return;
+
+      for (const char* entry : entries) {
+            if (!strcmp(entry, actionId))
+                  return;
+            }
+
+      if (beforeActionId) {
+            for (auto it = entries.begin(); it != entries.end(); ++it) {
+                  if (!strcmp(*it, beforeActionId)) {
+                        entries.insert(it, actionId);
+                        return;
+                        }
+                  }
+            }
+
+      entries.push_back(actionId);
+      }
+
+//---------------------------------------------------------
+//   migrate
+//    add here: ensureMenuAction() and ensureToolbarEntry() calls
+//    with uiVersion < [most recent version]
+//---------------------------------------------------------
+
+void Workspace::migrate(int uiVersion)
+      {
+      Q_UNUSED(uiVersion);
       }
 
 //---------------------------------------------------------

--- a/mscore/workspace.h
+++ b/mscore/workspace.h
@@ -41,6 +41,15 @@ class Workspace : public QObject {
 
       void readMenu(XmlReader& e, QMenu* menu);
 
+      void migrate(int uiVersion);
+      static void ensureMenuAction(const QString& menuId,
+                                   const QString& actionId,
+                                   const QString& beforeActionId = QString());
+
+      static void ensureToolbarEntry(std::list<const char*>& entries,
+                                     const char* actionId,
+                                     const char* beforeActionId = nullptr);
+
       static QString findStringFromAction(QAction* action);
       static QAction* findActionFromString(QString string);
       static QString findStringFromMenu(QMenu* menu);


### PR DESCRIPTION
The point here is that if a new toolbar icon is created, it can now be pointed out to MuseScore so that a workspace "versioning" exists, and then anything new should be automatically added in. If the user desires, manually removing whatever is added will be honored.

Since workspaces can contain the menus data, they will override any new additions unless manually added, which is undesirable because of a lack of discoverability.

With this addition, for example, a new action added into MuseScore then needs to update the version:

1) Update the workspace version in `mscore/workspace.cpp`:
```
static constexpr int WORKSPACE_UI_VERSION = 1;
```
2) Add it to athe migrate function:

```cpp
void Workspace::migrate(int uiVersion)
      {
      if (uiVersion < 1) {
            // add toggle piano roll in the menu
            ensureMenuAction("menu-view",
                             "toggle-piano-roll",
                             "toggle-scorecmp-tool");
            }
      }
```

Then toggle-piano-roll command will appear in the menu if it was actually coded to do so. 

Likewise with toolbars:
```cpp
void Workspace::migrate(int uiVersion)
      {
      // …
      if (uiVersion < 2) {
            // add the toggle-piano-roll to the alternative entry toolbar:
            std::list<const char*>* entries = mscore->alternativeEntries();

            if (entries) {
                  ensureToolbarEntry(*entries,
                                     "toggle-piano-roll",
                                     "empty-trailing-measure");

                  mscore->populateAlternativeOperations();
                  }
            }
      }
```
