### PR TITLE
Part Creation: Fix: Crash on creating part having to do with VBOX

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -3277,7 +3277,7 @@ void Score::insertMeasure(ElementType type, MeasureBase* measure, bool createEmp
                               }
                         else {
                               for (ScoreElement*& m : *measure->links()) {
-                                    if (measure->score() == score) {
+                                    if (m->score() == score) {
                                           im = toMeasureBase(m);
                                           break;
                                           }


### PR DESCRIPTION
Somehow when there is a Text Frame (TBOX) on the main score, the TBOX remains and then an assertion occurs in `Excerpt::createExcerpt()`. This seems to fix the problem, but who knows maybe it has unforeseen consequences so will keep tag word:

#watch

